### PR TITLE
Make non-required schema properties nullable

### DIFF
--- a/pkgs/_analyzer_macros/lib/query_service.dart
+++ b/pkgs/_analyzer_macros/lib/query_service.dart
@@ -31,19 +31,23 @@ class AnalyzerQueryService implements QueryService {
       uris: {
         uri: Library(
           scopes: {
-            clazz.name: Interface(members: {
-              // TODO(davidmorgan): return more than just fields.
-              // TODO(davidmorgan): specify in the query what to return.
-              for (final field in clazz.fields)
-                field.name: Member(
-                    properties: Properties(
-                  isAbstract: field.isAbstract,
-                  isGetter: false,
-                  isField: true,
-                  isMethod: false,
-                  isStatic: field.isStatic,
-                )),
-            })
+            clazz.name: Interface(
+              metadataAnnotations: const [],
+              properties: Properties(),
+              members: {
+                // TODO(davidmorgan): return more than just fields.
+                // TODO(davidmorgan): specify in the query what to return.
+                for (final field in clazz.fields)
+                  field.name: Member(
+                      properties: Properties(
+                    isAbstract: field.isAbstract,
+                    isGetter: false,
+                    isField: true,
+                    isMethod: false,
+                    isStatic: field.isStatic,
+                  )),
+              },
+            )
           },
         ),
       },

--- a/pkgs/_cfe_macros/lib/query_service.dart
+++ b/pkgs/_cfe_macros/lib/query_service.dart
@@ -61,7 +61,10 @@ class CfeQueryService implements QueryService {
           scopes: {
             // TODO(davidmorgan): return more than just fields.
             // TODO(davidmorgan): specify in the query what to return.
-            target.name: Interface(members: fields)
+            target.name: Interface(
+                members: fields,
+                metadataAnnotations: const [],
+                properties: Properties())
           },
         ),
       },

--- a/pkgs/_macro_client/test/macro_client_test.dart
+++ b/pkgs/_macro_client/test/macro_client_test.dart
@@ -118,8 +118,9 @@ void main() {
             socket.add,
             Response.queryResponse(
                     QueryResponse(
-                        model:
-                            Model(uris: {'package:foo/foo.dart': Library()})),
+                        model: Model(uris: {
+                      'package:foo/foo.dart': Library(scopes: const {})
+                    })),
                     requestId: queryRequestId)
                 .node);
 

--- a/pkgs/_macro_host/test/macro_host_test.dart
+++ b/pkgs/_macro_host/test/macro_host_test.dart
@@ -75,6 +75,7 @@ class TestQueryService implements QueryService {
   @override
   Future<QueryResponse> handle(QueryRequest request) async {
     return QueryResponse(
-        model: Model(uris: {'package:foo/foo.dart': Library()}));
+        model:
+            Model(uris: {'package:foo/foo.dart': Library(scopes: const {})}));
   }
 }

