### PR TITLE
Connect up augmentations from macro output through to host.

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:stable"
@@ -27,12 +27,12 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
           sdk: stable
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - name: mono_repo self validate
         run: dart pub global activate mono_repo 6.6.1
       - name: mono_repo self validate
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-48.0.dev;packages:pkgs/_analyzer_macros-pkgs/_cfe_macros-pkgs/_macro_builder-pkgs/_macro_client-pkgs/_macro_host-pkgs/_macro_runner-pkgs/_macro_server-pkgs/_test_macros-pkgs/dart_model-pkgs/macro-pkgs/macro_service-tool/dart_model_generator;commands:analyze"
@@ -52,12 +52,12 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
           sdk: "3.6.0-48.0.dev"
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - id: pkgs__analyzer_macros_pub_upgrade
         name: pkgs/_analyzer_macros; dart pub upgrade
         run: dart pub upgrade
@@ -171,7 +171,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/_analyzer_macros-pkgs/_macro_builder-pkgs/_macro_client-pkgs/_macro_host-pkgs/_macro_runner-pkgs/_macro_server-pkgs/_test_macros-pkgs/dart_model-pkgs/macro-pkgs/macro_service-tool/dart_model_generator;commands:analyze"
@@ -181,12 +181,12 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
           sdk: dev
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - id: pkgs__analyzer_macros_pub_upgrade
         name: pkgs/_analyzer_macros; dart pub upgrade
         run: dart pub upgrade
@@ -291,7 +291,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/_analyzer_macros-pkgs/_cfe_macros-pkgs/_macro_builder-pkgs/_macro_client-pkgs/_macro_host-pkgs/_macro_runner-pkgs/_macro_server-pkgs/_test_macros-pkgs/dart_model-pkgs/macro-pkgs/macro_service-tool/dart_model_generator;commands:format"
@@ -301,12 +301,12 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
           sdk: dev
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - id: pkgs__analyzer_macros_pub_upgrade
         name: pkgs/_analyzer_macros; dart pub upgrade
         run: dart pub upgrade
@@ -420,7 +420,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-48.0.dev;packages:pkgs/_analyzer_macros;commands:test"
@@ -430,12 +430,12 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
           sdk: "3.6.0-48.0.dev"
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - id: pkgs__analyzer_macros_pub_upgrade
         name: pkgs/_analyzer_macros; dart pub upgrade
         run: dart pub upgrade
@@ -455,7 +455,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-48.0.dev;packages:pkgs/_cfe_macros;commands:test"
@@ -465,12 +465,12 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
           sdk: "3.6.0-48.0.dev"
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - id: pkgs__cfe_macros_pub_upgrade
         name: pkgs/_cfe_macros; dart pub upgrade
         run: dart pub upgrade
@@ -490,7 +490,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-48.0.dev;packages:pkgs/_macro_builder;commands:test"
@@ -500,12 +500,12 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
           sdk: "3.6.0-48.0.dev"
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - id: pkgs__macro_builder_pub_upgrade
         name: pkgs/_macro_builder; dart pub upgrade
         run: dart pub upgrade
@@ -525,7 +525,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-48.0.dev;packages:pkgs/_macro_client;commands:test"
@@ -535,12 +535,12 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
           sdk: "3.6.0-48.0.dev"
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - id: pkgs__macro_client_pub_upgrade
         name: pkgs/_macro_client; dart pub upgrade
         run: dart pub upgrade
@@ -560,7 +560,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-48.0.dev;packages:pkgs/_macro_host;commands:test"
@@ -570,12 +570,12 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
           sdk: "3.6.0-48.0.dev"
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - id: pkgs__macro_host_pub_upgrade
         name: pkgs/_macro_host; dart pub upgrade
         run: dart pub upgrade
@@ -595,7 +595,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-48.0.dev;packages:pkgs/_macro_runner;commands:test"
@@ -605,12 +605,12 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
           sdk: "3.6.0-48.0.dev"
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - id: pkgs__macro_runner_pub_upgrade
         name: pkgs/_macro_runner; dart pub upgrade
         run: dart pub upgrade
@@ -630,7 +630,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-48.0.dev;packages:pkgs/_macro_server;commands:test"
@@ -640,12 +640,12 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
           sdk: "3.6.0-48.0.dev"
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - id: pkgs__macro_server_pub_upgrade
         name: pkgs/_macro_server; dart pub upgrade
         run: dart pub upgrade
@@ -665,7 +665,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-48.0.dev;packages:pkgs/dart_model;commands:test"
@@ -675,12 +675,12 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
           sdk: "3.6.0-48.0.dev"
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - id: pkgs_dart_model_pub_upgrade
         name: pkgs/dart_model; dart pub upgrade
         run: dart pub upgrade
