### PR TITLE
Make set_sd_ref also take dev tags and update SDK version. Update to latest.

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -38,23 +38,23 @@ jobs:
       - name: mono_repo self validate
         run: dart pub global run mono_repo generate --validate
   job_002:
-    name: "analyze_and_format; linux; Dart 3.6.0-48.0.dev; PKGS: pkgs/_analyzer_macros, pkgs/_cfe_macros, pkgs/_macro_builder, pkgs/_macro_client, pkgs/_macro_host, pkgs/_macro_runner, pkgs/_macro_server, pkgs/_test_macros, pkgs/dart_model, pkgs/macro, pkgs/macro_service, tool/dart_model_generator; `dart analyze --fatal-infos .`"
+    name: "analyze_and_format; linux; Dart 3.6.0-114.0.dev; PKGS: pkgs/_analyzer_macros, pkgs/_cfe_macros, pkgs/_macro_builder, pkgs/_macro_client, pkgs/_macro_host, pkgs/_macro_runner, pkgs/_macro_server, pkgs/_test_macros, pkgs/dart_model, pkgs/macro, pkgs/macro_service, tool/dart_model_generator; `dart analyze --fatal-infos .`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-48.0.dev;packages:pkgs/_analyzer_macros-pkgs/_cfe_macros-pkgs/_macro_builder-pkgs/_macro_client-pkgs/_macro_host-pkgs/_macro_runner-pkgs/_macro_server-pkgs/_test_macros-pkgs/dart_model-pkgs/macro-pkgs/macro_service-tool/dart_model_generator;commands:analyze"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-114.0.dev;packages:pkgs/_analyzer_macros-pkgs/_cfe_macros-pkgs/_macro_builder-pkgs/_macro_client-pkgs/_macro_host-pkgs/_macro_runner-pkgs/_macro_server-pkgs/_test_macros-pkgs/dart_model-pkgs/macro-pkgs/macro_service-tool/dart_model_generator;commands:analyze"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-48.0.dev;packages:pkgs/_analyzer_macros-pkgs/_cfe_macros-pkgs/_macro_builder-pkgs/_macro_client-pkgs/_macro_host-pkgs/_macro_runner-pkgs/_macro_server-pkgs/_test_macros-pkgs/dart_model-pkgs/macro-pkgs/macro_service-tool/dart_model_generator
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-48.0.dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-114.0.dev;packages:pkgs/_analyzer_macros-pkgs/_cfe_macros-pkgs/_macro_builder-pkgs/_macro_client-pkgs/_macro_host-pkgs/_macro_runner-pkgs/_macro_server-pkgs/_test_macros-pkgs/dart_model-pkgs/macro-pkgs/macro_service-tool/dart_model_generator
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-114.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.6.0-48.0.dev"
+          sdk: "3.6.0-114.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -416,23 +416,23 @@ jobs:
         if: "always() && steps.tool_dart_model_generator_pub_upgrade.conclusion == 'success'"
         working-directory: tool/dart_model_generator
   job_005:
-    name: "unit_test; linux; Dart 3.6.0-48.0.dev; PKG: pkgs/_analyzer_macros; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; linux; Dart 3.6.0-114.0.dev; PKG: pkgs/_analyzer_macros; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-48.0.dev;packages:pkgs/_analyzer_macros;commands:test"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-114.0.dev;packages:pkgs/_analyzer_macros;commands:test"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-48.0.dev;packages:pkgs/_analyzer_macros
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-48.0.dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-114.0.dev;packages:pkgs/_analyzer_macros
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-114.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.6.0-48.0.dev"
+          sdk: "3.6.0-114.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -451,23 +451,23 @@ jobs:
       - job_003
       - job_004
   job_006:
-    name: "unit_test; linux; Dart 3.6.0-48.0.dev; PKG: pkgs/_cfe_macros; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; linux; Dart 3.6.0-114.0.dev; PKG: pkgs/_cfe_macros; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-48.0.dev;packages:pkgs/_cfe_macros;commands:test"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-114.0.dev;packages:pkgs/_cfe_macros;commands:test"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-48.0.dev;packages:pkgs/_cfe_macros
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-48.0.dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-114.0.dev;packages:pkgs/_cfe_macros
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-114.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.6.0-48.0.dev"
+          sdk: "3.6.0-114.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -486,23 +486,23 @@ jobs:
       - job_003
       - job_004
   job_007:
-    name: "unit_test; linux; Dart 3.6.0-48.0.dev; PKG: pkgs/_macro_builder; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; linux; Dart 3.6.0-114.0.dev; PKG: pkgs/_macro_builder; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-48.0.dev;packages:pkgs/_macro_builder;commands:test"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-114.0.dev;packages:pkgs/_macro_builder;commands:test"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-48.0.dev;packages:pkgs/_macro_builder
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-48.0.dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-114.0.dev;packages:pkgs/_macro_builder
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-114.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.6.0-48.0.dev"
+          sdk: "3.6.0-114.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -521,23 +521,23 @@ jobs:
       - job_003
       - job_004
   job_008:
-    name: "unit_test; linux; Dart 3.6.0-48.0.dev; PKG: pkgs/_macro_client; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; linux; Dart 3.6.0-114.0.dev; PKG: pkgs/_macro_client; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-48.0.dev;packages:pkgs/_macro_client;commands:test"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-114.0.dev;packages:pkgs/_macro_client;commands:test"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-48.0.dev;packages:pkgs/_macro_client
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-48.0.dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-114.0.dev;packages:pkgs/_macro_client
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-114.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.6.0-48.0.dev"
+          sdk: "3.6.0-114.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -556,23 +556,23 @@ jobs:
       - job_003
       - job_004
   job_009:
-    name: "unit_test; linux; Dart 3.6.0-48.0.dev; PKG: pkgs/_macro_host; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; linux; Dart 3.6.0-114.0.dev; PKG: pkgs/_macro_host; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-48.0.dev;packages:pkgs/_macro_host;commands:test"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-114.0.dev;packages:pkgs/_macro_host;commands:test"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-48.0.dev;packages:pkgs/_macro_host
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-48.0.dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-114.0.dev;packages:pkgs/_macro_host
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-114.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.6.0-48.0.dev"
+          sdk: "3.6.0-114.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -591,23 +591,23 @@ jobs:
       - job_003
       - job_004
   job_010:
-    name: "unit_test; linux; Dart 3.6.0-48.0.dev; PKG: pkgs/_macro_runner; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; linux; Dart 3.6.0-114.0.dev; PKG: pkgs/_macro_runner; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-48.0.dev;packages:pkgs/_macro_runner;commands:test"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-114.0.dev;packages:pkgs/_macro_runner;commands:test"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-48.0.dev;packages:pkgs/_macro_runner
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-48.0.dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-114.0.dev;packages:pkgs/_macro_runner
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-114.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.6.0-48.0.dev"
+          sdk: "3.6.0-114.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -626,23 +626,23 @@ jobs:
       - job_003
       - job_004
   job_011:
-    name: "unit_test; linux; Dart 3.6.0-48.0.dev; PKG: pkgs/_macro_server; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; linux; Dart 3.6.0-114.0.dev; PKG: pkgs/_macro_server; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-48.0.dev;packages:pkgs/_macro_server;commands:test"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-114.0.dev;packages:pkgs/_macro_server;commands:test"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-48.0.dev;packages:pkgs/_macro_server
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-48.0.dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-114.0.dev;packages:pkgs/_macro_server
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-114.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.6.0-48.0.dev"
+          sdk: "3.6.0-114.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -661,23 +661,23 @@ jobs:
       - job_003
       - job_004
   job_012:
-    name: "unit_test; linux; Dart 3.6.0-48.0.dev; PKG: pkgs/dart_model; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; linux; Dart 3.6.0-114.0.dev; PKG: pkgs/dart_model; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-48.0.dev;packages:pkgs/dart_model;commands:test"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-114.0.dev;packages:pkgs/dart_model;commands:test"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-48.0.dev;packages:pkgs/dart_model
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-48.0.dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-114.0.dev;packages:pkgs/dart_model
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-114.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.6.0-48.0.dev"
+          sdk: "3.6.0-114.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -696,23 +696,23 @@ jobs:
       - job_003
       - job_004
   job_013:
-    name: "unit_test; linux; Dart 3.6.0-48.0.dev; PKG: tool/dart_model_generator; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; linux; Dart 3.6.0-114.0.dev; PKG: tool/dart_model_generator; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-48.0.dev;packages:tool/dart_model_generator;commands:test"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-114.0.dev;packages:tool/dart_model_generator;commands:test"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-48.0.dev;packages:tool/dart_model_generator
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-48.0.dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-114.0.dev;packages:tool/dart_model_generator
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-114.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.6.0-48.0.dev"
+          sdk: "3.6.0-114.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -1011,13 +1011,13 @@ jobs:
       - job_003
       - job_004
   job_022:
-    name: "unit_test; windows; Dart 3.6.0-48.0.dev; PKG: pkgs/_analyzer_macros; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; windows; Dart 3.6.0-114.0.dev; PKG: pkgs/_analyzer_macros; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.6.0-48.0.dev"
+          sdk: "3.6.0-114.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -1036,13 +1036,13 @@ jobs:
       - job_003
       - job_004
   job_023:
-    name: "unit_test; windows; Dart 3.6.0-48.0.dev; PKG: pkgs/_cfe_macros; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; windows; Dart 3.6.0-114.0.dev; PKG: pkgs/_cfe_macros; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.6.0-48.0.dev"
+          sdk: "3.6.0-114.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -1061,13 +1061,13 @@ jobs:
       - job_003
       - job_004
   job_024:
-    name: "unit_test; windows; Dart 3.6.0-48.0.dev; PKG: pkgs/_macro_builder; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; windows; Dart 3.6.0-114.0.dev; PKG: pkgs/_macro_builder; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.6.0-48.0.dev"
+          sdk: "3.6.0-114.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -1086,13 +1086,13 @@ jobs:
       - job_003
       - job_004
   job_025:
-    name: "unit_test; windows; Dart 3.6.0-48.0.dev; PKG: pkgs/_macro_client; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; windows; Dart 3.6.0-114.0.dev; PKG: pkgs/_macro_client; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.6.0-48.0.dev"
+          sdk: "3.6.0-114.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -1111,13 +1111,13 @@ jobs:
       - job_003
       - job_004
   job_026:
-    name: "unit_test; windows; Dart 3.6.0-48.0.dev; PKG: pkgs/_macro_host; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; windows; Dart 3.6.0-114.0.dev; PKG: pkgs/_macro_host; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.6.0-48.0.dev"
+          sdk: "3.6.0-114.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -1136,13 +1136,13 @@ jobs:
       - job_003
       - job_004
   job_027:
-    name: "unit_test; windows; Dart 3.6.0-48.0.dev; PKG: pkgs/_macro_runner; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; windows; Dart 3.6.0-114.0.dev; PKG: pkgs/_macro_runner; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.6.0-48.0.dev"
+          sdk: "3.6.0-114.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -1161,13 +1161,13 @@ jobs:
       - job_003
       - job_004
   job_028:
-    name: "unit_test; windows; Dart 3.6.0-48.0.dev; PKG: pkgs/_macro_server; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; windows; Dart 3.6.0-114.0.dev; PKG: pkgs/_macro_server; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.6.0-48.0.dev"
+          sdk: "3.6.0-114.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -1186,13 +1186,13 @@ jobs:
       - job_003
       - job_004
   job_029:
-    name: "unit_test; windows; Dart 3.6.0-48.0.dev; PKG: pkgs/dart_model; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; windows; Dart 3.6.0-114.0.dev; PKG: pkgs/dart_model; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.6.0-48.0.dev"
+          sdk: "3.6.0-114.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -1211,13 +1211,13 @@ jobs:
       - job_003
       - job_004
   job_030:
-    name: "unit_test; windows; Dart 3.6.0-48.0.dev; PKG: tool/dart_model_generator; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; windows; Dart 3.6.0-114.0.dev; PKG: tool/dart_model_generator; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.6.0-48.0.dev"
+          sdk: "3.6.0-114.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332

--- a/pkgs/_analyzer_macros/pubspec.yaml
+++ b/pkgs/_analyzer_macros/pubspec.yaml
@@ -4,7 +4,7 @@ description: Macro support for the analyzer.
 resolution: workspace
 
 environment:
-  sdk: ^3.6.0-48.0.dev
+  sdk: ^3.6.0-114.0.dev
 
 dev_dependencies:
   analyzer: any

--- a/pkgs/_analyzer_macros/test/package_under_test/pubspec.yaml
+++ b/pkgs/_analyzer_macros/test/package_under_test/pubspec.yaml
@@ -3,7 +3,7 @@ publish-to: none
 resolution: workspace
 
 environment:
-  sdk: ^3.6.0-48.0.dev
+  sdk: ^3.6.0-114.0.dev
 
 dependencies:
   _test_macros: any

--- a/pkgs/_cfe_macros/pubspec.yaml
+++ b/pkgs/_cfe_macros/pubspec.yaml
@@ -4,7 +4,7 @@ description: Macro support for the CFE.
 resolution: workspace
 
 environment:
-  sdk: ^3.6.0-48.0.dev
+  sdk: ^3.6.0-114.0.dev
 
 dev_dependencies:
   dart_flutter_team_lints: ^3.0.0

--- a/pkgs/_cfe_macros/test/package_under_test/pubspec.yaml
+++ b/pkgs/_cfe_macros/test/package_under_test/pubspec.yaml
@@ -3,7 +3,7 @@ publish-to: none
 resolution: workspace
 
 environment:
-  sdk: ^3.6.0-48.0.dev
+  sdk: ^3.6.0-114.0.dev
 
 dependencies:
   _test_macros: any

--- a/pkgs/_macro_builder/pubspec.yaml
+++ b/pkgs/_macro_builder/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/dart-lang/macros/tree/master/pkgs/_macro_builder
 resolution: workspace
 
 environment:
-  sdk: ^3.6.0-48.0.dev
+  sdk: ^3.6.0-114.0.dev
 
 dependencies:
   dart_model: any

--- a/pkgs/_macro_client/pubspec.yaml
+++ b/pkgs/_macro_client/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/dart-lang/macros/tree/master/pkgs/_macro_client
 resolution: workspace
 
 environment:
-  sdk: ^3.6.0-48.0.dev
+  sdk: ^3.6.0-114.0.dev
 
 dependencies:
   dart_model: any

--- a/pkgs/_macro_host/pubspec.yaml
+++ b/pkgs/_macro_host/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/dart-lang/macros/tree/master/pkgs/_macro_host
 resolution: workspace
 
 environment:
-  sdk: ^3.6.0-48.0.dev
+  sdk: ^3.6.0-114.0.dev
 
 dependencies:
   _macro_builder: any

--- a/pkgs/_macro_runner/pubspec.yaml
+++ b/pkgs/_macro_runner/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/dart-lang/macros/tree/master/pkgs/_macro_runner
 resolution: workspace
 
 environment:
-  sdk: ^3.6.0-48.0.dev
+  sdk: ^3.6.0-114.0.dev
 
 dependencies:
   _macro_builder: any

--- a/pkgs/_macro_server/pubspec.yaml
+++ b/pkgs/_macro_server/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/dart-lang/macros/tree/master/pkgs/_macro_server
 resolution: workspace
 
 environment:
-  sdk: ^3.6.0-48.0.dev
+  sdk: ^3.6.0-114.0.dev
 
 dependencies:
   dart_model: any

--- a/pkgs/_test_macros/pubspec.yaml
+++ b/pkgs/_test_macros/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/dart-lang/macros/tree/master/pkgs/_test_macros
 resolution: workspace
 
 environment:
-  sdk: ^3.6.0-48.0.dev
+  sdk: ^3.6.0-114.0.dev
 
 dependencies:
   dart_model: any

--- a/pkgs/dart_model/pubspec.yaml
+++ b/pkgs/dart_model/pubspec.yaml
@@ -8,7 +8,7 @@ repository: https://github.com/dart-lang/macros/tree/master/pkgs/dart_model
 resolution: workspace
 
 environment:
-  sdk: ^3.6.0-48.0.dev
+  sdk: ^3.6.0-114.0.dev
 
 dependencies:
   collection: ^1.19.0

--- a/pkgs/macro/pubspec.yaml
+++ b/pkgs/macro/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/dart-lang/macros/tree/master/pkgs/macro
 resolution: workspace
 
 environment:
-  sdk: ^3.6.0-48.0.dev
+  sdk: ^3.6.0-114.0.dev
 
 dependencies:
   collection: ^1.19.0

--- a/pkgs/macro_service/pubspec.yaml
+++ b/pkgs/macro_service/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/dart-lang/macros/tree/master/pkgs/macro_service
 resolution: workspace
 
 environment:
-  sdk: ^3.6.0-48.0.dev
+  sdk: ^3.6.0-114.0.dev
 
 dependencies:
   dart_model: any

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: macros_workspace
 environment:
-  sdk: ^3.6.0-48.0.dev
+  sdk: ^3.6.0-114.0.dev
 dev_dependencies:
   dart_flutter_team_lints: ^3.1.0
 publish_to: none
@@ -26,109 +26,109 @@ dependency_overrides:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/_fe_analyzer_shared
-      ref: 9664f0da3547ccd92cf56d2bf362e333edfefd92
+      ref: 3.6.0-114.0.dev
   _js_interop_checks:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/_js_interop_checks
-      ref: 9664f0da3547ccd92cf56d2bf362e333edfefd92
+      ref: 3.6.0-114.0.dev
   _macros:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/_macros
-      ref: 9664f0da3547ccd92cf56d2bf362e333edfefd92
+      ref: 3.6.0-114.0.dev
   analyzer:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/analyzer
-      ref: 9664f0da3547ccd92cf56d2bf362e333edfefd92
+      ref: 3.6.0-114.0.dev
   analyzer_utilities:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/analyzer_utilities
