### PR TITLE
Placeholder package config reader.

### DIFF
--- a/pkgs/_analyzer_macros/test/analyzer_test.dart
+++ b/pkgs/_analyzer_macros/test/analyzer_test.dart
@@ -24,12 +24,7 @@ void main() {
           AnalysisContextCollection(includedPaths: [directory.path]);
       analysisContext = contextCollection.contexts.first;
       injected.macroImplementation = await AnalyzerMacroImplementation.start(
-          packageConfig: Isolate.packageConfigSync!,
-          macroImplByName: {
-            'package:_test_macros/declare_x_macro.dart#DeclareX':
-                'package:_test_macros/declare_x_macro.dart'
-                    '#DeclareXImplementation'
-          });
+          packageConfig: Isolate.packageConfigSync!);
     });
 
     test('discovers macros, runs them, applies augmentations', () async {

--- a/pkgs/_cfe_macros/test/cfe_test.dart
+++ b/pkgs/_cfe_macros/test/cfe_test.dart
@@ -29,20 +29,8 @@ void main() {
       tempDir = Directory.systemTemp.createTempSync('cfe_test');
 
       // Inject test macro implementation.
-      // TODO(davidmorgan): the CFE passes us a mix of absolute file paths and
-      // package URIs, fix this properly.
-      final macroFileUri = Directory.current.uri
-          .resolve('../_test_macros/lib/declare_x_macro.dart');
       injected.macroImplementation = await CfeMacroImplementation.start(
-          packageConfig: Isolate.packageConfigSync!,
-          macroImplByName: {
-            '$macroFileUri#DeclareX':
-                'package:_test_macros/declare_x_macro.dart'
-                    '#DeclareXImplementation',
-            'package:_test_macros/declare_x_macro.dart#DeclareX':
-                'package:_test_macros/declare_x_macro.dart'
-                    '#DeclareXImplementation'
-          });
+          packageConfig: Isolate.packageConfigSync!);
     });
 
     test('discovers macros, runs them, applies augmentations', () async {

--- a/pkgs/_macro_host/lib/src/package_config.dart
+++ b/pkgs/_macro_host/lib/src/package_config.dart
@@ -1,0 +1,79 @@
+// Copyright (c) 2024, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:dart_model/dart_model.dart';
+import 'package:package_config/package_config.dart';
+
+/// Reads a package config to determine information about macros.
+class MacroPackageConfig {
+  final PackageConfig packageConfig;
+
+  MacroPackageConfig({required this.packageConfig});
+
+  factory MacroPackageConfig.readUri(Uri uri) => MacroPackageConfig(
+      packageConfig:
+          PackageConfig.parseBytes(File.fromUri(uri).readAsBytesSync(), uri));
+
+  /// Checks whether [name] is a macro annotation.
+  ///
+  /// If so, returns the qualified name of the macro implementation.
+  ///
+  /// If not, returns `null`.
+  ///
+  /// This is a placeholder implementation until `language/3728` is
+  /// implemented. It expects macros to be marked by a comment in the
+  /// annotation package `pubspec.yaml` that looks like this:
+  ///
+  /// ```
+  /// # macro <annotation name> <implementation name>
+  /// ```
+  ///
+  /// For example:
+  ///
+  /// ```
+  /// # macro lib/declare_x_macro.dart#DeclareX package:_test_macros/declare_x_macro.dart#DeclareXImplementation
+  /// ```
+  QualifiedName? lookupMacroImplementation(QualifiedName name) {
+    var packageName = name.uri;
+    if (packageName.startsWith('package:') && packageName.contains('/')) {
+      packageName = packageName.substring('package:'.length);
+      packageName = packageName.substring(0, packageName.indexOf('/'));
+    } else {
+      // TODO(davidmorgan): support macros outside lib dirs.
+      throw ArgumentError('Name must start "package:" and have a path: $name');
+    }
+    final libraryPath =
+        'lib/${name.string.substring(name.uri.indexOf('/') + 1)}';
+
+    final matchingPackage = packageConfig.packages
+        .where((p) => p.name == packageName)
+        .toList()
+        .singleOrNull;
+
+    if (matchingPackage == null) {
+      throw StateError('Package "$packageName" not found in package config.');
+    }
+
+    // TODO(language/3728): read macro annotation identifiers from package
+    // config. Until then, check the pubsec, to simulate what that feature will
+    // do.
+    final packageUri = matchingPackage.root;
+    final pubspecUri = packageUri.resolve('pubspec.yaml');
+    final lines = File.fromUri(pubspecUri).readAsLinesSync();
+
+    final implsByLibraryQualifiedName = <String, String>{};
+    for (final line in lines) {
+      if (!line.startsWith('# macro ')) continue;
+      final items = line.split(' ');
+      // The rest of the line should be the library qualified name of the
+      // annotation then the fully qualified name of the implementation.
+      implsByLibraryQualifiedName[items[2]] = items[3];
+    }
+
+    final result = implsByLibraryQualifiedName[libraryPath];
+    return result == null ? null : QualifiedName(result);
+  }
+}

--- a/pkgs/_macro_host/pubspec.yaml
+++ b/pkgs/_macro_host/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   _macro_server: any
   dart_model: any
   macro_service: any
+  package_config: ^2.1.0
 
 dev_dependencies:
   _test_macros: any

--- a/pkgs/_macro_host/test/macro_host_test.dart
+++ b/pkgs/_macro_host/test/macro_host_test.dart
@@ -19,12 +19,12 @@ void main() {
 
       final queryService = TestQueryService();
       final host = await MacroHost.serve(
-          macroImplByName: {macroName.string: macroImplementation.string},
+          packageConfig: Isolate.packageConfigSync!,
           queryService: queryService);
 
       final packageConfig = Isolate.packageConfigSync!;
 
-      expect(host.isMacro(packageConfig, macroName), true);
+      expect(host.isMacro(macroName), true);
       expect(
           await host.queryMacroPhases(packageConfig, macroImplementation), {2});
 
@@ -42,12 +42,12 @@ void main() {
 
       final queryService = TestQueryService();
       final host = await MacroHost.serve(
-          macroImplByName: {macroName.string: macroImplementation.string},
+          packageConfig: Isolate.packageConfigSync!,
           queryService: queryService);
 
       final packageConfig = Isolate.packageConfigSync!;
 
-      expect(host.isMacro(packageConfig, macroName), true);
+      expect(host.isMacro(macroName), true);
       expect(
           await host.queryMacroPhases(packageConfig, macroImplementation), {3});
 

--- a/pkgs/_macro_host/test/package_config_test.dart
+++ b/pkgs/_macro_host/test/package_config_test.dart
@@ -1,0 +1,25 @@
+// Copyright (c) 2024, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:isolate';
+
+import 'package:_macro_host/src/package_config.dart';
+import 'package:dart_model/dart_model.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group(MacroPackageConfig, () {
+    test('can look up macro implementations', () async {
+      final packageConfig =
+          MacroPackageConfig.readUri(Isolate.packageConfigSync!);
+
+      expect(
+          packageConfig
+              .lookupMacroImplementation(QualifiedName(
+                  'package:_test_macros/declare_x_macro.dart#DeclareX'))!
+              .string,
+          'package:_test_macros/declare_x_macro.dart#DeclareXImplementation');
+    });
+  });
+}

--- a/pkgs/_macro_host/test/package_config_test.dart
+++ b/pkgs/_macro_host/test/package_config_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
 import 'dart:isolate';
 
 import 'package:_macro_host/src/package_config.dart';
@@ -10,14 +11,29 @@ import 'package:test/test.dart';
 
 void main() {
   group(MacroPackageConfig, () {
-    test('can look up macro implementations', () async {
+    test('can look up macro implementations from package URIs', () async {
       final packageConfig =
-          MacroPackageConfig.readUri(Isolate.packageConfigSync!);
+          MacroPackageConfig.readFromUri(Isolate.packageConfigSync!);
 
       expect(
           packageConfig
               .lookupMacroImplementation(QualifiedName(
                   'package:_test_macros/declare_x_macro.dart#DeclareX'))!
+              .string,
+          'package:_test_macros/declare_x_macro.dart#DeclareXImplementation');
+    });
+
+    test('can look up macro implementations from file URIs', () async {
+      final packageConfig =
+          MacroPackageConfig.readFromUri(Isolate.packageConfigSync!);
+
+      final sourceFileUri = Directory.current.uri
+          .resolve('../_test_macros/lib/declare_x_macro.dart');
+
+      expect(
+          packageConfig
+              .lookupMacroImplementation(
+                  QualifiedName('$sourceFileUri#DeclareX'))!
               .string,
           'package:_test_macros/declare_x_macro.dart#DeclareXImplementation');
     });

--- a/pkgs/_test_macros/pubspec.yaml
+++ b/pkgs/_test_macros/pubspec.yaml
@@ -16,3 +16,7 @@ dependencies:
 dev_dependencies:
   dart_flutter_team_lints: ^3.0.0
   test: ^1.25.0
+
+# TODO(language/3728): use the real feature when there is one.
+# macro lib/declare_x_macro.dart#DeclareX package:_test_macros/declare_x_macro.dart#DeclareXImplementation
+# macro lib/query_class.dart#QueryClass package:_test_macros/query_class.dart#QueryClassImplementation


### PR DESCRIPTION
So we can identify macros based on pubspecs while we wait for that to be implemented properly.

Not used yet as that would overlap with other pending PRs, but it should be easy to plug in afterwards.