--- a/pkgs/_test_macros/lib/query_class.dart
+++ b/pkgs/_test_macros/lib/query_class.dart
@@ -25,7 +25,7 @@ class QueryClassImplementation implements Macro {
     if (request.phase != 3) return AugmentResponse(augmentations: []);
 
     final model = await host.query(Query(
-      target: request.target,
+      target: request.target!,
     ));
     return AugmentResponse(
         augmentations: [Augmentation(code: '// ${json.encode(model)}')]);

--- a/pkgs/dart_model/lib/src/dart_model.g.dart
+++ b/pkgs/dart_model/lib/src/dart_model.g.dart
@@ -5,9 +5,9 @@
 extension type Augmentation.fromJson(Map<String, Object?> node)
     implements Object {
   Augmentation({
-    String? code,
+    required String code,
   }) : this.fromJson({
-          if (code != null) 'code': code,
+          'code': code,
         });
 
   /// Augmentation code.
@@ -18,9 +18,9 @@ extension type Augmentation.fromJson(Map<String, Object?> node)
 extension type MetadataAnnotation.fromJson(Map<String, Object?> node)
     implements Object {
   MetadataAnnotation({
-    QualifiedName? type,
+    required QualifiedName type,
   }) : this.fromJson({
-          if (type != null) 'type': type,
+          'type': type,
         });
 
   /// The type of the annotation.
@@ -30,14 +30,13 @@ extension type MetadataAnnotation.fromJson(Map<String, Object?> node)
 /// An interface.
 extension type Interface.fromJson(Map<String, Object?> node) implements Object {
   Interface({
-    List<MetadataAnnotation>? metadataAnnotations,
-    Map<String, Member>? members,
-    Properties? properties,
+    required List<MetadataAnnotation> metadataAnnotations,
+    required Map<String, Member> members,
+    required Properties properties,
   }) : this.fromJson({
-          if (metadataAnnotations != null)
-            'metadataAnnotations': metadataAnnotations,
-          if (members != null) 'members': members,
-          if (properties != null) 'properties': properties,
+          'metadataAnnotations': metadataAnnotations,
+          'members': members,
+          'properties': properties,
         });
 
   /// The metadata annotations attached to this iterface.
@@ -54,9 +53,9 @@ extension type Interface.fromJson(Map<String, Object?> node) implements Object {
 /// Library.
 extension type Library.fromJson(Map<String, Object?> node) implements Object {
   Library({
-    Map<String, Interface>? scopes,
+    required Map<String, Interface> scopes,
   }) : this.fromJson({
-          if (scopes != null) 'scopes': scopes,
+          'scopes': scopes,
         });
 
   /// Scopes by name.
@@ -66,9 +65,9 @@ extension type Library.fromJson(Map<String, Object?> node) implements Object {
 /// Member of a scope.
 extension type Member.fromJson(Map<String, Object?> node) implements Object {
   Member({
-    Properties? properties,
+    required Properties properties,
   }) : this.fromJson({
-          if (properties != null) 'properties': properties,
+          'properties': properties,
         });
 
   /// The properties of this member.
@@ -78,9 +77,9 @@ extension type Member.fromJson(Map<String, Object?> node) implements Object {
 /// Partial model of a corpus of Dart source code.
 extension type Model.fromJson(Map<String, Object?> node) implements Object {
   Model({
-    Map<String, Library>? uris,
+    required Map<String, Library> uris,
   }) : this.fromJson({
-          if (uris != null) 'uris': uris,
+          'uris': uris,
         });
 
   /// Libraries by URI.
@@ -96,9 +95,9 @@ extension type NeverType.fromJson(Null _) {
 extension type NullableType.fromJson(Map<String, Object?> node)
     implements Object {
   NullableType({
-    StaticType? inner,
+    required StaticType inner,
   }) : this.fromJson({
-          if (inner != null) 'inner': inner,
+          'inner': inner,
         });
   StaticType get inner => node['inner'] as StaticType;
 }
@@ -123,22 +122,26 @@ extension type Properties.fromJson(Map<String, Object?> node)
         });
 
   /// Whether the entity is abstract, meaning it has no definition.
-  bool get isAbstract => node['isAbstract'] as bool;
+  bool get isAbstract =>
+      node['isAbstract'] == null ? false : node['isAbstract'] as bool;
 
   /// Whether the entity is a class.
-  bool get isClass => node['isClass'] as bool;
+  bool get isClass => node['isClass'] == null ? false : node['isClass'] as bool;
 
   /// Whether the entity is a getter.
-  bool get isGetter => node['isGetter'] as bool;
+  bool get isGetter =>
+      node['isGetter'] == null ? false : node['isGetter'] as bool;
 
   /// Whether the entity is a field.
-  bool get isField => node['isField'] as bool;
+  bool get isField => node['isField'] == null ? false : node['isField'] as bool;
 
   /// Whether the entity is a method.
-  bool get isMethod => node['isMethod'] as bool;
+  bool get isMethod =>
+      node['isMethod'] == null ? false : node['isMethod'] as bool;
 
   /// Whether the entity is static.
-  bool get isStatic => node['isStatic'] as bool;
+  bool get isStatic =>
+      node['isStatic'] == null ? false : node['isStatic'] as bool;
 }
 
 /// A URI combined with a name.
@@ -149,9 +152,9 @@ extension type QualifiedName.fromJson(String string) implements Object {
 /// Query about a corpus of Dart source code. TODO(davidmorgan): this queries about a single class, expand to a union type for different types of queries.
 extension type Query.fromJson(Map<String, Object?> node) implements Object {
   Query({
-    QualifiedName? target,
+    required QualifiedName target,
   }) : this.fromJson({
-          if (target != null) 'target': target,
+          'target': target,
         });
 
   /// The class to query about.

--- a/pkgs/macro_service/lib/src/macro_service.g.dart
+++ b/pkgs/macro_service/lib/src/macro_service.g.dart
@@ -7,10 +7,10 @@ import 'package:dart_model/dart_model.dart';
 extension type AugmentRequest.fromJson(Map<String, Object?> node)
     implements Object {
   AugmentRequest({
-    int? phase,
+    required int phase,
     QualifiedName? target,
   }) : this.fromJson({
-          if (phase != null) 'phase': phase,
+          'phase': phase,
           if (target != null) 'target': target,
         });
 
@@ -18,16 +18,17 @@ extension type AugmentRequest.fromJson(Map<String, Object?> node)
   int get phase => node['phase'] as int;
 
   /// The class to augment. TODO(davidmorgan): expand to more types of target
-  QualifiedName get target => node['target'] as QualifiedName;
+  QualifiedName? get target =>
+      node['target'] == null ? null : node['target'] as QualifiedName?;
 }
 
 /// Macro's response to an [AugmentRequest]: the resulting augmentations.
 extension type AugmentResponse.fromJson(Map<String, Object?> node)
     implements Object {
   AugmentResponse({
-    List<Augmentation>? augmentations,
+    required List<Augmentation> augmentations,
   }) : this.fromJson({
-          if (augmentations != null) 'augmentations': augmentations,
+          'augmentations': augmentations,
         });
 
   /// The augmentations.
@@ -39,9 +40,9 @@ extension type AugmentResponse.fromJson(Map<String, Object?> node)
 extension type ErrorResponse.fromJson(Map<String, Object?> node)
     implements Object {
   ErrorResponse({
-    String? error,
+    required String error,
   }) : this.fromJson({
-          if (error != null) 'error': error,
+          'error': error,
         });
 
   /// The error.
@@ -52,9 +53,9 @@ extension type ErrorResponse.fromJson(Map<String, Object?> node)
 extension type HostEndpoint.fromJson(Map<String, Object?> node)
     implements Object {
   HostEndpoint({
-    int? port,
+    required int port,
   }) : this.fromJson({
-          if (port != null) 'port': port,
+          'port': port,
         });
 
   /// TCP port to connect to.
@@ -104,9 +105,9 @@ extension type HostRequest.fromJson(Map<String, Object?> node)
 extension type MacroDescription.fromJson(Map<String, Object?> node)
     implements Object {
   MacroDescription({
-    List<int>? runsInPhases,
+    required List<int> runsInPhases,
   }) : this.fromJson({
-          if (runsInPhases != null) 'runsInPhases': runsInPhases,
+          'runsInPhases': runsInPhases,
         });
 
   /// Phases that the macro runs in: 1, 2 and/or 3.
@@ -117,9 +118,9 @@ extension type MacroDescription.fromJson(Map<String, Object?> node)
 extension type MacroStartedRequest.fromJson(Map<String, Object?> node)
     implements Object {
   MacroStartedRequest({
-    MacroDescription? macroDescription,
+    required MacroDescription macroDescription,
   }) : this.fromJson({
-          if (macroDescription != null) 'macroDescription': macroDescription,
+          'macroDescription': macroDescription,
         });
   MacroDescription get macroDescription =>
       node['macroDescription'] as MacroDescription;
@@ -192,9 +193,9 @@ extension type MacroRequest.fromJson(Map<String, Object?> node)
 /// The macro to host protocol version and encoding. TODO(davidmorgan): add the version.
 extension type Protocol.fromJson(Map<String, Object?> node) implements Object {
   Protocol({
-    String? encoding,
+    required String encoding,
   }) : this.fromJson({
-          if (encoding != null) 'encoding': encoding,
+          'encoding': encoding,
         });
 
   /// The wire format: json or binary. TODO(davidmorgan): use an enum?
@@ -205,9 +206,9 @@ extension type Protocol.fromJson(Map<String, Object?> node) implements Object {
 extension type QueryRequest.fromJson(Map<String, Object?> node)
     implements Object {
   QueryRequest({
-    Query? query,
+    required Query query,
   }) : this.fromJson({
-          if (query != null) 'query': query,
+          'query': query,
         });
   Query get query => node['query'] as Query;
 }
@@ -216,9 +217,9 @@ extension type QueryRequest.fromJson(Map<String, Object?> node)
 extension type QueryResponse.fromJson(Map<String, Object?> node)
     implements Object {
   QueryResponse({
-    Model? model,
+    required Model model,
   }) : this.fromJson({
-          if (model != null) 'model': model,
+          'model': model,
         });
   Model get model => node['model'] as Model;
 }

--- a/schemas/dart_model.schema.json
+++ b/schemas/dart_model.schema.json
@@ -14,7 +14,8 @@
           "type": "string",
           "description": "Augmentation code."
         }
-      }
+      },
+      "required": ["code"]
     },
     "MetadataAnnotation": {
       "type": "object",
@@ -24,7 +25,8 @@
           "$comment": "The type of the annotation.",
           "$ref": "#/$defs/QualifiedName"
         }
-      }
+      },
+      "required": ["type"]
     },
     "Interface": {
       "type": "object",
@@ -48,7 +50,8 @@
           "$comment": "The properties of this interface.",
           "$ref": "#/$defs/Properties"
         }
-      }
+      },
+      "required": ["metadataAnnotations", "members", "properties"]
     },
     "Library": {
       "description": "Library.",
@@ -61,7 +64,8 @@
             "$ref": "#/$defs/Interface"
           }
         }
-      }
+      },
+      "required": ["scopes"]
     },
     "Member": {
       "type": "object",
@@ -71,7 +75,8 @@
           "$comment": "The properties of this member.",
           "$ref": "#/$defs/Properties"
         }
-      }
+      },
+      "required": ["properties"]
     },
     "Model": {
       "type": "object",
@@ -84,7 +89,8 @@
             "$ref": "#/$defs/Library"
           }
         }