@@ -700,7 +700,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-48.0.dev;packages:tool/dart_model_generator;commands:test"
@@ -710,12 +710,12 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
           sdk: "3.6.0-48.0.dev"
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - id: tool_dart_model_generator_pub_upgrade
         name: tool/dart_model_generator; dart pub upgrade
         run: dart pub upgrade
@@ -735,7 +735,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/_analyzer_macros;commands:test"
@@ -745,12 +745,12 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
           sdk: dev
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - id: pkgs__analyzer_macros_pub_upgrade
         name: pkgs/_analyzer_macros; dart pub upgrade
         run: dart pub upgrade
@@ -770,7 +770,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/_macro_builder;commands:test"
@@ -780,12 +780,12 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
           sdk: dev
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - id: pkgs__macro_builder_pub_upgrade
         name: pkgs/_macro_builder; dart pub upgrade
         run: dart pub upgrade
@@ -805,7 +805,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/_macro_client;commands:test"
@@ -815,12 +815,12 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
           sdk: dev
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - id: pkgs__macro_client_pub_upgrade
         name: pkgs/_macro_client; dart pub upgrade
         run: dart pub upgrade
@@ -840,7 +840,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/_macro_host;commands:test"
@@ -850,12 +850,12 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
           sdk: dev
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - id: pkgs__macro_host_pub_upgrade
         name: pkgs/_macro_host; dart pub upgrade
         run: dart pub upgrade
@@ -875,7 +875,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/_macro_runner;commands:test"
@@ -885,12 +885,12 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
           sdk: dev
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - id: pkgs__macro_runner_pub_upgrade
         name: pkgs/_macro_runner; dart pub upgrade
         run: dart pub upgrade
@@ -910,7 +910,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/_macro_server;commands:test"
@@ -920,12 +920,12 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
           sdk: dev
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - id: pkgs__macro_server_pub_upgrade
         name: pkgs/_macro_server; dart pub upgrade
         run: dart pub upgrade
@@ -945,7 +945,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/dart_model;commands:test"
@@ -955,12 +955,12 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
           sdk: dev
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - id: pkgs_dart_model_pub_upgrade
         name: pkgs/dart_model; dart pub upgrade
         run: dart pub upgrade
@@ -980,7 +980,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
           key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:tool/dart_model_generator;commands:test"
@@ -990,12 +990,12 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
           sdk: dev
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - id: tool_dart_model_generator_pub_upgrade
         name: tool/dart_model_generator; dart pub upgrade
         run: dart pub upgrade
@@ -1015,12 +1015,12 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
           sdk: "3.6.0-48.0.dev"
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - id: pkgs__analyzer_macros_pub_upgrade
         name: pkgs/_analyzer_macros; dart pub upgrade
         run: dart pub upgrade
@@ -1040,12 +1040,12 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
           sdk: "3.6.0-48.0.dev"
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - id: pkgs__cfe_macros_pub_upgrade
         name: pkgs/_cfe_macros; dart pub upgrade
         run: dart pub upgrade
@@ -1065,12 +1065,12 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
           sdk: "3.6.0-48.0.dev"
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - id: pkgs__macro_builder_pub_upgrade
         name: pkgs/_macro_builder; dart pub upgrade
         run: dart pub upgrade
@@ -1090,12 +1090,12 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
           sdk: "3.6.0-48.0.dev"
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - id: pkgs__macro_client_pub_upgrade
         name: pkgs/_macro_client; dart pub upgrade
         run: dart pub upgrade
@@ -1115,12 +1115,12 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
           sdk: "3.6.0-48.0.dev"
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - id: pkgs__macro_host_pub_upgrade
         name: pkgs/_macro_host; dart pub upgrade
         run: dart pub upgrade
@@ -1140,12 +1140,12 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
           sdk: "3.6.0-48.0.dev"
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - id: pkgs__macro_runner_pub_upgrade
         name: pkgs/_macro_runner; dart pub upgrade
         run: dart pub upgrade
@@ -1165,12 +1165,12 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
           sdk: "3.6.0-48.0.dev"
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - id: pkgs__macro_server_pub_upgrade
         name: pkgs/_macro_server; dart pub upgrade
         run: dart pub upgrade
@@ -1190,12 +1190,12 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
           sdk: "3.6.0-48.0.dev"
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - id: pkgs_dart_model_pub_upgrade
         name: pkgs/dart_model; dart pub upgrade
         run: dart pub upgrade