-      ref: 9664f0da3547ccd92cf56d2bf362e333edfefd92
+      ref: 3.6.0-114.0.dev
   build_integration:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/build_integration
-      ref: 9664f0da3547ccd92cf56d2bf362e333edfefd92
+      ref: 3.6.0-114.0.dev
   compiler:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/compiler
-      ref: 9664f0da3547ccd92cf56d2bf362e333edfefd92
+      ref: 3.6.0-114.0.dev
   dart2js_info:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/dart2js_info
-      ref: 9664f0da3547ccd92cf56d2bf362e333edfefd92
+      ref: 3.6.0-114.0.dev
   dart2wasm:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/dart2wasm
-      ref: 9664f0da3547ccd92cf56d2bf362e333edfefd92
+      ref: 3.6.0-114.0.dev
   dev_compiler:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/dev_compiler
-      ref: 9664f0da3547ccd92cf56d2bf362e333edfefd92
+      ref: 3.6.0-114.0.dev
   front_end:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/front_end
-      ref: 9664f0da3547ccd92cf56d2bf362e333edfefd92
+      ref: 3.6.0-114.0.dev
   frontend_server:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/frontend_server
-      ref: 9664f0da3547ccd92cf56d2bf362e333edfefd92
+      ref: 3.6.0-114.0.dev
   heap_snapshot:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/heap_snapshot
-      ref: 9664f0da3547ccd92cf56d2bf362e333edfefd92
+      ref: 3.6.0-114.0.dev
   js_ast:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/js_ast
-      ref: 9664f0da3547ccd92cf56d2bf362e333edfefd92
+      ref: 3.6.0-114.0.dev
   js_runtime:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/js_runtime
-      ref: 9664f0da3547ccd92cf56d2bf362e333edfefd92
+      ref: 3.6.0-114.0.dev
   js_shared:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/js_shared
-      ref: 9664f0da3547ccd92cf56d2bf362e333edfefd92
+      ref: 3.6.0-114.0.dev
   kernel:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/kernel
-      ref: 9664f0da3547ccd92cf56d2bf362e333edfefd92
+      ref: 3.6.0-114.0.dev
   linter:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/linter
-      ref: 9664f0da3547ccd92cf56d2bf362e333edfefd92
+      ref: 3.6.0-114.0.dev
   mmap:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/mmap
-      ref: 9664f0da3547ccd92cf56d2bf362e333edfefd92
+      ref: 3.6.0-114.0.dev
   vm:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/vm
-      ref: 9664f0da3547ccd92cf56d2bf362e333edfefd92
+      ref: 3.6.0-114.0.dev
   vm_service:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/vm_service
-      ref: 9664f0da3547ccd92cf56d2bf362e333edfefd92
+      ref: 3.6.0-114.0.dev
   wasm_builder:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/wasm_builder
-      ref: 9664f0da3547ccd92cf56d2bf362e333edfefd92
+      ref: 3.6.0-114.0.dev

--- a/tool/dart_model_generator/pubspec.yaml
+++ b/tool/dart_model_generator/pubspec.yaml
@@ -2,7 +2,7 @@ name: generate_dart_model
 publish-to: none
 resolution: workspace
 environment:
-  sdk: ^3.6.0-48.0.dev
+  sdk: ^3.6.0-114.0.dev
 
 dependencies:
   dart_model: any

--- a/tool/set_sdk_ref
+++ b/tool/set_sdk_ref
@@ -1,13 +1,21 @@
 #!/bin/bash --
 #
 # Updates ref to SDK packages in pubspec.yaml.
+#
+# If it's a dev tag, also updates SDK version.
 
 REF=$1
 
-if echo $REF | grep -Eqv '^[a-z0-9][a-z0-9-]*$'; then
-  echo "Doesn't look like a git ref? $REF"
-  echo "Usage: tool/set_sdk_version <git ref>"
-  exit 1
+if echo $REF | grep -Eq 'dev$'; then
+  sed -i -e "s#^  sdk: .*#  sdk: ^$REF#" $(find . -name pubspec.yaml)
+else
+  if echo $REF | grep -Eqv '^[a-z0-9][a-z0-9-]*$'; then
+    echo "Doesn't look like a git ref? $REF"
+    echo "Usage: tool/set_sdk_version <git ref>"
+    exit 1
+  fi
+
+  echo "Got a ref, not a dev tag: updating deps but not SDK version."
 fi
 
 sed -i -e "s#^      ref: .*#      ref: $REF#" pubspec.yaml


### PR DESCRIPTION
If we want bleeding edge SDK we'll need to use a ref, but usually we can be on a dev version which means deps-from-the-SDK and SDK are at the same version.