### PR TITLE
Allow union types to have additional fields, support required fields.

### DIFF
--- a/pkgs/_macro_client/lib/macro_client.dart
+++ b/pkgs/_macro_client/lib/macro_client.dart
@@ -30,7 +30,8 @@ class MacroClient {
     // Tell the host which macros are in this bundle.
     for (final macro in macros) {
       _sendRequest(MacroRequest.macroStartedRequest(
-          MacroStartedRequest(macroDescription: macro.description)));
+          MacroStartedRequest(macroDescription: macro.description),
+          id: nextRequestId));
     }
 
     const Utf8Decoder()
@@ -64,7 +65,8 @@ class MacroClient {
     switch (hostRequest.type) {
       case HostRequestType.augmentRequest:
         _sendResponse(Response.augmentResponse(
-            await macros.single.augment(_host, hostRequest.asAugmentRequest)));
+            await macros.single.augment(_host, hostRequest.asAugmentRequest),
+            requestId: hostRequest.id));
       default:
       // Ignore unknown request.
       // TODO(davidmorgan): make handling of unknown request types a designed
@@ -96,7 +98,8 @@ class RemoteMacroHost implements Host {
 
   @override
   Future<Model> query(Query query) async {
-    _client._sendRequest(MacroRequest.queryRequest(QueryRequest(query: query)));
+    _client._sendRequest(MacroRequest.queryRequest(QueryRequest(query: query),
+        id: nextRequestId));
     // TODO(davidmorgan): this is needed because the constructor doesn't wait
     // for responses to `MacroStartedRequest`, so we need to discard the
     // responses. Properly track requests and responses.

--- a/pkgs/_macro_client/test/macro_client_test.dart
+++ b/pkgs/_macro_client/test/macro_client_test.dart
@@ -40,10 +40,13 @@ void main() {
       final responses = StreamQueue(
           const Utf8Decoder().bind(socket).transform(const LineSplitter()));
       final descriptionResponse = await responses.next;
+      final macroRequest = MacroRequest.fromJson(
+          jsonDecode(descriptionResponse) as Map<String, Object?>);
       expect(
           descriptionResponse,
           '{"type":"MacroStartedRequest","value":'
-          '{"macroDescription":{"runsInPhases":[2]}}}');
+          '{"macroDescription":{"runsInPhases":[2]}},'
+          '"id":${macroRequest.id}}');
 
       var requestId = nextRequestId;
       socket.writeln(json.encode(
@@ -70,35 +73,40 @@ void main() {
           .transform(const Utf8Decoder())
           .transform(const LineSplitter()));
       final descriptionResponse = await responses.next;
+      final macroStartedRequest = MacroRequest.fromJson(
+          jsonDecode(descriptionResponse) as Map<String, Object?>);
       expect(
           descriptionResponse,
           '{"type":"MacroStartedRequest","value":'
-          '{"macroDescription":{"runsInPhases":[3]}}}');
+          '{"macroDescription":{"runsInPhases":[3]}},'
+          '"id":${macroStartedRequest.id}}');
 
-      var requestId = nextRequestId;
+      final augmentRequestId = nextRequestId;
       socket.writeln(json.encode(HostRequest.augmentRequest(
           AugmentRequest(
               phase: 3, target: QualifiedName('package:foo/foo.dart#Foo')),
-          id: nextRequestId)));
+          id: augmentRequestId)));
       final queryRequest = await responses.next;
+      final macroQueryRequest = MacroRequest.fromJson(
+          jsonDecode(queryRequest) as Map<String, Object?>);
       expect(
         queryRequest,
         '{"type":"QueryRequest","value":'
         '{"query":{"target":"package:foo/foo.dart#Foo"}},'
-        '"id":$requestId}',
+        '"id":${macroQueryRequest.id}}',
       );
 
       socket.writeln(json.encode(Response.queryResponse(
           QueryResponse(
               model: Model(uris: {'package:foo/foo.dart': Library()})),
-          requestId: requestId)));
+          requestId: macroQueryRequest.id)));
 
       final augmentRequest = await responses.next;
       expect(
         augmentRequest,
         '{"type":"AugmentResponse","value":'
         '{"augmentations":[{"code":"// {\\"uris\\":{\\"package:foo/foo.dart\\":{}}}"}]},'
-        '"requestId":$requestId}',
+        '"requestId":$augmentRequestId}',
       );
     });
   });