@@ -1215,12 +1215,12 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
           sdk: "3.6.0-48.0.dev"
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - id: tool_dart_model_generator_pub_upgrade
         name: tool/dart_model_generator; dart pub upgrade
         run: dart pub upgrade
@@ -1240,12 +1240,12 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
           sdk: dev
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - id: pkgs__analyzer_macros_pub_upgrade
         name: pkgs/_analyzer_macros; dart pub upgrade
         run: dart pub upgrade
@@ -1265,12 +1265,12 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
           sdk: dev
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - id: pkgs__macro_builder_pub_upgrade
         name: pkgs/_macro_builder; dart pub upgrade
         run: dart pub upgrade
@@ -1290,12 +1290,12 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
           sdk: dev
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - id: pkgs__macro_client_pub_upgrade
         name: pkgs/_macro_client; dart pub upgrade
         run: dart pub upgrade
@@ -1315,12 +1315,12 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
           sdk: dev
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - id: pkgs__macro_host_pub_upgrade
         name: pkgs/_macro_host; dart pub upgrade
         run: dart pub upgrade
@@ -1340,12 +1340,12 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
           sdk: dev
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - id: pkgs__macro_runner_pub_upgrade
         name: pkgs/_macro_runner; dart pub upgrade
         run: dart pub upgrade
@@ -1365,12 +1365,12 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
           sdk: dev
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - id: pkgs__macro_server_pub_upgrade
         name: pkgs/_macro_server; dart pub upgrade
         run: dart pub upgrade
@@ -1390,12 +1390,12 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
           sdk: dev
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - id: pkgs_dart_model_pub_upgrade
         name: pkgs/dart_model; dart pub upgrade
         run: dart pub upgrade
@@ -1415,12 +1415,12 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
           sdk: dev
       - id: checkout
         name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - id: tool_dart_model_generator_pub_upgrade
         name: tool/dart_model_generator; dart pub upgrade
         run: dart pub upgrade

--- a/pkgs/_macro_client/lib/macro_client.dart
+++ b/pkgs/_macro_client/lib/macro_client.dart
@@ -14,7 +14,11 @@ import 'package:macro_service/macro_service.dart';
 /// TODO(davidmorgan): split to multpile implementations depending on
 /// transport used to connect to host.
 class MacroClient {
-  MacroClient._(Iterable<Macro> macros, Socket socket) {
+  final RemoteMacroHost host = RemoteMacroHost();
+  final Iterable<Macro> macros;
+  final Socket socket;
+
+  MacroClient._(this.macros, this.socket) {
     // TODO(davidmorgan): negotiation about protocol version goes here.
 
     // Tell the host which macros are in this bundle.
@@ -24,6 +28,11 @@ class MacroClient {
       // switch to binary.
       socket.writeln(json.encode(request.node));
     }
+
+    const Utf8Decoder()
+        .bind(socket)
+        .transform(const LineSplitter())
+        .listen(_handleRequest);
   }
 
   /// Runs [macros] for the host at [endpoint].
@@ -32,4 +41,22 @@ class MacroClient {
     final socket = await Socket.connect('localhost', endpoint.port);
     return MacroClient._(macros, socket);
   }
+
+  void _handleRequest(String request) async {
+    // TODO(davidmorgan): support more than one request type.
+    final augmentRequest =
+        AugmentRequest.fromJson(json.decode(request) as Map<String, Object?>);
+    // TODO(davidmorgan): support multiple macros.
+    final response = await macros.single.augment(host, augmentRequest);
+    _send(response.node);
+  }
+
+  void _send(Map<String, Object?> node) {
+    // TODO(davidmorgan): currently this is JSON with one request per line,
+    // switch to binary.
+    socket.writeln(json.encode(node));
+  }
 }
+
+/// [Host] that is connected to a remote macro host.
+class RemoteMacroHost implements Host {}

--- a/pkgs/_macro_client/pubspec.yaml
+++ b/pkgs/_macro_client/pubspec.yaml
@@ -14,5 +14,6 @@ dependencies:
 
 dev_dependencies:
   _test_macros: any
+  async: ^2.11.0
   dart_flutter_team_lints: ^3.0.0
   test: ^1.25.0

--- a/pkgs/_macro_client/test/macro_client_test.dart
+++ b/pkgs/_macro_client/test/macro_client_test.dart
@@ -3,10 +3,12 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:_macro_client/macro_client.dart';
 import 'package:_test_macros/declare_x_macro.dart';
+import 'package:async/async.dart';
 import 'package:macro_service/macro_service.dart';
 import 'package:test/test.dart';
 
@@ -22,6 +24,25 @@ void main() {
 
       expect(
           serverSocket.first.timeout(const Duration(seconds: 10)), completes);
+    });
+
+    test('sends requests to and from macros', () async {
+      final serverSocket = await ServerSocket.bind('localhost', 0);
+
+      unawaited(MacroClient.run(
+          endpoint: HostEndpoint(port: serverSocket.port),
+          macros: [DeclareXImplementation()]));
+
+      final socket = await serverSocket.first;
+
+      final responses = StreamQueue(
+          const Utf8Decoder().bind(socket).transform(const LineSplitter()));
+      final descriptionResponse = await responses.next;
+      expect(descriptionResponse, '{"macroDescription":{"runsInPhases":[2]}}');
+
+      socket.writeln(json.encode(AugmentRequest(phase: 2)));
+      final augmentResponse = await responses.next;
+      expect(augmentResponse, '{"augmentations":[{"code":"int get x => 3;"}]}');
     });
   });
 }