-      }
+      },
+      "required": ["uris"]
     },
     "NeverType": {
       "type": "null",
@@ -97,7 +103,8 @@
         "inner": {
           "$ref": "#/$defs/StaticType"
         }
-      }
+      },
+      "required": ["inner"]
     },
     "Properties": {
       "type": "object",
@@ -105,27 +112,33 @@
       "properties": {
         "isAbstract": {
           "description": "Whether the entity is abstract, meaning it has no definition.",
-          "type": "boolean"
+          "type": "boolean",
+          "default": false
         },
         "isClass": {
           "description": "Whether the entity is a class.",
-          "type": "boolean"
+          "type": "boolean",
+          "default": false
         },
         "isGetter": {
           "description": "Whether the entity is a getter.",
-          "type": "boolean"
+          "type": "boolean",
+          "default": false
         },
         "isField": {
           "description": "Whether the entity is a field.",
-          "type": "boolean"
+          "type": "boolean",
+          "default": false
         },
         "isMethod": {
           "description": "Whether the entity is a method.",
-          "type": "boolean"
+          "type": "boolean",
+          "default": false
         },
         "isStatic": {
           "description": "Whether the entity is static.",
-          "type": "boolean"
+          "type": "boolean",
+          "default": false
         }
       }
     },
@@ -141,7 +154,8 @@
           "$comment": "The class to query about.",
           "$ref": "#/$defs/QualifiedName"
         }
