### PR TITLE
Support binary serialization.

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -1,4 +1,4 @@
-# Created with package:mono_repo v6.6.1
+# Created with package:mono_repo v6.6.2
 name: Dart CI
 on:
   push:
@@ -34,7 +34,7 @@ jobs:
         name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - name: mono_repo self validate
-        run: dart pub global activate mono_repo 6.6.1
+        run: dart pub global activate mono_repo 6.6.2
       - name: mono_repo self validate
         run: dart pub global run mono_repo generate --validate
   job_002:
@@ -696,6 +696,41 @@ jobs:
       - job_003
       - job_004
   job_013:
+    name: "unit_test; linux; Dart 3.6.0-114.0.dev; PKG: pkgs/macro_service; `dart test --test-randomize-ordering-seed=random`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-114.0.dev;packages:pkgs/macro_service;commands:test"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-114.0.dev;packages:pkgs/macro_service
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-114.0.dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
+        with:
+          sdk: "3.6.0-114.0.dev"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - id: pkgs_macro_service_pub_upgrade
+        name: pkgs/macro_service; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/macro_service
+      - name: "pkgs/macro_service; dart test --test-randomize-ordering-seed=random"
+        run: "dart test --test-randomize-ordering-seed=random"
+        if: "always() && steps.pkgs_macro_service_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/macro_service
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+  job_014:
     name: "unit_test; linux; Dart 3.6.0-114.0.dev; PKG: tool/dart_model_generator; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -730,7 +765,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_014:
+  job_015:
     name: "unit_test; linux; Dart dev; PKG: pkgs/_analyzer_macros; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -765,7 +800,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_015:
+  job_016:
     name: "unit_test; linux; Dart dev; PKG: pkgs/_macro_builder; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -800,7 +835,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_016:
+  job_017:
     name: "unit_test; linux; Dart dev; PKG: pkgs/_macro_client; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -835,7 +870,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_017:
+  job_018:
     name: "unit_test; linux; Dart dev; PKG: pkgs/_macro_host; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -870,7 +905,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_018:
+  job_019:
     name: "unit_test; linux; Dart dev; PKG: pkgs/_macro_runner; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -905,7 +940,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_019:
+  job_020:
     name: "unit_test; linux; Dart dev; PKG: pkgs/_macro_server; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -940,7 +975,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_020:
+  job_021:
     name: "unit_test; linux; Dart dev; PKG: pkgs/dart_model; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -975,7 +1010,42 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_021:
+  job_022:
+    name: "unit_test; linux; Dart dev; PKG: pkgs/macro_service; `dart test --test-randomize-ordering-seed=random`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/macro_service;commands:test"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/macro_service
+            os:ubuntu-latest;pub-cache-hosted;sdk:dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
+        with:
+          sdk: dev
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - id: pkgs_macro_service_pub_upgrade
+        name: pkgs/macro_service; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/macro_service
+      - name: "pkgs/macro_service; dart test --test-randomize-ordering-seed=random"
+        run: "dart test --test-randomize-ordering-seed=random"
+        if: "always() && steps.pkgs_macro_service_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/macro_service
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+  job_023:
     name: "unit_test; linux; Dart dev; PKG: tool/dart_model_generator; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -1010,7 +1080,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_022:
+  job_024:
     name: "unit_test; windows; Dart 3.6.0-114.0.dev; PKG: pkgs/_analyzer_macros; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1035,7 +1105,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_023:
+  job_025:
     name: "unit_test; windows; Dart 3.6.0-114.0.dev; PKG: pkgs/_cfe_macros; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1060,7 +1130,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_024:
+  job_026:
     name: "unit_test; windows; Dart 3.6.0-114.0.dev; PKG: pkgs/_macro_builder; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1085,7 +1155,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_025:
+  job_027:
     name: "unit_test; windows; Dart 3.6.0-114.0.dev; PKG: pkgs/_macro_client; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1110,7 +1180,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_026:
+  job_028:
     name: "unit_test; windows; Dart 3.6.0-114.0.dev; PKG: pkgs/_macro_host; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1135,7 +1205,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_027:
+  job_029:
     name: "unit_test; windows; Dart 3.6.0-114.0.dev; PKG: pkgs/_macro_runner; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1160,7 +1230,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_028:
+  job_030:
     name: "unit_test; windows; Dart 3.6.0-114.0.dev; PKG: pkgs/_macro_server; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1185,7 +1255,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_029:
+  job_031:
     name: "unit_test; windows; Dart 3.6.0-114.0.dev; PKG: pkgs/dart_model; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1210,7 +1280,32 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_030:
+  job_032:
+    name: "unit_test; windows; Dart 3.6.0-114.0.dev; PKG: pkgs/macro_service; `dart test --test-randomize-ordering-seed=random`"
+    runs-on: windows-latest
+    steps:
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
+        with:
+          sdk: "3.6.0-114.0.dev"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - id: pkgs_macro_service_pub_upgrade
+        name: pkgs/macro_service; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/macro_service
+      - name: "pkgs/macro_service; dart test --test-randomize-ordering-seed=random"
+        run: "dart test --test-randomize-ordering-seed=random"
+        if: "always() && steps.pkgs_macro_service_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/macro_service
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+  job_033:
     name: "unit_test; windows; Dart 3.6.0-114.0.dev; PKG: tool/dart_model_generator; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1235,7 +1330,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_031:
+  job_034:
     name: "unit_test; windows; Dart dev; PKG: pkgs/_analyzer_macros; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1260,7 +1355,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_032:
+  job_035:
     name: "unit_test; windows; Dart dev; PKG: pkgs/_macro_builder; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1285,7 +1380,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_033:
+  job_036:
     name: "unit_test; windows; Dart dev; PKG: pkgs/_macro_client; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1310,7 +1405,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_034:
+  job_037:
     name: "unit_test; windows; Dart dev; PKG: pkgs/_macro_host; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1335,7 +1430,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_035:
+  job_038:
     name: "unit_test; windows; Dart dev; PKG: pkgs/_macro_runner; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1360,7 +1455,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_036:
+  job_039:
     name: "unit_test; windows; Dart dev; PKG: pkgs/_macro_server; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1385,7 +1480,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_037:
+  job_040:
     name: "unit_test; windows; Dart dev; PKG: pkgs/dart_model; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1410,7 +1505,32 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_038:
+  job_041:
+    name: "unit_test; windows; Dart dev; PKG: pkgs/macro_service; `dart test --test-randomize-ordering-seed=random`"
+    runs-on: windows-latest
+    steps:
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
+        with:
+          sdk: dev
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - id: pkgs_macro_service_pub_upgrade
+        name: pkgs/macro_service; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/macro_service
+      - name: "pkgs/macro_service; dart test --test-randomize-ordering-seed=random"
+        run: "dart test --test-randomize-ordering-seed=random"
+        if: "always() && steps.pkgs_macro_service_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/macro_service
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+  job_042:
     name: "unit_test; windows; Dart dev; PKG: tool/dart_model_generator; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:

--- a/pkgs/_analyzer_macros/lib/macro_implementation.dart
+++ b/pkgs/_analyzer_macros/lib/macro_implementation.dart
@@ -27,11 +27,15 @@ class AnalyzerMacroImplementation implements injected.MacroImplementation {
   /// [packageConfig] is the package config of the workspace of the code being
   /// edited.
   static Future<AnalyzerMacroImplementation> start({
+    required Protocol protocol,
     required Uri packageConfig,
   }) async =>
       AnalyzerMacroImplementation._(
           packageConfig,
           await MacroHost.serve(
+              // TODO(davidmorgan): this should be negotiated per client, not
+              // set here.
+              protocol: protocol,
               packageConfig: packageConfig,
               queryService: AnalyzerQueryService()));
 

--- a/pkgs/_analyzer_macros/test/analyzer_test.dart
+++ b/pkgs/_analyzer_macros/test/analyzer_test.dart
@@ -10,6 +10,7 @@ import 'package:analyzer/dart/analysis/analysis_context.dart';
 import 'package:analyzer/dart/analysis/analysis_context_collection.dart';
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/src/summary2/macro_injected_impl.dart' as injected;
+import 'package:macro_service/macro_service.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -24,6 +25,7 @@ void main() {
           AnalysisContextCollection(includedPaths: [directory.path]);
       analysisContext = contextCollection.contexts.first;
       injected.macroImplementation = await AnalyzerMacroImplementation.start(
+          protocol: Protocol(encoding: 'binary'),
           packageConfig: Isolate.packageConfigSync!);
     });
 

--- a/pkgs/_analyzer_macros/test/golden_test.dart
+++ b/pkgs/_analyzer_macros/test/golden_test.dart
@@ -11,6 +11,7 @@ import 'package:analyzer/dart/analysis/analysis_context.dart';
 import 'package:analyzer/dart/analysis/analysis_context_collection.dart';
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/src/summary2/macro_injected_impl.dart' as injected;
+import 'package:macro_service/macro_service.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
@@ -29,6 +30,7 @@ void main() {
           AnalysisContextCollection(includedPaths: [directory.path]);
       analysisContext = contextCollection.contexts.first;
       injected.macroImplementation = await AnalyzerMacroImplementation.start(
+          protocol: Protocol(encoding: 'binary'),
           packageConfig: Isolate.packageConfigSync!);
     });
 

