### PR TITLE
Add generation of comments; add coments to schema; add file for exten…

### DIFF
--- a/pkgs/dart_model/lib/dart_model.dart
+++ b/pkgs/dart_model/lib/dart_model.dart
@@ -2,6 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-export 'src/dart_model.g.dart';
+export 'src/dart_model.dart';
 export 'src/json.dart';
 export 'src/json_changes.dart';

--- a/pkgs/dart_model/lib/src/dart_model.dart
+++ b/pkgs/dart_model/lib/src/dart_model.dart
@@ -1,0 +1,12 @@
+// Copyright (c) 2024, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart_model.g.dart';
+
+export 'dart_model.g.dart';
+
+// TODO(davidmorgan): remove example when we have an actual extension method.
+extension ModelExtension on Model {
+  String get exampleGetter => 'exampleValue';
+}

--- a/pkgs/dart_model/lib/src/dart_model.g.dart
+++ b/pkgs/dart_model/lib/src/dart_model.g.dart
@@ -1,15 +1,19 @@
 // This file is generated. To make changes, edit schemas/dart_model.schema.json
 // then run from the repo root: dart tool/model_generator/bin/main.dart
 
+/// A metadata annotation.
 extension type MetadataAnnotation.fromJson(Map<String, Object?> node) {
   MetadataAnnotation({
     QualifiedName? type,
   }) : this.fromJson({
           if (type != null) 'type': type,
         });
+
+  /// The type of the annotation.
   QualifiedName get type => node['type'] as QualifiedName;
 }
 