--- a/pkgs/_macro_client/test/macro_client_test.dart
+++ b/pkgs/_macro_client/test/macro_client_test.dart
@@ -45,13 +45,15 @@ void main() {
           '{"type":"MacroStartedRequest","value":'
           '{"macroDescription":{"runsInPhases":[2]}}}');
 
-      socket.writeln(
-          json.encode(HostRequest.augmentRequest(AugmentRequest(phase: 2))));
+      var requestId = nextRequestId;
+      socket.writeln(json.encode(
+          HostRequest.augmentRequest(AugmentRequest(phase: 2), id: requestId)));
       final augmentResponse = await responses.next;
       expect(
           augmentResponse,
           '{"type":"AugmentResponse","value":'
-          '{"augmentations":[{"code":"int get x => 3;"}]}}');
+          '{"augmentations":[{"code":"int get x => 3;"}]},'
+          '"requestId":$requestId}');
     });
 
     test('sends query requests to host, sends reponse', () async {
@@ -73,23 +75,30 @@ void main() {
           '{"type":"MacroStartedRequest","value":'
           '{"macroDescription":{"runsInPhases":[3]}}}');
 
-      socket.writeln(json.encode(HostRequest.augmentRequest(AugmentRequest(
-          phase: 3, target: QualifiedName('package:foo/foo.dart#Foo')))));
+      var requestId = nextRequestId;
+      socket.writeln(json.encode(HostRequest.augmentRequest(
+          AugmentRequest(
+              phase: 3, target: QualifiedName('package:foo/foo.dart#Foo')),
+          id: nextRequestId)));
       final queryRequest = await responses.next;
       expect(
         queryRequest,
         '{"type":"QueryRequest","value":'
-        '{"query":{"target":"package:foo/foo.dart#Foo"}}}',
+        '{"query":{"target":"package:foo/foo.dart#Foo"}},'
+        '"id":$requestId}',
       );
 
-      socket.writeln(json.encode(Response.queryResponse(QueryResponse(
-          model: Model(uris: {'package:foo/foo.dart': Library()})))));
+      socket.writeln(json.encode(Response.queryResponse(
+          QueryResponse(
+              model: Model(uris: {'package:foo/foo.dart': Library()})),
+          requestId: requestId)));
 
       final augmentRequest = await responses.next;
       expect(
         augmentRequest,
         '{"type":"AugmentResponse","value":'
-        '{"augmentations":[{"code":"// {\\"uris\\":{\\"package:foo/foo.dart\\":{}}}"}]}}',
+        '{"augmentations":[{"code":"// {\\"uris\\":{\\"package:foo/foo.dart\\":{}}}"}]},'
+        '"requestId":$requestId}',
       );
     });
   });

--- a/pkgs/_macro_host/lib/macro_host.dart
+++ b/pkgs/_macro_host/lib/macro_host.dart
@@ -67,7 +67,7 @@ class MacroHost {
     // TODO(davidmorgan): this just assumes the macro is running, actually
     // track macro lifecycle.
     final response = await macroServer.sendToMacro(
-        name, HostRequest.augmentRequest(request));
+        name, HostRequest.augmentRequest(request, id: nextRequestId));
     return response.asAugmentResponse;
   }
 }
@@ -88,12 +88,15 @@ class _HostService implements HostService {
         _macroPhases!.complete(request
             .asMacroStartedRequest.macroDescription.runsInPhases
             .toSet());
-        return Response.macroStartedResponse(MacroStartedResponse());
+        return Response.macroStartedResponse(MacroStartedResponse(),
+            requestId: request.id);
       case MacroRequestType.queryRequest:
         return Response.queryResponse(
-            await queryService.handle(request.asQueryRequest));
+            await queryService.handle(request.asQueryRequest),
+            requestId: request.id);
       default:
-        return Response.errorResponse(ErrorResponse(error: 'unsupported'));
+        return Response.errorResponse(ErrorResponse(error: 'unsupported'),
+            requestId: request.id);
     }
   }
 }