-      }
+      },
+      "required": ["target"]
     },
     "StaticType": {
       "description": "A resolved type as it appears in Dart's type hierarchy.",

--- a/schemas/macro_service.schema.json
+++ b/schemas/macro_service.schema.json
@@ -24,7 +24,8 @@
           "$comment": "The class to augment. TODO(davidmorgan): expand to more types of target",
           "$ref": "file:dart_model.schema.json#/$defs/QualifiedName"
         }
-      }
+      },
+      "required": ["phase"]
     },
     "AugmentResponse": {
       "type": "object",
@@ -37,7 +38,8 @@
             "$ref": "file:dart_model.schema.json#/$defs/Augmentation"
           }
         }
-      }
+      },
+      "required": ["augmentations"]
     },
     "ErrorResponse": {
       "type": "object",
@@ -47,7 +49,8 @@
           "description": "The error.",
           "type": "string"
         }
-      }
+      },
+      "required": ["error"]
     },
     "HostEndpoint": {
       "type": "object",
@@ -57,7 +60,8 @@
           "description": "TCP port to connect to.",
           "type": "integer"
         }
-      }
+      },
+      "required": ["port"]
     },
     "HostRequest": {
       "$description": "A request sent from host to macro.",
@@ -94,7 +98,8 @@
             "type": "integer"
           }
         }
-      }
+      },
+      "required": ["runsInPhases"]
     },
     "MacroStartedRequest": {
       "type": "object",
@@ -103,7 +108,8 @@
         "macroDescription": {
           "$ref": "#/$defs/MacroDescription"
         }
-      }
+      },
+      "required": ["macroDescription"]
     },
     "MacroStartedResponse": {
       "type": "object",
@@ -144,7 +150,8 @@
           "type": "string",
           "description": "The wire format: json or binary. TODO(davidmorgan): use an enum?"
         }
-      }
+      },
+      "required": ["encoding"]
     },
     "QueryRequest": {
       "type": "object",
@@ -153,7 +160,8 @@
         "query": {
           "$ref": "file:dart_model.schema.json#/$defs/Query"
         }
-      }
+      },
+      "required": ["query"]
     },
     "QueryResponse": {
       "type": "object",
@@ -162,7 +170,8 @@
         "model": {
           "$ref": "file:dart_model.schema.json#/$defs/Model"
         }
-      }
+      },
+      "required": ["model"]
     },
     "Response": {
       "$description": "A response to a request.",


### PR DESCRIPTION
At the moment, only a few properties in the macro schemas have been declared as `required`. But even properties that aren't required are exposed as non-nullable getters in the generated code, which is dangerous and also makes properties that can genuinely be null impossible to access safely.

This PR fixes that by:

1. Marking all properties that are expected to be non-null as `required` in the JSON schemas.
2. Supporting default values for primitives that can be used as a fallback (used on the `Properties` class, where values aren't consistently filled out and supposed to be `false` by default I guess?? The current implementation would just throw when accessing fields that haven't been set...)
3. Generating nullable getters for the remaining values.