### PR TITLE
Add golden tests for introspection.

### DIFF
--- a/introspection_goldens/foo/analysis_options.yaml
+++ b/introspection_goldens/foo/analysis_options.yaml
@@ -1,0 +1,3 @@
+analyzer:
+  enable-experiment:
+    - macros

--- a/introspection_goldens/foo/lib/foo.dart
+++ b/introspection_goldens/foo/lib/foo.dart
@@ -1,0 +1,15 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:_test_macros/query_class.dart';
+
+@QueryClass()
+class Foo {
+  final int bar = 3;
+}
+
+@QueryClass()
+class Bar {
+  final int bar = 4;
+}

--- a/introspection_goldens/foo/lib/foo.json
+++ b/introspection_goldens/foo/lib/foo.json
@@ -1,0 +1,34 @@
+{
+  "uris": {
+    "package:foo/foo.dart": {
+      "scopes": {
+        "Foo": {
+          "members": {
+            "bar": {
+              "properties": {
+                "isAbstract": false,
+                "isGetter": false,
+                "isField": true,
+                "isMethod": false,
+                "isStatic": false
+              }
+            }
+          }
+        },
+        "Bar": {
+          "members": {
+            "bar": {
+              "properties": {
+                "isAbstract": false,
+                "isGetter": false,
+                "isField": true,
+                "isMethod": false,
+                "isStatic": false
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/introspection_goldens/foo/pubspec.yaml
+++ b/introspection_goldens/foo/pubspec.yaml
@@ -1,0 +1,9 @@
+name: foo
+publish-to: none
+resolution: workspace
+
+environment:
+  sdk: ^3.6.0-114.0.dev
+
+dependencies:
+  _test_macros: any

--- a/pkgs/_analyzer_macros/pubspec.yaml
+++ b/pkgs/_analyzer_macros/pubspec.yaml
@@ -15,4 +15,5 @@ dependencies:
 
 dev_dependencies:
   dart_flutter_team_lints: ^3.0.0
+  path: ^1.9.0
   test: ^1.25.0

--- a/pkgs/_analyzer_macros/test/analyzer_test.dart
+++ b/pkgs/_analyzer_macros/test/analyzer_test.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:convert';
 import 'dart:io';
 import 'dart:isolate';
 
@@ -46,50 +45,6 @@ void main() {
       expect(clazz.fields, isEmpty);
       expect(clazz.augmented.fields, isNotEmpty);
       expect(clazz.augmented.fields.single.name, 'x');
-    });
-
-    test('discovers macros, runs them, responds to queries', () async {
-      final path = File.fromUri(
-              Uri.parse('./test/package_under_test/lib/apply_query_class.dart'))
-          .absolute
-          .path;
-
-      // No analysis errors.
-      final errors =
-          await analysisContext.currentSession.getErrors(path) as ErrorsResult;
-      expect(errors.errors, isEmpty);
-
-      // The macro outputs an augmentation with the query results in a comment;
-      // find it and assert on that.
-      final resolvedLibrary = (await analysisContext.currentSession
-          .getResolvedLibrary(path)) as ResolvedLibraryResult;
-      final augmentationUnit =
-          resolvedLibrary.units.singleWhere((u) => u.isMacroAugmentation);
-      final macroOutput = augmentationUnit.content
-          .split('\n')
-          .singleWhere((l) => l.startsWith('// '))
-          .substring('// '.length);
-      expect(json.decode(macroOutput), {
-        'uris': {
-          'package:package_under_test_analyzer/apply_query_class.dart': {
-            'scopes': {
-              'ClassWithMacroApplied': {
-                'members': {
-                  'x': {
-                    'properties': {
-                      'isAbstract': true,
-                      'isGetter': false,
-                      'isField': true,
-                      'isMethod': false,
-                      'isStatic': false
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      });
     });
   });
 }

--- a/pkgs/_analyzer_macros/test/golden_test.dart
+++ b/pkgs/_analyzer_macros/test/golden_test.dart
@@ -1,0 +1,107 @@
+// Copyright (c) 2024, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:io';
+import 'dart:isolate';
+
+import 'package:_analyzer_macros/macro_implementation.dart';
+import 'package:analyzer/dart/analysis/analysis_context.dart';
+import 'package:analyzer/dart/analysis/analysis_context_collection.dart';
+import 'package:analyzer/dart/analysis/results.dart';
+import 'package:analyzer/src/summary2/macro_injected_impl.dart' as injected;
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+void main() {
+  late AnalysisContext analysisContext;
+
+  group('analyzer with injected macro impl query result matches golden', () {
+    final directory = Directory(
+        Isolate.resolvePackageUriSync(Uri.parse('package:foo/foo.dart'))!
+            .resolve('../../../introspection_goldens')
+            .toFilePath());
+
+    setUp(() async {
+      // Set up analyzer.
+      final contextCollection =
+          AnalysisContextCollection(includedPaths: [directory.path]);
+      analysisContext = contextCollection.contexts.first;
+      injected.macroImplementation = await AnalyzerMacroImplementation.start(
+          packageConfig: Isolate.packageConfigSync!);
+    });
+
+    for (final file in directory
+        .listSync(recursive: true)
+        .whereType<File>()
+        .where((f) => f.path.endsWith('.dart'))) {
+      final path = file.path;
+      final relativePath = p.relative(path, from: directory.path);
+
+      path.substring(path.indexOf('introspection_goldens') +
+          'introspection_goldens'.length);
+
+      late File goldenFile;
+      late Map<String, Object?> golden;
+      Map<String, Object?>? macroOutput;
+      final updateGoldens = Platform.environment['UPDATE_GOLDENS'] == 'yes';
+      setUp(() {
+        goldenFile = File(p.setExtension(path, '.json'));
+        golden =
+            json.decode(goldenFile.readAsStringSync()) as Map<String, Object?>;
+      });
+      if (updateGoldens) {
+        tearDown(() {
+          if (macroOutput != null) {
+            final string =
+                (const JsonEncoder.withIndent('  ')).convert(macroOutput);
+            if (goldenFile.readAsStringSync() != string) {
+              print('Updating mismatched golden: ${goldenFile.path}');
+              goldenFile.writeAsStringSync(string);
+            }
+          }
+        });
+      }
+
+      test(relativePath, () async {
+        final resolvedLibrary = (await analysisContext.currentSession
+            .getResolvedLibrary(path)) as ResolvedLibraryResult;
+        final augmentationUnit =
+            resolvedLibrary.units.singleWhere((u) => u.isMacroAugmentation);
+
+        // Each `QueryClass` outputs its query result as a comment in an
+        // augmentation. Collect them and merge them to compare with the
+        // golden.
+        final macroOutputs = augmentationUnit.content
+            .split('\n')
+            .where((l) => l.startsWith('// '))
+            .map((l) =>
+                json.decode(l.substring('// '.length)) as Map<String, Object?>);
+        macroOutput = _merge(macroOutputs);
+
+        expect(macroOutput, golden,
+            reason: updateGoldens
+                ? null
+                : '\n--> To update goldens, run: UPDATE_GOLDENS=yes dart test');
+      });
+    }
+  });
+}
+
+Map<String, Object?> _merge(Iterable<Map<String, Object?>> maps) {
+  final result = <String, Object?>{};
+  for (final map in maps) {
+    for (final entry in map.entries) {
+      if (result.containsKey(entry.key)) {
+        result[entry.key] = _merge([
+          result[entry.key]! as Map<String, Object?>,
+          entry.value as Map<String, Object?>
+        ]);
+      } else {
+        result[entry.key] = entry.value;
+      }
+    }
+  }
+  return result;
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,6 +5,7 @@ dev_dependencies:
   dart_flutter_team_lints: ^3.1.0
 publish_to: none
 workspace:
+  - introspection_goldens/foo
   - pkgs/_analyzer_macros
   - pkgs/_analyzer_macros/test/package_under_test
   - pkgs/_cfe_macros


### PR DESCRIPTION
I guess golden tests will be a good way for us to get introspection working as we want and also make sure the CFE and analyzer match.

This is a rough PR to get something in place:

 - No CFE test yet, but it will be added next, it will be very similar and read the same source + JSON as input, that's why the files are pulled out to a top level `introspection_goldens` folder rather than next to the analyzer tests; I guess we might also need a "skip list" for golden tests not working on one frontend yet
 - It's a bit awkward that the source has to explicitly add `QueryMacro` to everything; instead of doing introspection exactly via a macro we could try to do it with just the "query service", but it worries me a little that that would not exactly match what a macro does, so even though it's a bit awkward I think this makes sense
 - I guess we need to support having a different golden per phase

Any feedback+suggestion welcome :)