### PR TITLE
Support string and null as schema representation

### DIFF
--- a/pkgs/dart_model/lib/src/dart_model.g.dart
+++ b/pkgs/dart_model/lib/src/dart_model.g.dart
@@ -90,7 +90,7 @@ extension type NeverType.fromJson(Null _) {
   NeverType() : this.fromJson(null);
 }
 
-/// A Dart type of the form `T?` for an inner type `T`
+/// A Dart type of the form `T?` for an inner type `T`.
 extension type NullableType.fromJson(Map<String, Object?> node) {
   NullableType({
     StaticType? inner,

--- a/pkgs/dart_model/lib/src/dart_model.g.dart
+++ b/pkgs/dart_model/lib/src/dart_model.g.dart
@@ -85,6 +85,21 @@ extension type Model.fromJson(Map<String, Object?> node) {
   Map<String, Library> get uris => (node['uris'] as Map).cast();
 }
 
+/// Representation of the bottom type [Never].
+extension type NeverType.fromJson(Null _) {
+  NeverType() : this.fromJson(null);
+}
+
+/// A Dart type of the form `T?` for an inner type `T`
+extension type NullableType.fromJson(Map<String, Object?> node) {
+  NullableType({
+    StaticType? inner,
+  }) : this.fromJson({
+          if (inner != null) 'inner': inner,
+        });
+  StaticType get inner => node['inner'] as StaticType;
+}
+
 /// Set of boolean properties.
 extension type Properties.fromJson(Map<String, Object?> node) {
   Properties({
@@ -130,4 +145,58 @@ extension type QualifiedName.fromJson(String string) {
 /// Query about a corpus of Dart source code. TODO(davidmorgan): this is a placeholder.
 extension type Query.fromJson(Map<String, Object?> node) {
   Query() : this.fromJson({});
+}
+
+enum StaticTypeType {
+  unknown,
+  neverType,
+  nullableType,
+  voidType;
+}
+
+extension type StaticType.fromJson(Map<String, Object?> node) {
+  static StaticType neverType(NeverType neverType) =>
+      StaticType.fromJson({'type': 'NeverType', 'value': null});
+  static StaticType nullableType(NullableType nullableType) =>
+      StaticType.fromJson({'type': 'NullableType', 'value': nullableType.node});
+  static StaticType voidType(VoidType voidType) =>
+      StaticType.fromJson({'type': 'VoidType', 'value': voidType.string});
+  StaticTypeType get type {
+    switch (node['type'] as String) {
+      case 'NeverType':
+        return StaticTypeType.neverType;
+      case 'NullableType':
+        return StaticTypeType.nullableType;
+      case 'VoidType':
+        return StaticTypeType.voidType;
+      default:
+        return StaticTypeType.unknown;
+    }
+  }
+
+  NeverType get asNeverType {
+    if (node['type'] != 'NeverType') {
+      throw StateError('Not a NeverType.');
+    }
+    return NeverType.fromJson(node['value'] as Null);
+  }
+
+  NullableType get asNullableType {
+    if (node['type'] != 'NullableType') {
+      throw StateError('Not a NullableType.');
+    }
+    return NullableType.fromJson(node['value'] as Map<String, Object?>);
+  }
+
+  VoidType get asVoidType {
+    if (node['type'] != 'VoidType') {
+      throw StateError('Not a VoidType.');
+    }
+    return VoidType.fromJson(node['value'] as String);
+  }
+}
+
+/// The type-hierarchy representation of the type `void`.
+extension type VoidType.fromJson(String string) {
+  VoidType(String string) : this.fromJson(string);
 }

--- a/schemas/dart_model.schema.json
+++ b/schemas/dart_model.schema.json
@@ -139,11 +139,18 @@
     },
     "StaticType": {
       "description": "A resolved type as it appears in Dart's type hierarchy.",
-      "oneOf": [
-        {"$ref": "#/$defs/NeverType"},
-        {"$ref": "#/$defs/NullableType"},
-        {"$ref": "#/$defs/VoidType"}
-      ]
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "value": {
+          "oneOf": [
+            {"$ref": "#/$defs/NeverType"},
+            {"$ref": "#/$defs/NullableType"},
+            {"$ref": "#/$defs/VoidType"}
+          ]
+        }
+      }
     },
     "VoidType": {
       "description": "The type-hierarchy representation of the type `void`.",

--- a/schemas/dart_model.schema.json
+++ b/schemas/dart_model.schema.json
@@ -92,7 +92,7 @@
     },
     "NullableType": {
       "type": "object",
-      "description": "A Dart type of the form `T?` for an inner type `T`",
+      "description": "A Dart type of the form `T?` for an inner type `T`.",
       "properties": {
         "inner": {
           "$ref": "#/$defs/StaticType"

--- a/schemas/dart_model.schema.json
+++ b/schemas/dart_model.schema.json
@@ -86,6 +86,19 @@
         }
       }
     },
+    "NeverType": {
+      "type": "null",
+      "description": "Representation of the bottom type [Never]."
+    },
+    "NullableType": {
+      "type": "object",
+      "description": "A Dart type of the form `T?` for an inner type `T`",
+      "properties": {
+        "inner": {
+          "$ref": "#/$defs/StaticType"
+        }
+      }
+    },
     "Properties": {
       "type": "object",
       "description": "Set of boolean properties.",
@@ -123,6 +136,18 @@
     "Query": {
       "type": "object",
       "description": "Query about a corpus of Dart source code. TODO(davidmorgan): this is a placeholder."
+    },
+    "StaticType": {
+      "description": "A resolved type as it appears in Dart's type hierarchy.",
+      "oneOf": [
+        {"$ref": "#/$defs/NeverType"},
+        {"$ref": "#/$defs/NullableType"},
+        {"$ref": "#/$defs/VoidType"}
+      ]
+    },
+    "VoidType": {
+      "description": "The type-hierarchy representation of the type `void`.",
+      "type": "string"
     }
   }
 }

--- a/tool/dart_model_generator/lib/generate_dart_model.dart
+++ b/tool/dart_model_generator/lib/generate_dart_model.dart
@@ -57,7 +57,7 @@ String generate(String schemaJson,
 
 /// The Dart type used to represent the JSON value for [definition].
 ///
-/// This is most commonly a `Map<String, Object?>, but can also be a JSON
+/// This is most commonly a `Map<String, Object?>`, but can also be a JSON
 /// primitive type for simpler definitions.
 String _dartJsonType(JsonSchema definition) {
   return switch (definition.type) {


### PR DESCRIPTION
In addition to `"type": "object"`, it looks like the schema generator partially supports using `"type": "string"` for definitions. Those definitions are broken in unions though, as the generator for unions expects all definitions to be JSON.
This PR fixes that, and also adds support for `"type": "null"` definitions. Those are useful as part of unions if we only care about the element type. To model Dart's type hierarchy for instance, we may have an `union StaticType = InterfaceType {...} | NullableType { StaticType inner } | ... | DynamicType`. There is nothing interesting about `DynamicType` apart from knowing that we're dealing with `dynamic`, so `null` makes sense as the underlying JSON representation here.