### PR TITLE
Add minimal model schema and generation of extension types based on it.

### DIFF
--- a/pkgs/dart_model/lib/dart_model.dart
+++ b/pkgs/dart_model/lib/dart_model.dart
@@ -2,5 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+export 'src/dart_model.g.dart';
 export 'src/json.dart';
 export 'src/json_changes.dart';

--- a/pkgs/dart_model/lib/src/dart_model.g.dart
+++ b/pkgs/dart_model/lib/src/dart_model.g.dart
@@ -1,0 +1,82 @@
+extension type Annotation.fromJson(Map<String, Object?> node) {
+  Annotation({
+    QualifiedName? type,
+  }) : this.fromJson({
+          if (type != null) 'type': type,
+        });
+  QualifiedName get type => node['type']! as QualifiedName;
+}
+
+extension type Interface.fromJson(Map<String, Object?> node) {
+  Interface({
+    List<Annotation>? annotations,
+    Map<String, Member>? members,
+    Properties? properties,
+  }) : this.fromJson({
+          if (annotations != null) 'annotations': annotations,
+          if (members != null) 'members': members,
+          if (properties != null) 'properties': properties,
+        });
+  List<Annotation> get annotations => node['annotations']! as List<Annotation>;
+  Map<String, Member> get members => node['members']! as Map<String, Member>;
+  Properties get properties => node['properties']! as Properties;
+}
+
+extension type Member.fromJson(Map<String, Object?> node) {
+  Member({
+    Properties? properties,
+  }) : this.fromJson({
+          if (properties != null) 'properties': properties,
+        });
+  Properties get properties => node['properties']! as Properties;
+}
+
+extension type Model.fromJson(Map<String, Object?> node) {
+  Model({
+    Map<String, Library>? uris,
+  }) : this.fromJson({
+          if (uris != null) 'uris': uris,
+        });
+  Map<String, Library> get uris => node['uris']! as Map<String, Library>;
+}
+
+extension type Properties.fromJson(Map<String, Object?> node) {
+  Properties({
+    bool? isAbstract,
+    bool? isClass,
+    bool? isGetter,
+    bool? isField,
+    bool? isMethod,
+    bool? isStatic,
+    bool? isSynthetic,
+  }) : this.fromJson({
+          if (isAbstract != null) 'isAbstract': isAbstract,
+          if (isClass != null) 'isClass': isClass,
+          if (isGetter != null) 'isGetter': isGetter,
+          if (isField != null) 'isField': isField,
+          if (isMethod != null) 'isMethod': isMethod,
+          if (isStatic != null) 'isStatic': isStatic,
+          if (isSynthetic != null) 'isSynthetic': isSynthetic,
+        });
+  bool get isAbstract => node['isAbstract']! as bool;
+  bool get isClass => node['isClass']! as bool;
+  bool get isGetter => node['isGetter']! as bool;
+  bool get isField => node['isField']! as bool;
+  bool get isMethod => node['isMethod']! as bool;
+  bool get isStatic => node['isStatic']! as bool;
+  bool get isSynthetic => node['isSynthetic']! as bool;
+}
+
+extension type Library.fromJson(Map<String, Object?> node) {
+  Library({
+    Map<String, Interface>? scopes,
+  }) : this.fromJson({
+          if (scopes != null) 'scopes': scopes,
+        });
+  Map<String, Interface> get scopes =>
+      node['scopes']! as Map<String, Interface>;
+}
+
+extension type QualifiedName.fromJson(String string) {
+  QualifiedName(String string) : this.fromJson(string);
+}