--- a/pkgs/_cfe_macros/lib/macro_implementation.dart
+++ b/pkgs/_cfe_macros/lib/macro_implementation.dart
@@ -27,12 +27,17 @@ class CfeMacroImplementation implements injected.MacroImplementation {
   /// [packageConfig] is the package config of the workspace of the code being
   /// edited.
   static Future<CfeMacroImplementation> start({
+    // TODO(davidmorgan): this should be negotiated per client, not
+    // set here.
+    required Protocol protocol,
     required Uri packageConfig,
   }) async =>
       CfeMacroImplementation._(
           packageConfig,
           await MacroHost.serve(
-              packageConfig: packageConfig, queryService: CfeQueryService()));
+              protocol: protocol,
+              packageConfig: packageConfig,
+              queryService: CfeQueryService()));
 
   @override
   injected.MacroPackageConfigs get packageConfigs =>

--- a/pkgs/_cfe_macros/test/cfe_test.dart
+++ b/pkgs/_cfe_macros/test/cfe_test.dart
@@ -8,6 +8,7 @@ import 'dart:isolate';
 import 'package:_cfe_macros/macro_implementation.dart';
 import 'package:front_end/src/macros/macro_injected_impl.dart' as injected;
 import 'package:frontend_server/compute_kernel.dart';
+import 'package:macro_service/macro_service.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -30,6 +31,7 @@ void main() {
 
       // Inject test macro implementation.
       injected.macroImplementation = await CfeMacroImplementation.start(
+          protocol: Protocol(encoding: 'json'),
           packageConfig: Isolate.packageConfigSync!);
     });
 

--- a/pkgs/_cfe_macros/test/golden_test.dart
+++ b/pkgs/_cfe_macros/test/golden_test.dart
@@ -9,6 +9,7 @@ import 'dart:isolate';
 import 'package:_cfe_macros/macro_implementation.dart';
 import 'package:front_end/src/macros/macro_injected_impl.dart' as injected;
 import 'package:frontend_server/compute_kernel.dart';
+import 'package:macro_service/macro_service.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
@@ -37,6 +38,7 @@ void main() {
 
       // Inject test macro implementation.
       injected.macroImplementation = await CfeMacroImplementation.start(
+          protocol: Protocol(encoding: 'json'),
           packageConfig: Isolate.packageConfigSync!);
     });
 