+/// An interface.
 extension type Interface.fromJson(Map<String, Object?> node) {
   Interface({
     List<MetadataAnnotation>? metadataAnnotations,
@@ -21,30 +25,43 @@ extension type Interface.fromJson(Map<String, Object?> node) {
           if (members != null) 'members': members,
           if (properties != null) 'properties': properties,
         });
+
+  /// The metadata annotations attached to this iterface.
   List<MetadataAnnotation> get metadataAnnotations =>
       (node['metadataAnnotations'] as List).cast();
+
+  /// Map of members by name.
   Map<String, Member> get members => (node['members'] as Map).cast();
+
+  /// The properties of this interface.
   Properties get properties => node['properties'] as Properties;
 }
 
+/// Member of a scope.
 extension type Member.fromJson(Map<String, Object?> node) {
   Member({
     Properties? properties,
   }) : this.fromJson({
           if (properties != null) 'properties': properties,
         });
+
+  /// The properties of this member.
   Properties get properties => node['properties'] as Properties;
 }
 
+/// Partial model of a corpus of Dart source code.
 extension type Model.fromJson(Map<String, Object?> node) {
   Model({
     Map<String, Library>? uris,
   }) : this.fromJson({
           if (uris != null) 'uris': uris,
         });
+
+  /// Libraries by URI.
   Map<String, Library> get uris => (node['uris'] as Map).cast();
 }
 
+/// Set of boolean properties.
 extension type Properties.fromJson(Map<String, Object?> node) {
   Properties({
     bool? isAbstract,
@@ -53,7 +70,6 @@ extension type Properties.fromJson(Map<String, Object?> node) {
     bool? isField,
     bool? isMethod,
     bool? isStatic,
-    bool? isSynthetic,
   }) : this.fromJson({
           if (isAbstract != null) 'isAbstract': isAbstract,
           if (isClass != null) 'isClass': isClass,
@@ -61,26 +77,40 @@ extension type Properties.fromJson(Map<String, Object?> node) {
           if (isField != null) 'isField': isField,
           if (isMethod != null) 'isMethod': isMethod,
           if (isStatic != null) 'isStatic': isStatic,
-          if (isSynthetic != null) 'isSynthetic': isSynthetic,
         });
+
+  /// Whether the entity is abstract, meaning it has no definition.
   bool get isAbstract => node['isAbstract'] as bool;
+
+  /// Whether the entity is a class.
   bool get isClass => node['isClass'] as bool;
+
+  /// Whether the entity is a getter.
   bool get isGetter => node['isGetter'] as bool;
+
+  /// Whether the entity is a field.
   bool get isField => node['isField'] as bool;
+
+  /// Whether the entity is a method.
   bool get isMethod => node['isMethod'] as bool;
+
+  /// Whether the entity is static.
   bool get isStatic => node['isStatic'] as bool;
-  bool get isSynthetic => node['isSynthetic'] as bool;
 }
 
+/// Library.
 extension type Library.fromJson(Map<String, Object?> node) {
   Library({
     Map<String, Interface>? scopes,
   }) : this.fromJson({
           if (scopes != null) 'scopes': scopes,
         });
+
+  /// Scopes by name.
   Map<String, Interface> get scopes => (node['scopes'] as Map).cast();
 }
 
+/// A URI combined with a name.
 extension type QualifiedName.fromJson(String string) {
   QualifiedName(String string) : this.fromJson(string);
 }

--- a/pkgs/dart_model/test/model_test.dart
+++ b/pkgs/dart_model/test/model_test.dart
@@ -46,6 +46,10 @@ void main() {
       }
     };
 
+    test('has extension methods', () {
+      expect(model.exampleGetter, 'exampleValue');
+    });
+
     test('maps to JSON', () {
       expect(model as Map, expected);
     });

--- a/schemas/dart_model.schema.json
+++ b/schemas/dart_model.schema.json
@@ -9,7 +9,10 @@
       "type": "object",
       "description": "A metadata annotation.",
       "properties": {
-        "type": {"$ref": "#/$defs/QualifiedName"}
+        "type": {
+          "$comment": "The type of the annotation.",
+          "$ref": "#/$defs/QualifiedName"
+        }
       }
     },
     "Interface": {
@@ -17,6 +20,7 @@
       "description": "An interface.",
       "properties": {
         "metadataAnnotations": {
+          "description": "The metadata annotations attached to this iterface.",
           "type": "array",
           "items": {"$ref": "#/$defs/MetadataAnnotation"}
         },
@@ -25,14 +29,20 @@
           "description": "Map of members by name.",
           "additionalProperties": {"$ref": "#/$defs/Member"}
         },
-        "properties": {"$ref": "#/$defs/Properties"}
+        "properties": {
+          "$comment": "The properties of this interface.",
+          "$ref": "#/$defs/Properties"
+        }
       }
     },
     "Member": {
       "type": "object",
       "description": "Member of a scope.",
       "properties": {
-        "properties": {"$ref": "#/$defs/Properties"}
+        "properties": {
+          "$comment": "The properties of this member.",
+          "$ref": "#/$defs/Properties"
+        }
       }
     },
     "Model": {
@@ -50,13 +60,30 @@
       "type": "object",
       "description": "Set of boolean properties.",
       "properties": {
-        "isAbstract": {"type": "boolean"},
-        "isClass": {"type": "boolean"},
-        "isGetter": {"type": "boolean"},
-        "isField": {"type": "boolean"},
-        "isMethod": {"type": "boolean"},
-        "isStatic": {"type": "boolean"},
-        "isSynthetic": {"type": "boolean"}
+        "isAbstract": {
+          "description": "Whether the entity is abstract, meaning it has no definition.",
+          "type": "boolean"
+        },
+        "isClass": {
+          "description": "Whether the entity is a class.",
+          "type": "boolean"
+        },
+        "isGetter": {
+          "description": "Whether the entity is a getter.",
+          "type": "boolean"
+        },
+        "isField": {
+          "description": "Whether the entity is a field.",
+          "type": "boolean"
+        },
+        "isMethod": {
+          "description": "Whether the entity is a method.",
+          "type": "boolean"
+        },
+        "isStatic": {
+          "description": "Whether the entity is static.",
+          "type": "boolean"
+        }
       }
     },
     "Library": {
@@ -71,6 +98,7 @@
       }
     },
     "QualifiedName": {
+      "description": "A URI combined with a name.",
       "type": "string"
     }
   }