--- a/pkgs/_macro_server/test/macro_server_test.dart
+++ b/pkgs/_macro_server/test/macro_server_test.dart
@@ -36,8 +36,10 @@ class TestHostService implements HostService {
   Future<Response> handle(MacroRequest request) async {
     if (request.type == MacroRequestType.macroStartedRequest) {
       _macroStartedRequestsController.add(request.asMacroStartedRequest);
-      return Response.macroStartedResponse(MacroStartedResponse());
+      return Response.macroStartedResponse(MacroStartedResponse(),
+          requestId: request.id);
     }
-    return Response.errorResponse(ErrorResponse(error: 'unimplemented'));
+    return Response.errorResponse(ErrorResponse(error: 'unimplemented'),
+        requestId: request.id);
   }
 }

--- a/pkgs/dart_model/lib/src/dart_model.g.dart
+++ b/pkgs/dart_model/lib/src/dart_model.g.dart
@@ -1,5 +1,5 @@
 // This file is generated. To make changes edit schemas/*.schema.json
-// then run from the repo root: dart tool/model_generator/bin/main.dart
+// then run from the repo root: dart tool/dart_model_generator/bin/main.dart
 
 /// An augmentation to Dart code. TODO(davidmorgan): this is a placeholder.
 extension type Augmentation.fromJson(Map<String, Object?> node) {
@@ -165,12 +165,19 @@ enum StaticTypeType {
 }
 
 extension type StaticType.fromJson(Map<String, Object?> node) {
-  static StaticType neverType(NeverType neverType) =>
-      StaticType.fromJson({'type': 'NeverType', 'value': null});
+  static StaticType neverType(NeverType neverType) => StaticType.fromJson({
+        'type': 'NeverType',
+        'value': neverType,
+      });
   static StaticType nullableType(NullableType nullableType) =>
-      StaticType.fromJson({'type': 'NullableType', 'value': nullableType.node});
-  static StaticType voidType(VoidType voidType) =>
-      StaticType.fromJson({'type': 'VoidType', 'value': voidType.string});
+      StaticType.fromJson({
+        'type': 'NullableType',
+        'value': nullableType,
+      });
+  static StaticType voidType(VoidType voidType) => StaticType.fromJson({
+        'type': 'VoidType',
+        'value': voidType,
+      });
   StaticTypeType get type {
     switch (node['type'] as String) {
       case 'NeverType':

--- a/pkgs/macro_service/lib/src/macro_service.dart
+++ b/pkgs/macro_service/lib/src/macro_service.dart
@@ -28,7 +28,7 @@ abstract interface class MacroService {
 /// and that is allowed.
 int get nextRequestId {
   final next = _nextRequestId++;
-  if (_nextRequestId > 2 ^ 32) {
+  if (_nextRequestId > 0x7fffffff) {
     _nextRequestId = 0;
   }
   return next;

--- a/pkgs/macro_service/lib/src/macro_service.dart
+++ b/pkgs/macro_service/lib/src/macro_service.dart
@@ -18,3 +18,20 @@ abstract interface class MacroService {
   /// Handles [request].
   Future<Response> handle(HostRequest request);
 }
+
+/// Shared implementation of auto incrementing 32 bit IDs.
+///
+/// These roll back to 0 once it is greater than 2^32.
+///
+/// These are only unique to the process which generates the request,
+/// so for instance the host and macro services may generate conflicting ids
+/// and that is allowed.
+int get nextRequestId {
+  final next = _nextRequestId++;
+  if (_nextRequestId > 2 ^ 32) {
+    _nextRequestId = 0;
+  }
+  return next;
+}
+
+int _nextRequestId = 0;

--- a/pkgs/macro_service/lib/src/macro_service.g.dart
+++ b/pkgs/macro_service/lib/src/macro_service.g.dart
@@ -1,5 +1,5 @@
 // This file is generated. To make changes edit schemas/*.schema.json
-// then run from the repo root: dart tool/model_generator/bin/main.dart
+// then run from the repo root: dart tool/dart_model_generator/bin/main.dart
 
 import 'package:dart_model/dart_model.dart';
 
@@ -66,9 +66,15 @@ enum HostRequestType {
 }
 
 extension type HostRequest.fromJson(Map<String, Object?> node) {
-  static HostRequest augmentRequest(AugmentRequest augmentRequest) =>
-      HostRequest.fromJson(
-          {'type': 'AugmentRequest', 'value': augmentRequest.node});
+  static HostRequest augmentRequest(
+    AugmentRequest augmentRequest, {
+    required int id,
+  }) =>
+      HostRequest.fromJson({
+        'type': 'AugmentRequest',
+        'value': augmentRequest,
+        'id': id,
+      });
   HostRequestType get type {
     switch (node['type'] as String) {
       case 'AugmentRequest':
@@ -84,6 +90,9 @@ extension type HostRequest.fromJson(Map<String, Object?> node) {
     }
     return AugmentRequest.fromJson(node['value'] as Map<String, Object?>);
   }
+
+  /// The id of this request, must be returned in responses.
+  int get id => node['id'] as int;
 }
 
 /// Information about a macro that the macro provides to the host.
@@ -125,12 +134,23 @@ enum MacroRequestType {
 
 extension type MacroRequest.fromJson(Map<String, Object?> node) {
   static MacroRequest macroStartedRequest(
-          MacroStartedRequest macroStartedRequest) =>
-      MacroRequest.fromJson(
-          {'type': 'MacroStartedRequest', 'value': macroStartedRequest.node});
-  static MacroRequest queryRequest(QueryRequest queryRequest) =>
-      MacroRequest.fromJson(
-          {'type': 'QueryRequest', 'value': queryRequest.node});
+    MacroStartedRequest macroStartedRequest, {
+    required int id,
+  }) =>
+      MacroRequest.fromJson({
+        'type': 'MacroStartedRequest',
+        'value': macroStartedRequest,
+        'id': id,
+      });
+  static MacroRequest queryRequest(
+    QueryRequest queryRequest, {
+    required int id,
+  }) =>
+      MacroRequest.fromJson({
+        'type': 'QueryRequest',
+        'value': queryRequest,
+        'id': id,
+      });
   MacroRequestType get type {
     switch (node['type'] as String) {
       case 'MacroStartedRequest':
@@ -155,6 +175,9 @@ extension type MacroRequest.fromJson(Map<String, Object?> node) {
     }
     return QueryRequest.fromJson(node['value'] as Map<String, Object?>);
   }
+
+  /// The id of this request, must be returned in responses.
+  int get id => node['id'] as int;
 }
 
 /// Macro's query about the code it should augment.
@@ -189,17 +212,42 @@ enum ResponseType {
 }
 
 extension type Response.fromJson(Map<String, Object?> node) {
-  static Response augmentResponse(AugmentResponse augmentResponse) =>
-      Response.fromJson(
-          {'type': 'AugmentResponse', 'value': augmentResponse.node});
-  static Response errorResponse(ErrorResponse errorResponse) =>
-      Response.fromJson({'type': 'ErrorResponse', 'value': errorResponse.node});
+  static Response augmentResponse(
+    AugmentResponse augmentResponse, {
+    required int requestId,
+  }) =>
+      Response.fromJson({
+        'type': 'AugmentResponse',
+        'value': augmentResponse,
+        'requestId': requestId,
+      });
+  static Response errorResponse(
+    ErrorResponse errorResponse, {
+    required int requestId,
+  }) =>
+      Response.fromJson({
+        'type': 'ErrorResponse',
+        'value': errorResponse,
+        'requestId': requestId,
+      });
   static Response macroStartedResponse(
-          MacroStartedResponse macroStartedResponse) =>
-      Response.fromJson(
-          {'type': 'MacroStartedResponse', 'value': macroStartedResponse.node});
-  static Response queryResponse(QueryResponse queryResponse) =>
-      Response.fromJson({'type': 'QueryResponse', 'value': queryResponse.node});
+    MacroStartedResponse macroStartedResponse, {
+    required int requestId,
+  }) =>
+      Response.fromJson({
+        'type': 'MacroStartedResponse',
+        'value': macroStartedResponse,
+        'requestId': requestId,
+      });
+  static Response queryResponse(
+    QueryResponse queryResponse, {
+    required int requestId,
+  }) =>
+      Response.fromJson({
+        'type': 'QueryResponse',
+        'value': queryResponse,
+        'requestId': requestId,
+      });
   ResponseType get type {
     switch (node['type'] as String) {
       case 'AugmentResponse':
@@ -242,4 +290,7 @@ extension type Response.fromJson(Map<String, Object?> node) {
     }
     return QueryResponse.fromJson(node['value'] as Map<String, Object?>);
   }
+
+  /// The id of the [AugmentRequest] this is responding to.
+  int get requestId => node['requestId'] as int;
 }

--- a/pkgs/macro_service/lib/src/macro_service.g.dart
+++ b/pkgs/macro_service/lib/src/macro_service.g.dart
@@ -291,6 +291,6 @@ extension type Response.fromJson(Map<String, Object?> node) {
     return QueryResponse.fromJson(node['value'] as Map<String, Object?>);
   }
 
-  /// The id of the [AugmentRequest] this is responding to.
+  /// The id of the request this is responding to.
   int get requestId => node['requestId'] as int;
 }

--- a/schemas/macro_service.schema.json
+++ b/schemas/macro_service.schema.json
@@ -62,6 +62,10 @@
     "HostRequest": {
       "$description": "A request sent from host to macro.",
       "properties": {
+        "id": {
+          "description": "The id of this request, must be returned in responses.",
+          "type": "integer"
+        },
         "type": {
           "type": "string"
         },
@@ -72,7 +76,12 @@
             }
           ]
         }
-      }
+      },
+      "required": [
+        "id",
+        "type",
+        "value"
+      ]
     },
     "MacroDescription": {
       "type": "object",
@@ -103,6 +112,10 @@
     "MacroRequest": {
       "$description": "A request sent from macro to host.",
       "properties": {
+        "id": {
+          "description": "The id of this request, must be returned in responses.",
+          "type": "integer"
+        },
         "type": {
           "type": "string"
         },
@@ -116,7 +129,12 @@
             }
           ]
         }
-      }
+      },
+      "required": [
+        "id",
+        "type",
+        "value"
+      ]
     },
     "QueryRequest": {
       "type": "object",
@@ -139,6 +157,10 @@
     "Response": {
       "$description": "A response to a [MacroRequest] or [HostRequest].",
       "properties": {
+        "requestId": {
+          "description": "The id of the [AugmentRequest] this is responding to.",
+          "type": "integer"
+        },
         "type": {
           "type": "string"
         },
@@ -158,7 +180,12 @@
             }
           ]
         }
-      }
+      },
+      "required": [
+        "requestId",
+        "type",
+        "value"
+      ]
     }
   }
 }