--- a/pkgs/dart_model/lib/src/dart_model.g.dart
+++ b/pkgs/dart_model/lib/src/dart_model.g.dart
@@ -1,25 +1,30 @@
-extension type Annotation.fromJson(Map<String, Object?> node) {
-  Annotation({
+// This file is generated. To make changes, edit schemas/dart_model.schema.json
+// then run from the repo root: dart tool/model_generator/bin/main.dart
+
+extension type MetadataAnnotation.fromJson(Map<String, Object?> node) {
+  MetadataAnnotation({
     QualifiedName? type,
   }) : this.fromJson({
           if (type != null) 'type': type,
         });
-  QualifiedName get type => node['type']! as QualifiedName;
+  QualifiedName get type => node['type'] as QualifiedName;
 }
 
 extension type Interface.fromJson(Map<String, Object?> node) {
   Interface({
-    List<Annotation>? annotations,
+    List<MetadataAnnotation>? metadataAnnotations,
     Map<String, Member>? members,
     Properties? properties,
   }) : this.fromJson({
-          if (annotations != null) 'annotations': annotations,
+          if (metadataAnnotations != null)
+            'metadataAnnotations': metadataAnnotations,
           if (members != null) 'members': members,
           if (properties != null) 'properties': properties,
         });
-  List<Annotation> get annotations => node['annotations']! as List<Annotation>;
-  Map<String, Member> get members => node['members']! as Map<String, Member>;
-  Properties get properties => node['properties']! as Properties;
+  List<MetadataAnnotation> get metadataAnnotations =>
+      (node['metadataAnnotations'] as List).cast();
+  Map<String, Member> get members => (node['members'] as Map).cast();
+  Properties get properties => node['properties'] as Properties;
 }
 
 extension type Member.fromJson(Map<String, Object?> node) {
@@ -28,7 +33,7 @@ extension type Member.fromJson(Map<String, Object?> node) {
   }) : this.fromJson({
           if (properties != null) 'properties': properties,
         });
-  Properties get properties => node['properties']! as Properties;
+  Properties get properties => node['properties'] as Properties;
 }
 
 extension type Model.fromJson(Map<String, Object?> node) {
@@ -37,7 +42,7 @@ extension type Model.fromJson(Map<String, Object?> node) {
   }) : this.fromJson({
           if (uris != null) 'uris': uris,
         });
-  Map<String, Library> get uris => node['uris']! as Map<String, Library>;
+  Map<String, Library> get uris => (node['uris'] as Map).cast();
 }
 
 extension type Properties.fromJson(Map<String, Object?> node) {
@@ -58,13 +63,13 @@ extension type Properties.fromJson(Map<String, Object?> node) {
           if (isStatic != null) 'isStatic': isStatic,
           if (isSynthetic != null) 'isSynthetic': isSynthetic,
         });
-  bool get isAbstract => node['isAbstract']! as bool;
-  bool get isClass => node['isClass']! as bool;
-  bool get isGetter => node['isGetter']! as bool;
-  bool get isField => node['isField']! as bool;
-  bool get isMethod => node['isMethod']! as bool;
-  bool get isStatic => node['isStatic']! as bool;
-  bool get isSynthetic => node['isSynthetic']! as bool;
+  bool get isAbstract => node['isAbstract'] as bool;
+  bool get isClass => node['isClass'] as bool;
+  bool get isGetter => node['isGetter'] as bool;
+  bool get isField => node['isField'] as bool;
+  bool get isMethod => node['isMethod'] as bool;
+  bool get isStatic => node['isStatic'] as bool;
+  bool get isSynthetic => node['isSynthetic'] as bool;
 }
 
 extension type Library.fromJson(Map<String, Object?> node) {
@@ -73,8 +78,7 @@ extension type Library.fromJson(Map<String, Object?> node) {
   }) : this.fromJson({
           if (scopes != null) 'scopes': scopes,
         });
