### PR TITLE
First query via the CFE.

### DIFF
--- a/pkgs/_analyzer_macros/lib/query_service.dart
+++ b/pkgs/_analyzer_macros/lib/query_service.dart
@@ -5,10 +5,8 @@
 import 'package:_macro_host/macro_host.dart';
 // ignore: implementation_imports
 import 'package:analyzer/src/summary2/linked_element_factory.dart' as analyzer;
-// ignore: implementation_imports
 import 'package:dart_model/dart_model.dart';
 import 'package:macro_service/macro_service.dart';
-// ignore: implementation_imports
 
 // Hack to access analyzer internals via the introspector that's available.
 // TODO(davidmorgan): handle lifecycle, are these equivalent, do they need

--- a/pkgs/_cfe_macros/lib/query_service.dart
+++ b/pkgs/_cfe_macros/lib/query_service.dart
@@ -1,0 +1,50 @@
+// Copyright (c) 2024, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:_macro_host/macro_host.dart';
+import 'package:dart_model/dart_model.dart';
+import 'package:macro_service/macro_service.dart';
+import 'package:macros/macros.dart' hide Library;
+
+// TODO(davidmorgan): using this type requires going via `package:macros`
+// types, add a hook so we can go directly to underlying `MacroIntrospection`.
+DeclarationPhaseIntrospector? introspector;
+
+class CfeQueryService implements QueryService {
+  @override
+  Future<QueryResponse> handle(QueryRequest request) async {
+    return QueryResponse(
+        model: await _evaluateClassQuery(request.query.target));
+  }
+
+  Future<Model> _evaluateClassQuery(QualifiedName target) async {
+    final uri = target.uri;
+    final identifier = await introspector!
+        // ignore: deprecated_member_use
+        .resolveIdentifier(Uri.parse(target.uri), target.name);
+    final declaration = await introspector!.typeDeclarationOf(identifier);
+    final fields = await introspector!.fieldsOf(declaration);
+    return Model(
+      uris: {
+        uri: Library(
+          scopes: {
+            target.name: Interface(members: {
+              // TODO(davidmorgan): return more than just fields.
+              // TODO(davidmorgan): specify in the query what to return.
+              for (final field in fields)
+                field.identifier.name: Member(
+                    properties: Properties(
+                  isAbstract: field.hasAbstract,
+                  isGetter: false,
+                  isField: true,
+                  isMethod: false,
+                  isStatic: field.hasStatic,
+                )),
+            })
+          },
+        ),
+      },
+    );
+  }
+}

--- a/pkgs/_cfe_macros/test/cfe_test.dart
+++ b/pkgs/_cfe_macros/test/cfe_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:convert';
 import 'dart:io';
 import 'dart:isolate';
 
@@ -55,6 +56,67 @@ void main() {
       // The source has a main method that uses the new declaration, so the
       // compile can only succeed if it was added by the macro.
       expect(computeKernelResult.succeeded, true);
+    });
+
+    test('discovers macros, runs them, responds to queries', () async {
+      final packagesUri = Isolate.packageConfigSync;
+      final sourceFile =
+          File('test/package_under_test/lib/apply_query_class.dart');
+      final outputFile = File('${tempDir.path}/out2.dill');
+
+      final computeKernelResult = await computeKernel([
+        '--enable-experiment=macros',
+        '--no-summary',
+        '--no-summary-only',
+        '--target=vm',
+        '--dart-sdk-summary=${productPlatformDill.uri}',
+        '--output=${outputFile.path}',
+        '--source=${sourceFile.uri}',
+        '--packages-file=$packagesUri',
+        // TODO(davidmorgan): this is so we can pull the generated augmentation
+        // source out of incremental compiler state; find a less hacky way.
+        '--use-incremental-compiler',
+        // For augmentations.
+        '--enable-experiment=macros',
+      ]);
+
+      // The source has a main method that uses the new declaration, so the
+      // compile can only succeed if it was added by the macro.
+      expect(computeKernelResult.succeeded, true);
+
+      final sources = computeKernelResult
+          .previousState!.incrementalCompiler!.context.uriToSource;
+      final macroSource = sources.entries
+          .singleWhere((e) => e.key.scheme == 'dart-macro+file')
+          .value;
+
+      // The macro outputs an augmentation with the query results in a comment;
+      // find it and assert on that.
+      final macroOutput = macroSource.text
+          .split('\n')
+          .singleWhere((l) => l.startsWith('// '))
+          .substring('// '.length);
+      expect(json.decode(macroOutput), {
+        'uris': {
+          'package:package_under_test_cfe/apply_query_class.dart': {
+            'scopes': {
+              'ClassWithMacroApplied': {
+                'members': {
+                  'x': {
+                    'properties': {
+                      'isAbstract': true,
+                      'isGetter': false,
+                      'isField': true,
+                      'isMethod': false,
+                      'isStatic': false
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      });
     });
   });
 }

--- a/pkgs/_cfe_macros/test/package_under_test/lib/apply_query_class.dart
+++ b/pkgs/_cfe_macros/test/package_under_test/lib/apply_query_class.dart
@@ -1,0 +1,10 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:_test_macros/query_class.dart';
+
+@QueryClass()
+abstract class ClassWithMacroApplied {
+  abstract final int x;
+}


### PR DESCRIPTION
This PR ends up using the introspector interface rather than digging into internals like the analyzer PR does, because the internals are not available; I think it needs a PR on the CFE side first.