--- a/schemas/macro_service.schema.json
+++ b/schemas/macro_service.schema.json
@@ -155,10 +155,10 @@
       }
     },
     "Response": {
-      "$description": "A response to a [MacroRequest] or [HostRequest].",
+      "$description": "A response to a request.",
       "properties": {
         "requestId": {
-          "description": "The id of the [AugmentRequest] this is responding to.",
+          "description": "The id of the request this is responding to.",
           "type": "integer"
         },
         "type": {


### PR DESCRIPTION
- Union types can now have additional fields beyond just `type` and `value`. These can be passed to each specialized constructor along with the value.
- Adds support for required fields in schemas, which essentially just makes the parameters for these fields in the constructors be required. These are not intended to be widely used, but there are certain things which are truly required.
- Uses these features to add a required `id` field to request types, and `requestId` field to response types.
- These will be used to support multiple ongoing requests and remove hacks with global variables for cfe/analyzer internals in the future.
- Also dropped the special `_dartWrapperToJson` function - afaik this was never necessary (but please let me know if that is wrong).

If you would like, I could separate out the support here from adding the actual required fields.

## Risks

This makes requests non-hermetic, because of the `id` field. This is always only in the _outer_ request type though. We can still do caching based on the _inner_ request type, which I think should work out fine.

Note that having the IDs on the outer types means they are not generally visible to the user APIs which is good.