--- a/pkgs/_macro_host/test/macro_host_test.dart
+++ b/pkgs/_macro_host/test/macro_host_test.dart
@@ -21,6 +21,11 @@ void main() {
 
       expect(host.isMacro(packageConfig, macroName), true);
       expect(await host.queryMacroPhases(packageConfig, macroName), {2});
+
+      expect(
+          await host.augment(macroName, AugmentRequest(phase: 2)),
+          AugmentResponse(
+              augmentations: [Augmentation(code: 'int get x => 3;')]));
     });
   });
 }

--- a/pkgs/_macro_server/lib/macro_server.dart
+++ b/pkgs/_macro_server/lib/macro_server.dart
@@ -2,9 +2,11 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:dart_model/dart_model.dart';
 import 'package:macro_service/macro_service.dart';
 
 /// Serves a [MacroService].
@@ -12,6 +14,9 @@ class MacroServer {
   final MacroService service;
   final HostEndpoint endpoint;
   final ServerSocket serverSocket;
+
+  // TODO(davidmorgan): track which socket corresponds to which macro(s).
+  Socket? _lastSocket;
 
   MacroServer._(this.service, this.endpoint, this.serverSocket) {
     serverSocket.forEach(_handleConnection);
@@ -26,7 +31,12 @@ class MacroServer {
         service, HostEndpoint(port: serverSocket.port), serverSocket);
   }
 
+  void sendToMacro(QualifiedName name, AugmentRequest request) async {
+    _lastSocket!.writeln(json.encode(request.node));
+  }
+
   void _handleConnection(Socket socket) {
+    _lastSocket = socket;
     // TODO(davidmorgan): currently this is JSON with one request per line,
     // switch to binary.
     socket

--- a/pkgs/_macro_server/pubspec.yaml
+++ b/pkgs/_macro_server/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
   sdk: ^3.6.0-48.0.dev
 
 dependencies:
+  dart_model: any
   macro_service: any
 
 dev_dependencies:

--- a/pkgs/_test_macros/lib/declare_x_macro.dart
+++ b/pkgs/_test_macros/lib/declare_x_macro.dart
@@ -2,21 +2,23 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:dart_model/dart_model.dart';
 import 'package:macro/macro.dart';
 import 'package:macro_service/macro_service.dart';
 
+/// Adds a getter `int get x` to the class.
 class DeclareX {
   const DeclareX();
 }
 
-// TODO(davidmorgan): this is a placeholder; make it do something, test it.
 class DeclareXImplementation implements Macro {
   @override
   MacroDescription get description => MacroDescription(runsInPhases: [2]);
 
   @override
   Future<AugmentResponse> augment(Host host, AugmentRequest request) async {
-    // TODO(davidmorgan): add an implementation.
-    return AugmentResponse();
+    // TODO(davidmorgan): still need to pass through the augment target.
+    return AugmentResponse(
+        augmentations: [Augmentation(code: 'int get x => 3;')]);
   }
 }

--- a/pkgs/dart_model/lib/src/dart_model.g.dart
+++ b/pkgs/dart_model/lib/src/dart_model.g.dart
@@ -1,9 +1,16 @@
 // This file is generated. To make changes edit schemas/*.schema.json
 // then run from the repo root: dart tool/model_generator/bin/main.dart
 
-/// An augmentation to Dart code. TODO(davidmorgan): this is a placeholder, add some data.
+/// An augmentation to Dart code. TODO(davidmorgan): this is a placeholder.
 extension type Augmentation.fromJson(Map<String, Object?> node) {
-  Augmentation() : this.fromJson({});
+  Augmentation({
+    String? code,
+  }) : this.fromJson({
+          if (code != null) 'code': code,
+        });
+
+  /// Augmentation code.
+  String get code => node['code'] as String;
 }
 
 /// A metadata annotation.

--- a/pkgs/macro_service/lib/src/macro_service.g.dart
+++ b/pkgs/macro_service/lib/src/macro_service.g.dart
@@ -1,6 +1,8 @@
 // This file is generated. To make changes edit schemas/*.schema.json
 // then run from the repo root: dart tool/model_generator/bin/main.dart
 
+import 'package:dart_model/dart_model.dart';
+
 /// A request to a macro to augment some code.
 extension type AugmentRequest.fromJson(Map<String, Object?> node) {
   AugmentRequest({
@@ -15,7 +17,15 @@ extension type AugmentRequest.fromJson(Map<String, Object?> node) {
 
 /// Macro's response to an [AugmentRequest]: the resulting augmentations.
 extension type AugmentResponse.fromJson(Map<String, Object?> node) {
-  AugmentResponse() : this.fromJson({});
+  AugmentResponse({
+    List<Augmentation>? augmentations,
+  }) : this.fromJson({
+          if (augmentations != null) 'augmentations': augmentations,
+        });
+
+  /// The augmentations.
+  List<Augmentation> get augmentations =>
+      (node['augmentations'] as List).cast();
 }
 
 /// A macro host server endpoint. TODO(davidmorgan): this should be a oneOf supporting different types of connection. TODO(davidmorgan): it's not clear if this belongs in this package! But, where else?

--- a/pkgs/macro_service/pubspec.yaml
+++ b/pkgs/macro_service/pubspec.yaml
@@ -8,5 +8,8 @@ resolution: workspace
 environment:
   sdk: ^3.6.0-48.0.dev
 
+dependencies:
+  dart_model: any
+
 dev_dependencies:
   dart_flutter_team_lints: ^3.0.0

--- a/schemas/dart_model.schema.json
+++ b/schemas/dart_model.schema.json
@@ -1,14 +1,17 @@
 {
-  "$id": "https://github.com/dart-lang/macros/blob/main/schemas/dart_model.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "oneOf": [
     {"$ref": "#/$defs/Model"}
   ],
   "$defs": {
     "Augmentation": {
-      "description": "An augmentation to Dart code. TODO(davidmorgan): this is a placeholder, add some data.",
+      "description": "An augmentation to Dart code. TODO(davidmorgan): this is a placeholder.",
       "type": "object",
       "properties": {
+        "code": {
+          "type": "string",
+          "description": "Augmentation code."
+        }
       }
     },
     "MetadataAnnotation": {

--- a/schemas/macro_service.schema.json
+++ b/schemas/macro_service.schema.json
@@ -1,5 +1,4 @@
 {
-  "$id": "https://github.com/dart-lang/macros/blob/main/schemas/macro_service.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "oneOf": [
     {"$ref": "#/$defs/AugmentRequest"},
@@ -18,7 +17,14 @@
     },
     "AugmentResponse": {
       "type": "object",
-      "description": "Macro's response to an [AugmentRequest]: the resulting augmentations."
+      "description": "Macro's response to an [AugmentRequest]: the resulting augmentations.",
+      "properties": {
+        "augmentations": {
+          "description": "The augmentations.",
+          "type": "array",
+          "items": {"$ref": "file:dart_model.schema.json#/$defs/Augmentation"}
+        }
+      }
     },
     "HostEndpoint": {
       "type": "object",

--- a/tool/dart_model_generator/test/generated_output_test.dart
+++ b/tool/dart_model_generator/test/generated_output_test.dart
@@ -12,7 +12,10 @@ void main() {
   for (final package in ['dart_model', 'macro_service']) {
     test('$package output is up to date', () {
       final expected = dart_model_generator.generate(
-          File('../../schemas/$package.schema.json').readAsStringSync());
+          File('../../schemas/$package.schema.json').readAsStringSync(),
+          importDartModel: package == 'macro_service',
+          dartModelJson:
+              File('../../schemas/dart_model.schema.json').readAsStringSync());
       final actual = File('../../pkgs/$package/lib/src/$package.g.dart')
           .readAsStringSync();
       // TODO: On windows we get carriage returns, which makes this fail


### PR DESCRIPTION
Hook up macro augmentation output end to end.

Add the capability to reference the `dart_model` schema from the `macro_service` schema, because `Augmentation` is in `dart_model`.

The wire format still does not carry the actual request type because it's not needed yet, there are few enough request types to always "guess" correctly. It will need the request type very soon :)