--- a/tool/dart_model_generator/lib/generate_dart_model.dart
+++ b/tool/dart_model_generator/lib/generate_dart_model.dart
@@ -41,6 +41,9 @@ String _generateExtensionType(String name, JsonSchema definition) {
     SchemaType.string => 'String string',
     _ => throw UnsupportedError('Schema type ${definition.type}.'),
   };
+  if (definition.description != null) {
+    result.writeln('/// ${definition.description}');
+  }
   result.writeln('extension type $name.fromJson($jsonType) {');
 
   // Generate the non-JSON constructor, which accepts an optional value for
@@ -80,6 +83,8 @@ String _generateExtensionType(String name, JsonSchema definition) {
   // extension types or casts collections as needed. The getters assume the
   // data is present and will throw if it's not.
   for (final property in propertyMetadatas) {
+    if (property.description != null)
+      result.writeln('/// ${property.description}');
     result.writeln(switch (property.type) {
       PropertyType.object =>
         // TODO(davidmorgan): use the extension type constructor instead of
@@ -111,7 +116,15 @@ PropertyMetadata _readPropertyMetadata(String name, JsonSchema schema) {
     if (ref.startsWith(r'#/$defs/')) {
       final schemaName = ref.substring(r'#/$defs/'.length);
       return PropertyMetadata(
-          name: name, type: PropertyType.object, elementTypeName: schemaName);
+          // The "description" comes from the ref'd schema. But, we want to
+          // describe the property, not the type of the property. It's possible
+          // to use `allOf` to specify a second schema with a second
+          // `description`, but for simplicity use `$comment` which is just
+          // ignored by standard tooling.
+          description: schema.schemaMap![r'$comment'] as String?,
+          name: name,
+          type: PropertyType.object,
+          elementTypeName: schemaName);
     } else {
       throw UnsupportedError('Unsupported: $name $schema');
     }
@@ -119,15 +132,18 @@ PropertyMetadata _readPropertyMetadata(String name, JsonSchema schema) {
 
   // Otherwise, it's a schema with a type.
   return switch (schema.type) {
-    SchemaType.boolean => PropertyMetadata(name: name, type: PropertyType.bool),
-    SchemaType.string =>
-      PropertyMetadata(name: name, type: PropertyType.string),
+    SchemaType.boolean => PropertyMetadata(
+        description: schema.description, name: name, type: PropertyType.bool),
+    SchemaType.string => PropertyMetadata(
+        description: schema.description, name: name, type: PropertyType.string),
     SchemaType.array => PropertyMetadata(
+        description: schema.description,
         name: name,
         type: PropertyType.list,
         // `items` should be a type specified with a `$ref`.
         elementTypeName: _readRefName(schema, 'items')),
     SchemaType.object => PropertyMetadata(
+        description: schema.description,
         name: name,
         type: PropertyType.map,
         // `additionalProperties` should be a type specified with a `$ref`.
@@ -153,10 +169,14 @@ enum PropertyType {
 
 /// Metadata about a property in an extension type.
 class PropertyMetadata {
+  String? description;
   String name;
   PropertyType type;
   String? elementTypeName;
 
   PropertyMetadata(
-      {required this.name, required this.type, this.elementTypeName});
+      {this.description,
+      required this.name,
+      required this.type,
+      this.elementTypeName});
 }


### PR DESCRIPTION
Fix #6 

Go with extensions on extension types, and generation of comments.

There's just one wrinkle with generation of comments, which is that when you `$ref` a type it pulls in the description of the _type_ as the description of the _property_. So the description of the field `Foo myFoo;` is copied from `Foo`, which is not what you want.

It's possible to [use `allOf`](https://github.com/json-schema-org/json-schema-spec/issues/239#issuecomment-277129772) to specify a second `description`, but that's pretty ugly, I suggest we use `$comment`, which is slightly worse in terms of what it means (nothing!) but looks nicer in the schema and is fine for generation. It's a bit annoying that we have to remember to use `$comment` only next to `$ref`, but that's easier to remember than using `allOf` with a `description` next to `$ref` :) what do you think?