### PR TITLE
Make union type "unknown" private to force use of default.

### DIFF
--- a/pkgs/_macro_client/lib/macro_client.dart
+++ b/pkgs/_macro_client/lib/macro_client.dart
@@ -71,16 +71,10 @@ class MacroClient {
       // part of the protocol+code, update implementation here and below.
     }
     final response = Response.fromJson(jsonData);
-    switch (response.type) {
-      case ResponseType.unknown:
-        // Ignore unknown response.
-        break;
-      default:
-        // TODO(davidmorgan): track requests and responses properly.
-        if (_responseCompleter != null) {
-          _responseCompleter!.complete(response);
-          _responseCompleter = null;
-        }
+    // TODO(davidmorgan): track requests and responses properly.
+    if (_responseCompleter != null) {
+      _responseCompleter!.complete(response);
+      _responseCompleter = null;
     }
   }
 }

--- a/pkgs/_macro_server/lib/macro_server.dart
+++ b/pkgs/_macro_server/lib/macro_server.dart
@@ -51,13 +51,13 @@ class MacroServer {
         .forEach((line) {
       final jsonData = json.decode(line) as Map<String, Object?>;
       final request = MacroRequest.fromJson(jsonData);
-      if (request.type != MacroRequestType.unknown) {
+      if (request.type.isKnown) {
         service
             .handle(request)
             .then((response) => socket.writeln(json.encode(response!.node)));
       }
       final response = Response.fromJson(jsonData);
-      if (response.type != ResponseType.unknown) {
+      if (response.type.isKnown) {
         _responseCompleter!.complete(response);
         _responseCompleter = null;
       }

--- a/pkgs/dart_model/lib/src/dart_model.g.dart
+++ b/pkgs/dart_model/lib/src/dart_model.g.dart
@@ -148,10 +148,13 @@ extension type Query.fromJson(Map<String, Object?> node) {
 }
 
 enum StaticTypeType {
-  unknown,
+  // Private so switches must have a default. See `isKnown`.
+  _unknown,
   neverType,
   nullableType,
   voidType;
+
+  bool get isKnown => this != _unknown;
 }
 
 extension type StaticType.fromJson(Map<String, Object?> node) {
@@ -170,7 +173,7 @@ extension type StaticType.fromJson(Map<String, Object?> node) {
       case 'VoidType':
         return StaticTypeType.voidType;
       default:
-        return StaticTypeType.unknown;
+        return StaticTypeType._unknown;
     }
   }
 

--- a/pkgs/macro_service/lib/src/macro_service.g.dart
+++ b/pkgs/macro_service/lib/src/macro_service.g.dart
@@ -53,8 +53,11 @@ extension type HostEndpoint.fromJson(Map<String, Object?> node) {
 }
 
 enum HostRequestType {
-  unknown,
+  // Private so switches must have a default. See `isKnown`.
+  _unknown,
   augmentRequest;
+
+  bool get isKnown => this != _unknown;
 }
 
 extension type HostRequest.fromJson(Map<String, Object?> node) {
@@ -66,7 +69,7 @@ extension type HostRequest.fromJson(Map<String, Object?> node) {
       case 'AugmentRequest':
         return HostRequestType.augmentRequest;
       default:
-        return HostRequestType.unknown;
+        return HostRequestType._unknown;
     }
   }
 
@@ -107,9 +110,12 @@ extension type MacroStartedResponse.fromJson(Map<String, Object?> node) {
 }
 
 enum MacroRequestType {
-  unknown,
+  // Private so switches must have a default. See `isKnown`.
+  _unknown,
   macroStartedRequest,
   queryRequest;
+
+  bool get isKnown => this != _unknown;
 }
 
 extension type MacroRequest.fromJson(Map<String, Object?> node) {
@@ -127,7 +133,7 @@ extension type MacroRequest.fromJson(Map<String, Object?> node) {
       case 'QueryRequest':
         return MacroRequestType.queryRequest;
       default:
-        return MacroRequestType.unknown;
+        return MacroRequestType._unknown;
     }
   }
 
@@ -167,11 +173,14 @@ extension type QueryResponse.fromJson(Map<String, Object?> node) {
 }
 
 enum ResponseType {
-  unknown,
+  // Private so switches must have a default. See `isKnown`.
+  _unknown,
   augmentResponse,
   errorResponse,
   macroStartedResponse,
   queryResponse;
+
+  bool get isKnown => this != _unknown;
 }
 
 extension type Response.fromJson(Map<String, Object?> node) {
@@ -197,7 +206,7 @@ extension type Response.fromJson(Map<String, Object?> node) {
       case 'QueryResponse':
         return ResponseType.queryResponse;
       default:
-        return ResponseType.unknown;
+        return ResponseType._unknown;
     }
   }
 

--- a/tool/dart_model_generator/lib/generate_dart_model.dart
+++ b/tool/dart_model_generator/lib/generate_dart_model.dart
@@ -198,10 +198,12 @@ String _generateUnion(
   // TODO(davidmorgan): add description(s).
   result
     ..writeln('enum ${name}Type {')
-    ..writeln(['unknown']
-        .followedBy(unionEntries.map((e) => _firstToLowerCase(e.$1)))
-        .join(', '))
-    ..writeln(';}');
+    ..writeln('  // Private so switches must have a default. See `isKnown`.')
+    ..writeln('_unknown,')
+    ..write(unionEntries.map((e) => _firstToLowerCase(e.$1)).join(', '))
+    ..writeln(';')
+    ..writeln('bool get isKnown => this != _unknown;')
+    ..writeln('}');
 
   // TODO(davidmorgan): add description.
   result.writeln('extension type $name.fromJson(Map<String, Object?> node) {');
@@ -222,7 +224,7 @@ String _generateUnion(
     result.writeln("case '$type': return ${name}Type.$lowerType;");
   }
   result
-    ..writeln('default: return ${name}Type.unknown;')
+    ..writeln('default: return ${name}Type._unknown;')
     ..writeln('}')
     ..writeln('}');
 


### PR DESCRIPTION
This stops people from writing switch statements over union types that will break at compile time when we add a type to a union.

Fix #24 