--- a/pkgs/_macro_builder/lib/src/bootstrap.dart
+++ b/pkgs/_macro_builder/lib/src/bootstrap.dart
@@ -20,8 +20,11 @@ import 'package:macro_service/macro_service.dart' as macro_service;
 
 void main(List<String> arguments) {
    macro_client.MacroClient.run(
-      endpoint: macro_service.HostEndpoint.fromJson(
+      // TODO(davidmorgan): this should be negotiated, not passed here.
+      protocol: macro_service.Protocol.fromJson(
         convert.json.decode(arguments[0])),
+      endpoint: macro_service.HostEndpoint.fromJson(
+        convert.json.decode(arguments[1])),
       macros: [''');
   for (var i = 0; i != macros.length; ++i) {
     final macro = macros[i];

--- a/pkgs/_macro_builder/test/macro_builder_test.dart
+++ b/pkgs/_macro_builder/test/macro_builder_test.dart
@@ -31,8 +31,11 @@ import 'package:macro_service/macro_service.dart' as macro_service;
 
 void main(List<String> arguments) {
    macro_client.MacroClient.run(
-      endpoint: macro_service.HostEndpoint.fromJson(
+      // TODO(davidmorgan): this should be negotiated, not passed here.
+      protocol: macro_service.Protocol.fromJson(
         convert.json.decode(arguments[0])),
+      endpoint: macro_service.HostEndpoint.fromJson(
+        convert.json.decode(arguments[1])),
       macros: [m0.DeclareX(), m1.DeclareY(), m2.OtherMacroImplementation()]);
 }
 ''');

--- a/pkgs/_macro_host/lib/macro_host.dart
+++ b/pkgs/_macro_host/lib/macro_host.dart
@@ -27,12 +27,15 @@ class MacroHost {
 
   /// Starts a macro host with introspection queries handled by [queryService].
   static Future<MacroHost> serve({
+    // TODO(davidmorgan): this should be negotiated per client, not set here.
+    required Protocol protocol,
     required Uri packageConfig,
     required QueryService queryService,
   }) async {
     final macroPackageConfig = MacroPackageConfig.readFromUri(packageConfig);
     final hostService = _HostService(queryService);
-    final server = await MacroServer.serve(service: hostService);
+    final server =
+        await MacroServer.serve(protocol: protocol, service: hostService);
     return MacroHost._(macroPackageConfig, server, hostService);
   }
 
@@ -57,7 +60,10 @@ class MacroHost {
     }
     _hostService._macroPhases = Completer();
     final macroBundle = await macroBuilder.build(packageConfig, [name]);
-    macroRunner.start(macroBundle: macroBundle, endpoint: macroServer.endpoint);
+    macroRunner.start(
+        macroBundle: macroBundle,
+        protocol: macroServer.protocol,
+        endpoint: macroServer.endpoint);
     return _hostService._macroPhases!.future;
   }
 

--- a/pkgs/_macro_host/test/macro_host_test.dart
+++ b/pkgs/_macro_host/test/macro_host_test.dart
@@ -10,57 +10,65 @@ import 'package:macro_service/macro_service.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group(MacroHost, () {
-    test('hosts a macro, receives augmentations', () async {
-      final macroName =
-          QualifiedName('package:_test_macros/declare_x_macro.dart#DeclareX');
-      final macroImplementation = QualifiedName(
-          'package:_test_macros/declare_x_macro.dart#DeclareXImplementation');
+  for (final protocol in [
+    Protocol(encoding: 'json'),
+    Protocol(encoding: 'binary')
+  ]) {
+    group('MacroHost using ${protocol.encoding}', () {
+      test('hosts a macro, receives augmentations', () async {
+        final macroName =
+            QualifiedName('package:_test_macros/declare_x_macro.dart#DeclareX');
+        final macroImplementation = QualifiedName(
+            'package:_test_macros/declare_x_macro.dart#DeclareXImplementation');
 
-      final queryService = TestQueryService();
-      final host = await MacroHost.serve(
-          packageConfig: Isolate.packageConfigSync!,
-          queryService: queryService);
+        final queryService = TestQueryService();
+        final host = await MacroHost.serve(
+            protocol: protocol,
+            packageConfig: Isolate.packageConfigSync!,
+            queryService: queryService);
 
-      final packageConfig = Isolate.packageConfigSync!;
+        final packageConfig = Isolate.packageConfigSync!;
 
-      expect(host.isMacro(macroName), true);
-      expect(
-          await host.queryMacroPhases(packageConfig, macroImplementation), {2});
+        expect(host.isMacro(macroName), true);
+        expect(await host.queryMacroPhases(packageConfig, macroImplementation),
+            {2});
 
-      expect(
-          await host.augment(macroName, AugmentRequest(phase: 2)),
-          AugmentResponse(
-              augmentations: [Augmentation(code: 'int get x => 3;')]));
+        expect(
+            await host.augment(macroName, AugmentRequest(phase: 2)),
+            AugmentResponse(
+                augmentations: [Augmentation(code: 'int get x => 3;')]));
+      });
+
+      test('hosts a macro, responds to queries', () async {
+        final macroName =
+            QualifiedName('package:_test_macros/query_class.dart#QueryClass');
+        final macroImplementation = QualifiedName(
+            'package:_test_macros/query_class.dart#QueryClassImplementation');
+
+        final queryService = TestQueryService();
+        final host = await MacroHost.serve(
+            protocol: protocol,
+            packageConfig: Isolate.packageConfigSync!,
+            queryService: queryService);
+
+        final packageConfig = Isolate.packageConfigSync!;
+
+        expect(host.isMacro(macroName), true);
+        expect(await host.queryMacroPhases(packageConfig, macroImplementation),
+            {3});
+
+        expect(
+            await host.augment(
+                macroName,
+                AugmentRequest(
+                    phase: 3,
+                    target: QualifiedName('package:foo/foo.dart#Foo'))),
+            AugmentResponse(augmentations: [
+              Augmentation(code: '// {"uris":{"package:foo/foo.dart":{}}}')
+            ]));
+      });
     });
-
-    test('hosts a macro, responds to queries', () async {
-      final macroName =
-          QualifiedName('package:_test_macros/query_class.dart#QueryClass');
-      final macroImplementation = QualifiedName(
-          'package:_test_macros/query_class.dart#QueryClassImplementation');
-
-      final queryService = TestQueryService();
-      final host = await MacroHost.serve(
-          packageConfig: Isolate.packageConfigSync!,
-          queryService: queryService);
-
-      final packageConfig = Isolate.packageConfigSync!;
-
-      expect(host.isMacro(macroName), true);
-      expect(
-          await host.queryMacroPhases(packageConfig, macroImplementation), {3});
-
-      expect(
-          await host.augment(
-              macroName,
-              AugmentRequest(
-                  phase: 3, target: QualifiedName('package:foo/foo.dart#Foo'))),
-          AugmentResponse(augmentations: [
-            Augmentation(code: '// {"uris":{"package:foo/foo.dart":{}}}')
-          ]));
-    });
-  });
+  }
 }
 
 class TestQueryService implements QueryService {

--- a/pkgs/_macro_runner/lib/macro_runner.dart
+++ b/pkgs/_macro_runner/lib/macro_runner.dart
@@ -14,9 +14,12 @@ import 'package:macro_service/macro_service.dart';
 class MacroRunner {
   /// Starts [macroBundle] connected to [endpoint].
   void start(
-      {required BuiltMacroBundle macroBundle, required HostEndpoint endpoint}) {
-    Process.run(macroBundle.executablePath, [json.encode(endpoint)])
-        .then((result) {
+      {required BuiltMacroBundle macroBundle,
+      // TODO(davidmorgan): this should be negotiated, not passed here.
+      required Protocol protocol,
+      required HostEndpoint endpoint}) {
+    Process.run(macroBundle.executablePath,
+        [json.encode(protocol), json.encode(endpoint)]).then((result) {
       if (result.exitCode != 0) {
         print('Macro process exited with error: ${result.stderr}');
       }

--- a/pkgs/_macro_runner/test/macro_runner_test.dart
+++ b/pkgs/_macro_runner/test/macro_runner_test.dart
@@ -12,23 +12,30 @@ import 'package:macro_service/macro_service.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group(MacroRunner, () {
-    test('runs macros', () async {
-      final builder = MacroBuilder();
-      final bundle = await builder.build(Isolate.packageConfigSync!, [
-        QualifiedName(
-            'package:_test_macros/declare_x_macro.dart#DeclareXImplementation')
-      ]);
+  for (final protocol in [
+    Protocol(encoding: 'json'),
+    Protocol(encoding: 'binary')
+  ]) {
+    group('MacroRunner with ${protocol.encoding}', () {
+      test('runs macros', () async {
+        final builder = MacroBuilder();
+        final bundle = await builder.build(Isolate.packageConfigSync!, [
+          QualifiedName(
+              'package:_test_macros/declare_x_macro.dart#DeclareXImplementation')
+        ]);
 
-      final serverSocket = await ServerSocket.bind('localhost', 0);
-      addTearDown(serverSocket.close);
+        final serverSocket = await ServerSocket.bind('localhost', 0);
+        addTearDown(serverSocket.close);
 
-      final runner = MacroRunner();
-      runner.start(
-          macroBundle: bundle, endpoint: HostEndpoint(port: serverSocket.port));
+        final runner = MacroRunner();
+        runner.start(
+            macroBundle: bundle,
+            protocol: protocol,
+            endpoint: HostEndpoint(port: serverSocket.port));
 
-      expect(
-          serverSocket.first.timeout(const Duration(seconds: 10)), completes);
+        expect(
+            serverSocket.first.timeout(const Duration(seconds: 10)), completes);
+      });
     });
-  });
+  }
 }

--- a/pkgs/_macro_server/lib/macro_server.dart
+++ b/pkgs/_macro_server/lib/macro_server.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:dart_model/dart_model.dart';
@@ -11,6 +10,7 @@ import 'package:macro_service/macro_service.dart';
 
 /// Serves a [MacroService].
 class MacroServer {
+  final Protocol protocol;
   final HostService service;
   final HostEndpoint endpoint;
   final ServerSocket serverSocket;
@@ -21,40 +21,38 @@ class MacroServer {
   // TODO(davidmorgan): properly track requests and responses.
   Completer<Response>? _responseCompleter;
 
-  MacroServer._(this.service, this.endpoint, this.serverSocket) {
+  MacroServer._(this.protocol, this.service, this.endpoint, this.serverSocket) {
     serverSocket.forEach(_handleConnection);
   }
 
   /// Serves [service].
   ///
   /// TODO(davidmorgan): other transports besides TCP/IP.
-  static Future<MacroServer> serve({required HostService service}) async {
+  static Future<MacroServer> serve({
+    // TODO(davidmorgan): this should be negotiated per client, not set for
+    // each server.
+    required Protocol protocol,
+    required HostService service,
+  }) async {
     final serverSocket = await ServerSocket.bind('localhost', 0);
     return MacroServer._(
-        service, HostEndpoint(port: serverSocket.port), serverSocket);
+        protocol, service, HostEndpoint(port: serverSocket.port), serverSocket);
   }
 
   Future<Response> sendToMacro(QualifiedName name, HostRequest request) async {
     _responseCompleter = Completer<Response>();
-    _lastSocket!.writeln(json.encode(request.node));
+    protocol.send(_lastSocket!.add, request.node);
     return _responseCompleter!.future;
   }
 
   void _handleConnection(Socket socket) {
     _lastSocket = socket;
-    // TODO(davidmorgan): currently this is JSON with one request per line,
-    // switch to binary.
-    socket
-        .cast<List<int>>()
-        .transform(const Utf8Decoder())
-        .transform(const LineSplitter())
-        .forEach((line) {
-      final jsonData = json.decode(line) as Map<String, Object?>;
+    protocol.decode(socket).forEach((jsonData) {
       final request = MacroRequest.fromJson(jsonData);
       if (request.type.isKnown) {
         service
             .handle(request)
-            .then((response) => socket.writeln(json.encode(response!.node)));
+            .then((response) => protocol.send(socket.add, response!.node));
       }
       final response = Response.fromJson(jsonData);
       if (response.type.isKnown) {

--- a/pkgs/_macro_server/test/macro_server_test.dart
+++ b/pkgs/_macro_server/test/macro_server_test.dart
@@ -11,19 +11,28 @@ import 'package:macro_service/macro_service.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group(MacroServer, () {
-    test('serves a macro service', () async {
-      final service = TestHostService();
-      final server = await MacroServer.serve(service: service);
+  for (final protocol in [
+    Protocol(encoding: 'json'),
+    Protocol(encoding: 'binary')
+  ]) {
+    group('MacroServer using ${protocol.encoding}', () {
+      test('serves a macro service', () async {
+        final service = TestHostService();
+        final server =
+            await MacroServer.serve(protocol: protocol, service: service);
 
-      await MacroClient.run(
-          endpoint: server.endpoint, macros: [DeclareXImplementation()]);
+        await MacroClient.run(
+            // TODO(davidmorgan): this should be negotiated, not set here.
+            protocol: protocol,
+            endpoint: server.endpoint,
+            macros: [DeclareXImplementation()]);
 
-      // Check that the macro sent its description to the host on startup.
-      expect((await service.macroStartedRequests.first).macroDescription,
-          DeclareXImplementation().description);
+        // Check that the macro sent its description to the host on startup.
+        expect((await service.macroStartedRequests.first).macroDescription,
+            DeclareXImplementation().description);
+      });
     });
-  });
+  }
 }
 
 class TestHostService implements HostService {

--- a/pkgs/dart_model/lib/serialization.dart
+++ b/pkgs/dart_model/lib/serialization.dart
@@ -1,0 +1,12 @@
+import 'dart:typed_data';
+
+import 'src/json_buffer.dart';
+
+extension SerializeExtension on Map<String, Object?> {
+  Uint8List serializeToBinary() => JsonBuffer.serializeToBinary(this);
+}
+
+extension DeserializeExtension on Uint8List {
+  Map<String, Object?> deserializeFromBinary() =>
+      JsonBuffer.deserialize(this).asMap;
+}

--- a/pkgs/dart_model/test/json_buffer_test.dart
+++ b/pkgs/dart_model/test/json_buffer_test.dart
@@ -23,6 +23,15 @@ void main() {
       expect(buffer.asMap, {'a': false, 'aa': true, 'bbb': false});
     });
 
+    test('map with int values', () {
+      final buffer = JsonBuffer(
+          LazyMap(['1', '1000', '1000000', '1000000000'], int.parse));
+
+      expect(buffer.asMap.keys, ['1', '1000', '1000000', '1000000000']);
+      expect(buffer.asMap,
+          {'1': 1, '1000': 1000, '1000000': 1000000, '1000000000': 1000000000});
+    });
+
     test('map with map values', () {
       final buffer = JsonBuffer(LazyMap(
           ['a', 'aa', 'bbb'],
@@ -34,6 +43,18 @@ void main() {
         'a': {'a1': '1', 'a2': '2'},
         'aa': {'aa1': '1', 'aa2': '2'},
         'bbb': {'bbb1': '1', 'bbb2': '2'},
+      });
+    });
+
+    test('map with list values', () {
+      final buffer = JsonBuffer(
+          LazyMap(['a', 'aa', 'bbb'], (key) => ['${key}1', '${key}2']));
+
+      expect(buffer.asMap.keys, ['a', 'aa', 'bbb']);
+      expect(buffer.asMap, {
+        'a': ['a1', 'a2'],
+        'aa': ['aa1', 'aa2'],
+        'bbb': ['bbb1', 'bbb2'],
       });
     });
 

--- a/pkgs/macro_service/lib/src/macro_service.dart
+++ b/pkgs/macro_service/lib/src/macro_service.dart
@@ -2,7 +2,14 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dart_model/serialization.dart';
+
 import 'macro_service.g.dart';
+import 'message_grouper.dart';
 
 /// Service provided by the host to the macro.
 abstract interface class HostService {
@@ -35,3 +42,54 @@ int get nextRequestId {
 }
 
 int _nextRequestId = 0;
+
+final _jsonConverter = json.fuse(utf8);
+
+extension ProtocolExtension on Protocol {
+  bool get isJson => encoding == 'json';
+  bool get isBinary => encoding == 'binary';
+
+  /// Serializes [node] and sends it to [sink].
+  void send(void Function(Uint8List) sink, Map<String, Object?> node) {
+    if (isJson) {
+      sink(_jsonConverter.encode(node) as Uint8List);
+      sink(_utf8Newline);
+    } else if (isBinary) {
+      // Four byte message length followed by message.
+      // TODO(davidmorgan): variable length int encoding probably makes more
+      // sense than fixed four bytes.
+      final binary = node.serializeToBinary();
+      final length = binary.length;
+      sink(Uint8List.fromList([
+        (length >> 24) & 255,
+        (length >> 16) & 255,
+        (length >> 8) & 255,
+        length & 255,
+      ]));
+      sink(binary);
+    } else {
+      throw StateError('Unsupported protocol: $this.');
+    }
+  }
+
+  /// Deserializes [stream] to JSON objects.
+  ///
+  /// The data on `stream` can be arbitrarily split to `Uint8List` instances,
+  /// it does not have to be one list per message.
+  Stream<Map<String, Object?>> decode(Stream<Uint8List> stream) {
+    if (isJson) {
+      return const Utf8Decoder()
+          .bind(stream)
+          .transform(const LineSplitter())
+          .map((line) => json.decode(line) as Map<String, Object?>);
+    } else if (isBinary) {
+      return MessageGrouper(stream)
+          .messageStream
+          .map((message) => message.deserializeFromBinary());
+    } else {
+      throw StateError('Unsupported protocol: $this');
+    }
+  }
+}
+
+final _utf8Newline = const Utf8Encoder().convert('\n');

--- a/pkgs/macro_service/lib/src/macro_service.g.dart
+++ b/pkgs/macro_service/lib/src/macro_service.g.dart
@@ -180,6 +180,18 @@ extension type MacroRequest.fromJson(Map<String, Object?> node) {
   int get id => node['id'] as int;
 }
 
+/// The macro to host protocol version and encoding. TODO(davidmorgan): add the version.
+extension type Protocol.fromJson(Map<String, Object?> node) {
+  Protocol({
+    String? encoding,
+  }) : this.fromJson({
+          if (encoding != null) 'encoding': encoding,
+        });
+
+  /// The wire format: json or binary. TODO(davidmorgan): use an enum?
+  String get encoding => node['encoding'] as String;
+}
+
 /// Macro's query about the code it should augment.
 extension type QueryRequest.fromJson(Map<String, Object?> node) {
   QueryRequest({

--- a/pkgs/macro_service/lib/src/message_grouper.dart
+++ b/pkgs/macro_service/lib/src/message_grouper.dart
@@ -1,0 +1,107 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+/// Collects messages from an input stream of bytes.
+///
+/// Each message should start with a 32 bit big endian uint indicating its size,
+/// followed by that many bytes.
+class MessageGrouper {
+  /// The input bytes stream subscription.
+  late final StreamSubscription _inputStreamSubscription;
+
+  /// The buffer to store the length bytes in.
+  final _FixedBuffer _lengthBuffer = _FixedBuffer(4);
+
+  /// If reading raw data, buffer for the data.
+  _FixedBuffer? _messageBuffer;
+
+  late final StreamController<Uint8List> _messageStreamController =
+      StreamController<Uint8List>(onCancel: () {
+    _inputStreamSubscription.cancel();
+  });
+
+  Stream<Uint8List> get messageStream => _messageStreamController.stream;
+
+  MessageGrouper(Stream<List<int>> inputStream) {
+    _inputStreamSubscription = inputStream.listen(_handleBytes, onDone: cancel);
+  }
+
+  /// Stop listening to the input stream for further updates, and close the
+  /// output stream.
+  void cancel() {
+    _inputStreamSubscription.cancel();
+    _messageStreamController.close();
+  }
+
+  void _handleBytes(List<int> bytes, [int offset = 0]) {
+    final messageBuffer = _messageBuffer;
+    if (messageBuffer == null) {
+      while (offset < bytes.length && !_lengthBuffer.isReady) {
+        _lengthBuffer.addByte(bytes[offset++]);
+      }
+      if (_lengthBuffer.isReady) {
+        final length = _lengthBuffer[0] << 24 |
+            _lengthBuffer[1] << 16 |
+            _lengthBuffer[2] << 8 |
+            _lengthBuffer[3];
+        // Reset the length reading state.
+        _lengthBuffer.reset();
+        // Switch to the message payload reading state.
+        _messageBuffer = _FixedBuffer(length);
+        _handleBytes(bytes, offset);
+      } else {
+        // Continue reading the length.
+        return;
+      }
+    } else {
+      // Read the data from `bytes`.
+      offset += messageBuffer.addBytes(bytes, offset);
+
+      // If we completed a message, add it to the output stream.
+      if (messageBuffer.isReady) {
+        _messageStreamController.add(messageBuffer.bytes);
+        // Switch to the length reading state.
+        _messageBuffer = null;
+        _handleBytes(bytes, offset);
+      }
+    }
+  }
+}
+
+/// A buffer of fixed length.
+class _FixedBuffer {
+  final Uint8List bytes;
+
+  /// The offset in [bytes].
+  int _offset = 0;
+
+  _FixedBuffer(int length) : bytes = Uint8List(length);
+
+  /// Return `true` when the required number of bytes added.
+  bool get isReady => _offset == bytes.length;
+
+  int operator [](int index) => bytes[index];
+
+  void addByte(int byte) {
+    bytes[_offset++] = byte;
+  }
+
+  /// Consume at most as many bytes from [source] as required by fill [bytes].
+  /// Return the number of consumed bytes.
+  int addBytes(List<int> source, int offset) {
+    int toConsume = math.min(source.length - offset, bytes.length - _offset);
+    bytes.setRange(_offset, _offset + toConsume, source, offset);
+    _offset += toConsume;
+    return toConsume;
+  }
+
+  /// Reset the number of added bytes to zero.
+  void reset() {
+    _offset = 0;
+  }
+}

--- a/pkgs/macro_service/mono_pkg.yaml
+++ b/pkgs/macro_service/mono_pkg.yaml
@@ -8,3 +8,8 @@ stages:
   - format:
     sdk:
     - dev
+- unit_test:
+  - test: --test-randomize-ordering-seed=random
+    os:
+    - linux
+    - windows

--- a/pkgs/macro_service/pubspec.yaml
+++ b/pkgs/macro_service/pubspec.yaml
@@ -9,7 +9,9 @@ environment:
   sdk: ^3.6.0-114.0.dev
 
 dependencies:
+  async: ^2.11.0
   dart_model: any
 
 dev_dependencies:
   dart_flutter_team_lints: ^3.0.0
+  test: ^1.25.0

--- a/pkgs/macro_service/test/protocol_test.dart
+++ b/pkgs/macro_service/test/protocol_test.dart
@@ -1,0 +1,77 @@
+// Copyright (c) 2024, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:math' show min;
+import 'dart:typed_data';
+
+import 'package:macro_service/macro_service.dart';
+import 'package:test/test.dart';
+
+void main() {
+  for (final protocol in [
+    Protocol(encoding: 'json'),
+    Protocol(encoding: 'binary')
+  ]) {
+    group('Protocol using ${protocol.encoding}', () {
+      test('can round trip JSON data', () async {
+        final json = {
+          'string': 'string',
+          'int': 7,
+          'boolean': true,
+          'map': {'key': 'value'},
+          'list': [1, 'two', 3]
+        };
+
+        final receivedData = <int>[];
+        void sink(Uint8List data) => receivedData.addAll(data);
+        protocol.send(sink, json);
+
+        final streamController = StreamController<Uint8List>();
+        final decodedStream = protocol.decode(streamController.stream);
+        streamController.add(Uint8List.fromList(receivedData));
+        final message = await decodedStream.first;
+
+        expect(message, json);
+      });
+
+      test('can handle multiple arbitrarily split messages', () async {
+        final json = {
+          'string': 'string',
+          'int': 7,
+          'boolean': true,
+          'map': {'key': 'value'},
+          'list': [1, 'two', 3]
+        };
+
+        final receivedData = <int>[];
+        void sink(Uint8List data) => receivedData.addAll(data);
+        for (var i = 0; i != 1000; ++i) {
+          protocol.send(sink, json);
+        }
+
+        final streamController = StreamController<Uint8List>();
+        final decodedStream = protocol.decode(streamController.stream);
+
+        // Split into chunks with size 1, 2, 3, ... until done.
+        var sizeToTake = 1;
+        while (receivedData.isNotEmpty) {
+          final take = min(sizeToTake++, receivedData.length);
+          final takenBytes =
+              Uint8List.fromList(receivedData.take(take).toList());
+          receivedData.removeRange(0, take);
+          streamController.add(takenBytes);
+        }
+        unawaited(streamController.close());
+
+        final messages = await decodedStream.toList();
+        expect(messages.length, 1000);
+
+        for (final message in messages) {
+          expect(message, json);
+        }
+      });
+    });
+  }
+}

--- a/schemas/macro_service.schema.json
+++ b/schemas/macro_service.schema.json
@@ -136,6 +136,16 @@
         "value"
       ]
     },
+    "Protocol": {
+      "type": "object",
+      "description": "The macro to host protocol version and encoding. TODO(davidmorgan): add the version.",
+      "properties": {
+        "encoding": {
+          "type": "string",
+          "description": "The wire format: json or binary. TODO(davidmorgan): use an enum?"
+        }
+      }
+    },
     "QueryRequest": {
       "type": "object",
       "description": "Macro's query about the code it should augment.",

--- a/tool/ci.sh
+++ b/tool/ci.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Created with package:mono_repo v6.6.1
+# Created with package:mono_repo v6.6.2
 
 # Support built in commands on windows out of the box.
 


### PR DESCRIPTION
Introduce new type `Protocol` for wire format and version; for now it's just set explicitly everywhere, it should be negotiated.

Move serialization logic to this type, including new code to split a binary stream into messages using length-then-message encoding.

Add support for lists to `JsonBuffer`.

Interesting things after this:

 - Add some way to ensure we are using `LazyMap` instead of `Map` where it matters
 - Protocol versioning, negotiation