-  Map<String, Interface> get scopes =>
-      node['scopes']! as Map<String, Interface>;
+  Map<String, Interface> get scopes => (node['scopes'] as Map).cast();
 }
 
 extension type QualifiedName.fromJson(String string) {

--- a/pkgs/dart_model/test/model_test.dart
+++ b/pkgs/dart_model/test/model_test.dart
@@ -2,39 +2,102 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:convert';
+
 import 'package:dart_model/dart_model.dart';
 import 'package:test/test.dart';
 
 void main() {
   group(Model, () {
-    test('maps to JSON', () {
-      final model = Model(uris: {
-        'package:dart_model/dart_model.dart': Library(scopes: {
-          'JsonData':
-              Interface(properties: Properties(isClass: true), members: {
-            '_root': Member(
-              properties: Properties(isField: true),
-            )
-          })
-        })
-      });
+    final model = Model(uris: {
+      'package:dart_model/dart_model.dart': Library(scopes: {
+        'JsonData': Interface(
+            properties: Properties(isClass: true),
+            metadataAnnotations: [
+              MetadataAnnotation(
+                  type: QualifiedName(
+                      'package:dart_model/dart_model.dart#SomeAnnotation'))
+            ],
+            members: {
+              '_root': Member(
+                properties: Properties(isField: true),
+              )
+            })
+      })
+    });
 
-      expect(model as Map, {
-        'uris': {
-          'package:dart_model/dart_model.dart': {
-            'scopes': {
-              'JsonData': {
-                'members': {
-                  '_root': {
-                    'properties': {'isField': true}
-                  }
-                },
-                'properties': {'isClass': true}
-              }
+    final expected = {
+      'uris': {
+        'package:dart_model/dart_model.dart': {
+          'scopes': {
+            'JsonData': {
+              'metadataAnnotations': [
+                {'type': 'package:dart_model/dart_model.dart#SomeAnnotation'}
+              ],
+              'members': {
+                '_root': {
+                  'properties': {'isField': true}
+                }
+              },
+              'properties': {'isClass': true}
             }
           }
         }
-      });
+      }
+    };
+
+    test('maps to JSON', () {
+      expect(model as Map, expected);
+    });
+
+    test('maps to JSON after deserialization', () {
+      final deserializedModel =
+          Model.fromJson(json.decode(json.encode(model as Map)));
+      expect(deserializedModel as Map, expected);
+    });
+
+    test('maps can be accessed as fields', () {
+      expect(model.uris['package:dart_model/dart_model.dart'],
+          expected['uris']!['package:dart_model/dart_model.dart']);
+      expect(
+          model.uris['package:dart_model/dart_model.dart']!.scopes['JsonData'],
+          expected['uris']!['package:dart_model/dart_model.dart']!['scopes']![
+              'JsonData']);
+      expect(
+          model.uris['package:dart_model/dart_model.dart']!.scopes['JsonData']!
+              .properties,
+          expected['uris']!['package:dart_model/dart_model.dart']!['scopes']![
+              'JsonData']!['properties']);
+    });
+
+    test('maps can be accessed as fields after deserialization', () {
+      final deserializedModel =
+          Model.fromJson(json.decode(json.encode(model as Map)));
+
+      expect(
+          deserializedModel.uris['package:dart_model/dart_model.dart']!
+              .scopes['JsonData']!.properties,
+          expected['uris']!['package:dart_model/dart_model.dart']!['scopes']![
+              'JsonData']!['properties']);
+    });
+
+    test('lists can be accessed as fields', () {
+      expect(
+          model.uris['package:dart_model/dart_model.dart']!.scopes['JsonData']!
+              .members,
+          expected['uris']!['package:dart_model/dart_model.dart']!['scopes']![
+              'JsonData']!['members']);
+    });
+
+    test('lists can be accessed as fields after deserialization', () {
+      final deserializedModel =
+          Model.fromJson(json.decode(json.encode(model as Map)));
+
+      expect(
+          deserializedModel.uris['package:dart_model/dart_model.dart']!
+              .scopes['JsonData']!.members,
+          expected['uris']!['package:dart_model/dart_model.dart']!['scopes']![
+              'JsonData']!['members']);
     });
   });
 }

--- a/pkgs/dart_model/test/model_test.dart
+++ b/pkgs/dart_model/test/model_test.dart
@@ -1,0 +1,40 @@
+// Copyright (c) 2024, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:dart_model/dart_model.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group(Model, () {
+    test('maps to JSON', () {
+      final model = Model(uris: {
+        'package:dart_model/dart_model.dart': Library(scopes: {
+          'JsonData':
+              Interface(properties: Properties(isClass: true), members: {
+            '_root': Member(
+              properties: Properties(isField: true),
+            )
+          })
+        })
+      });
+
+      expect(model as Map, {
+        'uris': {
+          'package:dart_model/dart_model.dart': {
+            'scopes': {
+              'JsonData': {
+                'members': {
+                  '_root': {
+                    'properties': {'isField': true}
+                  }
+                },
+                'properties': {'isClass': true}
+              }
+            }
+          }
+        }
+      });
+    });
+  });
+}

--- a/pkgs/dart_model/test/model_test.dart
+++ b/pkgs/dart_model/test/model_test.dart
@@ -51,8 +51,8 @@ void main() {
     });
 
     test('maps to JSON after deserialization', () {
-      final deserializedModel =
-          Model.fromJson(json.decode(json.encode(model as Map)));
+      final deserializedModel = Model.fromJson(
+          json.decode(json.encode(model as Map)) as Map<String, Object?>);
       expect(deserializedModel as Map, expected);
     });
 
@@ -71,8 +71,8 @@ void main() {
     });
 
     test('maps can be accessed as fields after deserialization', () {
-      final deserializedModel =
-          Model.fromJson(json.decode(json.encode(model as Map)));
+      final deserializedModel = Model.fromJson(
+          json.decode(json.encode(model as Map)) as Map<String, Object?>);
 
       expect(
           deserializedModel.uris['package:dart_model/dart_model.dart']!
@@ -90,8 +90,8 @@ void main() {
     });
 
     test('lists can be accessed as fields after deserialization', () {
-      final deserializedModel =
-          Model.fromJson(json.decode(json.encode(model as Map)));
+      final deserializedModel = Model.fromJson(
+          json.decode(json.encode(model as Map)) as Map<String, Object?>);
 
       expect(
           deserializedModel.uris['package:dart_model/dart_model.dart']!

--- a/schemas/dart_model.schema.json
+++ b/schemas/dart_model.schema.json
@@ -1,0 +1,76 @@
+{
+  "$id": "https://github.com/dart-lang/macros/blob/main/schemas/dart_model.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "oneOf": [
+    {"$ref": "#/$defs/Model"}
+  ],
+  "$defs": {
+    "Annotation": {
+      "type": "object",
+      "description": "An annotation.",
+      "properties": {
+        "type": {"$ref": "#/$defs/QualifiedName"}
+      }
+    },
+    "Interface": {
+      "type": "object",
+      "description": "An interface.",
+      "properties": {
+        "annotations": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/Annotation"}
+        },
+        "members": {
+          "type": "object",
+          "description": "Map of members by name.",
+          "additionalProperties": {"$ref": "#/$defs/Member"}
+        },
+        "properties": {"$ref": "#/$defs/Properties"}
+      }
+    },
+    "Member": {
+      "type": "object",
+      "description": "Member of a scope.",
+      "properties": {
+        "properties": {"$ref": "#/$defs/Properties"}
+      }
+    },
+    "Model": {
+      "type": "object",
+      "properties": {
+        "uris": {
+          "type": "object",
+          "description": "Libraries by URI.",
+          "additionalProperties": {"$ref": "#/$defs/Library"}
+        }
+      }
+    },
+    "Properties": {
+      "type": "object",
+      "description": "Set of boolean properties.",
+      "properties": {
+        "isAbstract": {"type": "boolean"},
+        "isClass": {"type": "boolean"},
+        "isGetter": {"type": "boolean"},
+        "isField": {"type": "boolean"},
+        "isMethod": {"type": "boolean"},
+        "isStatic": {"type": "boolean"},
+        "isSynthetic": {"type": "boolean"}
+      }
+    },
+    "Library": {
+      "description": "Library.",
+      "type": "object",
+      "properties": {
+        "scopes": {
+          "type": "object",
+          "description": "Scopes by name.",
+          "additionalProperties": {"$ref": "#/$defs/Interface"}
+        }
+      }
+    },
+    "QualifiedName": {
+      "type": "string"
+    }
+  }
+}

--- a/schemas/dart_model.schema.json
+++ b/schemas/dart_model.schema.json
@@ -5,9 +5,9 @@
     {"$ref": "#/$defs/Model"}
   ],
   "$defs": {
-    "Annotation": {
+    "MetadataAnnotation": {
       "type": "object",
-      "description": "An annotation.",
+      "description": "A metadata annotation.",
       "properties": {
         "type": {"$ref": "#/$defs/QualifiedName"}
       }
@@ -16,9 +16,9 @@
       "type": "object",
       "description": "An interface.",
       "properties": {
-        "annotations": {
+        "metadataAnnotations": {
           "type": "array",
-          "items": {"$ref": "#/$defs/Annotation"}
+          "items": {"$ref": "#/$defs/MetadataAnnotation"}
         },
         "members": {
           "type": "object",
@@ -37,6 +37,7 @@
     },
     "Model": {
       "type": "object",
+      "description": "Partial model of a corpus of Dart source code.",
       "properties": {
         "uris": {
           "type": "object",

--- a/tool/dart_model_generator/analysis_options.yaml
+++ b/tool/dart_model_generator/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:dart_flutter_team_lints/analysis_options.yaml

--- a/tool/dart_model_generator/bin/main.dart
+++ b/tool/dart_model_generator/bin/main.dart
@@ -1,0 +1,3 @@
+import 'package:generate_dart_model/generate_dart_model.dart';
+
+void main() => DartModelGenerator().run();

--- a/tool/dart_model_generator/bin/main.dart
+++ b/tool/dart_model_generator/bin/main.dart
@@ -1,3 +1,8 @@
-import 'package:generate_dart_model/generate_dart_model.dart';
+// Copyright (c) 2024, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
 
-void main() => DartModelGenerator().run();
+import 'package:generate_dart_model/generate_dart_model.dart'
+    as dart_model_generator;
+
+void main() => dart_model_generator.run();

--- a/tool/dart_model_generator/lib/generate_dart_model.dart
+++ b/tool/dart_model_generator/lib/generate_dart_model.dart
@@ -1,0 +1,136 @@
+// Copyright (c) 2024, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:dart_style/dart_style.dart';
+import 'package:json_schema/json_schema.dart';
+
+class DartModelGenerator {
+  void run() {
+    final result = <String>[];
+    final schema = JsonSchema.create(
+        File('schemas/dart_model.schema.json').readAsStringSync());
+    for (final def in schema.defs.entries) {
+      result.add(_generateExtensionType(def.key, def.value));
+    }
+
+    File('pkgs/dart_model/lib/src/dart_model.g.dart').writeAsStringSync(
+        DartFormatter().formatSource(SourceCode(result.join('\n'))).text);
+  }
+
+  String _generateExtensionType(String name, JsonSchema definition) {
+    final result = StringBuffer();
+
+    final jsonType = switch (definition.type) {
+      SchemaType.object => 'Map<String, Object?> node',
+      SchemaType.string => 'String string',
+      _ => throw UnsupportedError('Schema type ${definition.type}.'),
+    };
+    result.writeln('extension type $name.fromJson($jsonType) {');
+
+    final propertyMetadatas = definition.properties.entries
+        .map((e) => _readPropertyMetadata(e.key, e.value))
+        .toList();
+    if (definition.type == SchemaType.object) {
+      result.writeln('  $name({');
+      for (final property in propertyMetadatas) {
+        result.writeln(switch (property.type) {
+          PropertyType.object =>
+            '${property.elementTypeName}? ${property.name},',
+          PropertyType.bool => 'bool? ${property.name},',
+          PropertyType.string => 'string? ${property.name},',
+          PropertyType.list =>
+            'List<${property.elementTypeName}>? ${property.name},',
+          PropertyType.map =>
+            'Map<String, ${property.elementTypeName}>? ${property.name},',
+        });
+      }
+      result.writeln('}) : this.fromJson({');
+      for (final property in propertyMetadatas) {
+        result.writeln('if (${property.name} != null) '
+            "'${property.name}': ${property.name},");
+      }
+      result.writeln('});');
+    } else if (definition.type == SchemaType.string) {
+      result.writeln('$name(String string) : this.fromJson(string);');
+    }
+
+    for (final property in propertyMetadatas) {
+      result.writeln(switch (property.type) {
+        PropertyType.object =>
+          // TODO(davidmorgan): use the extension type constructor instead of
+          // casting.
+          '${property.elementTypeName} get ${property.name} => '
+              'node[\'${property.name}\']!'
+              ' as ${property.elementTypeName};',
+        PropertyType.bool => 'bool get ${property.name} => '
+            'node[\'${property.name}\']! as bool;',
+        PropertyType.string => 'String get ${property.name} => '
+            'node[\'${property.name}\']! as String;',
+        PropertyType.list =>
+          'List<${property.elementTypeName}> get ${property.name} => '
+              'node[\'${property.name}\']! '
+              'as List<${property.elementTypeName}>;',
+        PropertyType.map =>
+          'Map<String, ${property.elementTypeName}> get ${property.name} => '
+              'node[\'${property.name}\']! '
+              'as Map<String, ${property.elementTypeName}>;',
+      });
+    }
+    result.writeln('}');
+    return result.toString();
+  }
+
+  PropertyMetadata _readPropertyMetadata(String name, JsonSchema schema) {
+    if (schema.schemaMap!.containsKey(r'$ref')) {
+      final ref = schema.schemaMap![r'$ref']! as String;
+      if (ref.startsWith(r'#/$defs/')) {
+        final schemaName = ref.substring(r'#/$defs/'.length);
+        return PropertyMetadata(
+            name: name, type: PropertyType.object, elementTypeName: schemaName);
+      } else {
+        throw UnsupportedError('Unsupported: $name $schema');
+      }
+    }
+
+    return switch (schema.type) {
+      SchemaType.boolean =>
+        PropertyMetadata(name: name, type: PropertyType.bool),
+      SchemaType.string =>
+        PropertyMetadata(name: name, type: PropertyType.string),
+      SchemaType.array => PropertyMetadata(
+          name: name,
+          type: PropertyType.list,
+          elementTypeName: _readRefName(schema, 'items')),
+      SchemaType.object => PropertyMetadata(
+          name: name,
+          type: PropertyType.map,
+          elementTypeName: _readRefName(schema, 'additionalProperties')),
+      _ => throw UnsupportedError('Unsupported schema type: ${schema.type}'),
+    };
+  }
+
+  String _readRefName(JsonSchema schema, String key) {
+    final ref = schema.schemaMap![key]![r'$ref'];
+    return ref.substring(r'#/$defs/'.length);
+  }
+}
+
+enum PropertyType {
+  object,
+  bool,
+  string,
+  list,
+  map,
+}
+
+class PropertyMetadata {
+  String name;
+  PropertyType type;
+  String? elementTypeName;
+
+  PropertyMetadata(
+      {required this.name, required this.type, this.elementTypeName});
+}

--- a/tool/dart_model_generator/lib/generate_dart_model.dart
+++ b/tool/dart_model_generator/lib/generate_dart_model.dart
@@ -138,7 +138,7 @@ PropertyMetadata _readPropertyMetadata(String name, JsonSchema schema) {
 
 /// Reads the type name of a `$ref` to a `$def`.
 String _readRefName(JsonSchema schema, String key) {
-  final ref = schema.schemaMap![key]![r'$ref'];
+  final ref = (schema.schemaMap![key] as Map)[r'$ref'] as String;
   return ref.substring(r'#/$defs/'.length);
 }
 

--- a/tool/dart_model_generator/lib/generate_dart_model.dart
+++ b/tool/dart_model_generator/lib/generate_dart_model.dart
@@ -7,40 +7,57 @@ import 'dart:io';
 import 'package:dart_style/dart_style.dart';
 import 'package:json_schema/json_schema.dart';
 
-class DartModelGenerator {
-  void run() {
-    final result = <String>[];
-    final schema = JsonSchema.create(
-        File('schemas/dart_model.schema.json').readAsStringSync());
-    for (final def in schema.defs.entries) {
-      result.add(_generateExtensionType(def.key, def.value));
-    }
-
-    File('pkgs/dart_model/lib/src/dart_model.g.dart').writeAsStringSync(
-        DartFormatter().formatSource(SourceCode(result.join('\n'))).text);
+/// Generates `pkgs/dart_model/lib/src/dart_model.g.dart` from
+/// `schemas/dart_model.schema.json`.
+///
+/// Generated types are extension types with JSON maps as the underlying data.
+/// They have a `fromJson` constructor that takes that JSON, and a no-name
+/// constructor that builds it.
+void run() {
+  final result = <String>[
+    '// This file is generated. To make changes, '
+        'edit schemas/dart_model.schema.json',
+    '// then run from the repo root: '
+        'dart tool/model_generator/bin/main.dart',
+    '',
+  ];
+  final schema = JsonSchema.create(
+      File('schemas/dart_model.schema.json').readAsStringSync());
+  for (final def in schema.defs.entries) {
+    result.add(_generateExtensionType(def.key, def.value));
   }
 
-  String _generateExtensionType(String name, JsonSchema definition) {
-    final result = StringBuffer();
+  File('pkgs/dart_model/lib/src/dart_model.g.dart').writeAsStringSync(
+      DartFormatter().formatSource(SourceCode(result.join('\n'))).text);
+}
 
-    final jsonType = switch (definition.type) {
-      SchemaType.object => 'Map<String, Object?> node',
-      SchemaType.string => 'String string',
-      _ => throw UnsupportedError('Schema type ${definition.type}.'),
-    };
-    result.writeln('extension type $name.fromJson($jsonType) {');
+String _generateExtensionType(String name, JsonSchema definition) {
+  final result = StringBuffer();
 
-    final propertyMetadatas = definition.properties.entries
-        .map((e) => _readPropertyMetadata(e.key, e.value))
-        .toList();
-    if (definition.type == SchemaType.object) {
+  // Generate the extension type header with `fromJson` constructor and the
+  // appropriate underlying type.
+  final jsonType = switch (definition.type) {
+    SchemaType.object => 'Map<String, Object?> node',
+    SchemaType.string => 'String string',
+    _ => throw UnsupportedError('Schema type ${definition.type}.'),
+  };
+  result.writeln('extension type $name.fromJson($jsonType) {');
+
+  // Generate the non-JSON constructor, which accepts an optional value for
+  // every field and constructs JSON from it.
+  final propertyMetadatas = [
+    for (var e in definition.properties.entries)
+      _readPropertyMetadata(e.key, e.value)
+  ];
+  switch (definition.type) {
+    case SchemaType.object:
       result.writeln('  $name({');
       for (final property in propertyMetadatas) {
         result.writeln(switch (property.type) {
           PropertyType.object =>
             '${property.elementTypeName}? ${property.name},',
           PropertyType.bool => 'bool? ${property.name},',
-          PropertyType.string => 'string? ${property.name},',
+          PropertyType.string => 'String? ${property.name},',
           PropertyType.list =>
             'List<${property.elementTypeName}>? ${property.name},',
           PropertyType.map =>
@@ -53,71 +70,79 @@ class DartModelGenerator {
             "'${property.name}': ${property.name},");
       }
       result.writeln('});');
-    } else if (definition.type == SchemaType.string) {
+    case SchemaType.string:
       result.writeln('$name(String string) : this.fromJson(string);');
-    }
-
-    for (final property in propertyMetadatas) {
-      result.writeln(switch (property.type) {
-        PropertyType.object =>
-          // TODO(davidmorgan): use the extension type constructor instead of
-          // casting.
-          '${property.elementTypeName} get ${property.name} => '
-              'node[\'${property.name}\']!'
-              ' as ${property.elementTypeName};',
-        PropertyType.bool => 'bool get ${property.name} => '
-            'node[\'${property.name}\']! as bool;',
-        PropertyType.string => 'String get ${property.name} => '
-            'node[\'${property.name}\']! as String;',
-        PropertyType.list =>
-          'List<${property.elementTypeName}> get ${property.name} => '
-              'node[\'${property.name}\']! '
-              'as List<${property.elementTypeName}>;',
-        PropertyType.map =>
-          'Map<String, ${property.elementTypeName}> get ${property.name} => '
-              'node[\'${property.name}\']! '
-              'as Map<String, ${property.elementTypeName}>;',
-      });
-    }
-    result.writeln('}');
-    return result.toString();
+    default:
+      throw UnsupportedError('Unsupported type: ${definition.type}');
   }
 
-  PropertyMetadata _readPropertyMetadata(String name, JsonSchema schema) {
-    if (schema.schemaMap!.containsKey(r'$ref')) {
-      final ref = schema.schemaMap![r'$ref']! as String;
-      if (ref.startsWith(r'#/$defs/')) {
-        final schemaName = ref.substring(r'#/$defs/'.length);
-        return PropertyMetadata(
-            name: name, type: PropertyType.object, elementTypeName: schemaName);
-      } else {
-        throw UnsupportedError('Unsupported: $name $schema');
-      }
-    }
-
-    return switch (schema.type) {
-      SchemaType.boolean =>
-        PropertyMetadata(name: name, type: PropertyType.bool),
-      SchemaType.string =>
-        PropertyMetadata(name: name, type: PropertyType.string),
-      SchemaType.array => PropertyMetadata(
-          name: name,
-          type: PropertyType.list,
-          elementTypeName: _readRefName(schema, 'items')),
-      SchemaType.object => PropertyMetadata(
-          name: name,
-          type: PropertyType.map,
-          elementTypeName: _readRefName(schema, 'additionalProperties')),
-      _ => throw UnsupportedError('Unsupported schema type: ${schema.type}'),
-    };
+  // Generate a getter for every field that looks up in the JSON and "creates"
+  // extension types or casts collections as needed. The getters assume the
+  // data is present and will throw if it's not.
+  for (final property in propertyMetadatas) {
+    result.writeln(switch (property.type) {
+      PropertyType.object =>
+        // TODO(davidmorgan): use the extension type constructor instead of
+        // casting.
+        '${property.elementTypeName} get ${property.name} => '
+            'node[\'${property.name}\'] '
+            'as ${property.elementTypeName};',
+      PropertyType.bool => 'bool get ${property.name} => '
+          'node[\'${property.name}\'] as bool;',
+      PropertyType.string => 'String get ${property.name} => '
+          'node[\'${property.name}\'] as String;',
+      PropertyType.list =>
+        'List<${property.elementTypeName}> get ${property.name} => '
+            '(node[\'${property.name}\'] as List).cast();',
+      PropertyType.map =>
+        'Map<String, ${property.elementTypeName}> get ${property.name} => '
+            '(node[\'${property.name}\'] as Map).cast();',
+    });
   }
-
-  String _readRefName(JsonSchema schema, String key) {
-    final ref = schema.schemaMap![key]![r'$ref'];
-    return ref.substring(r'#/$defs/'.length);
-  }
+  result.writeln('}');
+  return result.toString();
 }
 
+/// Gets information about an extension type property from [schema].
+PropertyMetadata _readPropertyMetadata(String name, JsonSchema schema) {
+  // Check for a `$ref` to another extension type defined under `$defs`.
+  if (schema.schemaMap!.containsKey(r'$ref')) {
+    final ref = schema.schemaMap![r'$ref'] as String;
+    if (ref.startsWith(r'#/$defs/')) {
+      final schemaName = ref.substring(r'#/$defs/'.length);
+      return PropertyMetadata(
+          name: name, type: PropertyType.object, elementTypeName: schemaName);
+    } else {
+      throw UnsupportedError('Unsupported: $name $schema');
+    }
+  }
+
+  // Otherwise, it's a schema with a type.
+  return switch (schema.type) {
+    SchemaType.boolean => PropertyMetadata(name: name, type: PropertyType.bool),
+    SchemaType.string =>
+      PropertyMetadata(name: name, type: PropertyType.string),
+    SchemaType.array => PropertyMetadata(
+        name: name,
+        type: PropertyType.list,
+        // `items` should be a type specified with a `$ref`.
+        elementTypeName: _readRefName(schema, 'items')),
+    SchemaType.object => PropertyMetadata(
+        name: name,
+        type: PropertyType.map,
+        // `additionalProperties` should be a type specified with a `$ref`.
+        elementTypeName: _readRefName(schema, 'additionalProperties')),
+    _ => throw UnsupportedError('Unsupported schema type: ${schema.type}'),
+  };
+}
+
+/// Reads the type name of a `$ref` to a `$def`.
+String _readRefName(JsonSchema schema, String key) {
+  final ref = schema.schemaMap![key]![r'$ref'];
+  return ref.substring(r'#/$defs/'.length);
+}
+
+/// The Dart types used in extension types to model JSON types.
 enum PropertyType {
   object,
   bool,
@@ -126,6 +151,7 @@ enum PropertyType {
   map,
 }
 
+/// Metadata about a property in an extension type.
 class PropertyMetadata {
   String name;
   PropertyType type;

--- a/tool/dart_model_generator/pubspec.yaml
+++ b/tool/dart_model_generator/pubspec.yaml
@@ -7,9 +7,10 @@ environment:
 dependencies:
   dart_model: any
   dart_style: ^2.3.6
+  json_schema: ^5.1.7
 
 dev_dependencies:
-  json_schema: ^5.1.7
+  dart_flutter_team_lints: ^3.0.0
   test: ^1.25.7
 
 dependency_overrides:

--- a/tool/dart_model_generator/pubspec.yaml
+++ b/tool/dart_model_generator/pubspec.yaml
@@ -1,0 +1,18 @@
+name: generate_dart_model
+publish-to: none
+
+environment:
+  sdk: ^3.4.0
+
+dependencies:
+  dart_model: any
+  dart_style: ^2.3.6
+
+dev_dependencies:
+  json_schema: ^5.1.7
+  test: ^1.25.7
+
+dependency_overrides:
+  dart_model:
+    path:
+      ../../pkgs/dart_model


### PR DESCRIPTION
Add a schema and a generator that generates extension types based on it.

Obviously we don't have to check in the generated code but it seems useful for now that we review it.

No particular clear ideas on the best way to lay this out, e.g. the top level "schema" folder, the generator under "tool". Happy to hear any suggestions.

No test coverage for the generator yet but we get exactly one golden file test, the output, for free :) happy to add anything you think is useful at this point.

Next steps:

1) a way to combine manually written code with the generated code, to add docs and helper methods.
2) a way to construct the extension types that is compatible with representation as a byte buffer, i.e. the underlying collections need to be swapped for special purpose ones.