### PR TITLE
Define the JSON types in Dart code instead of with a schema.

### DIFF
--- a/pkgs/dart_model/lib/src/dart_model.g.dart
+++ b/pkgs/dart_model/lib/src/dart_model.g.dart
@@ -1,6 +1,6 @@
-// This file is generated. To make changes edit schemas/*.schema.json
+// This file is generated. To make changes edit tool/dart_model_generator
 // then run from the repo root: dart tool/dart_model_generator/bin/main.dart
-
+// ignore: implementation_imports
 /// An augmentation to Dart code. TODO(davidmorgan): this is a placeholder.
 extension type Augmentation.fromJson(Map<String, Object?> node)
     implements Object {
@@ -37,6 +37,8 @@ extension type FunctionTypeDesc.fromJson(Map<String, Object?> node)
             'optionalPositionalParameters': optionalPositionalParameters,
           if (namedParameters != null) 'namedParameters': namedParameters,
         });
+
+  /// The return type of this function type.
   StaticTypeDesc get returnType => node['returnType'] as StaticTypeDesc;
 
   /// Static type parameters introduced by this function type.
@@ -78,12 +80,14 @@ extension type Interface.fromJson(Map<String, Object?> node) implements Object {
           if (properties != null) 'properties': properties,
         });
 
-  /// The metadata annotations attached to this iterface.
+  /// The metadata annotations attached to this interface.
   List<MetadataAnnotation> get metadataAnnotations =>
       (node['metadataAnnotations'] as List).cast();
 
   /// Map of members by name.
   Map<String, Member> get members => (node['members'] as Map).cast();
+
+  /// The type of the expression `this` when used in this interface.
   NamedTypeDesc get thisType => node['thisType'] as NamedTypeDesc;
 
   /// The properties of this interface.
@@ -126,6 +130,8 @@ extension type Model.fromJson(Map<String, Object?> node) implements Object {
 
   /// Libraries by URI.
   Map<String, Library> get uris => (node['uris'] as Map).cast();
+
+  /// The resolved static type hierarchy.
   TypeHierarchy get types => node['types'] as TypeHierarchy;
 }
 
@@ -160,7 +166,7 @@ extension type NamedRecordField.fromJson(Map<String, Object?> node)
   StaticTypeDesc get type => node['type'] as StaticTypeDesc;
 }
 
-/// A resolved static type
+/// A resolved static type.
 extension type NamedTypeDesc.fromJson(Map<String, Object?> node)
     implements Object {
   NamedTypeDesc({
@@ -188,6 +194,8 @@ extension type NullableTypeDesc.fromJson(Map<String, Object?> node)
   }) : this.fromJson({
           if (inner != null) 'inner': inner,
         });
+
+  /// The type T.
   StaticTypeDesc get inner => node['inner'] as StaticTypeDesc;
 }
 
@@ -265,9 +273,9 @@ enum StaticTypeDescType {
   _unknown,
   dynamicTypeDesc,
   functionTypeDesc,
+  namedTypeDesc,
   neverTypeDesc,
   nullableTypeDesc,
-  namedTypeDesc,
   recordTypeDesc,
   typeParameterTypeDesc,
   voidTypeDesc;
@@ -287,6 +295,11 @@ extension type StaticTypeDesc.fromJson(Map<String, Object?> node)
         'type': 'FunctionTypeDesc',
         'value': functionTypeDesc,
       });
+  static StaticTypeDesc namedTypeDesc(NamedTypeDesc namedTypeDesc) =>
+      StaticTypeDesc.fromJson({
+        'type': 'NamedTypeDesc',
+        'value': namedTypeDesc,
+      });
   static StaticTypeDesc neverTypeDesc(NeverTypeDesc neverTypeDesc) =>
       StaticTypeDesc.fromJson({
         'type': 'NeverTypeDesc',
@@ -296,11 +309,6 @@ extension type StaticTypeDesc.fromJson(Map<String, Object?> node)
       StaticTypeDesc.fromJson({
         'type': 'NullableTypeDesc',
         'value': nullableTypeDesc,
-      });
-  static StaticTypeDesc namedTypeDesc(NamedTypeDesc namedTypeDesc) =>
-      StaticTypeDesc.fromJson({
-        'type': 'NamedTypeDesc',
-        'value': namedTypeDesc,
       });
   static StaticTypeDesc recordTypeDesc(RecordTypeDesc recordTypeDesc) =>
       StaticTypeDesc.fromJson({
@@ -324,12 +332,12 @@ extension type StaticTypeDesc.fromJson(Map<String, Object?> node)
         return StaticTypeDescType.dynamicTypeDesc;
       case 'FunctionTypeDesc':
         return StaticTypeDescType.functionTypeDesc;
+      case 'NamedTypeDesc':
+        return StaticTypeDescType.namedTypeDesc;
       case 'NeverTypeDesc':
         return StaticTypeDescType.neverTypeDesc;
       case 'NullableTypeDesc':
         return StaticTypeDescType.nullableTypeDesc;
-      case 'NamedTypeDesc':
-        return StaticTypeDescType.namedTypeDesc;
       case 'RecordTypeDesc':
         return StaticTypeDescType.recordTypeDesc;
       case 'TypeParameterTypeDesc':
@@ -355,6 +363,13 @@ extension type StaticTypeDesc.fromJson(Map<String, Object?> node)
     return FunctionTypeDesc.fromJson(node['value'] as Map<String, Object?>);
   }
 
+  NamedTypeDesc get asNamedTypeDesc {
+    if (node['type'] != 'NamedTypeDesc') {
+      throw StateError('Not a NamedTypeDesc.');
+    }
+    return NamedTypeDesc.fromJson(node['value'] as Map<String, Object?>);
+  }
+
   NeverTypeDesc get asNeverTypeDesc {
     if (node['type'] != 'NeverTypeDesc') {
       throw StateError('Not a NeverTypeDesc.');
@@ -367,13 +382,6 @@ extension type StaticTypeDesc.fromJson(Map<String, Object?> node)
       throw StateError('Not a NullableTypeDesc.');
     }
     return NullableTypeDesc.fromJson(node['value'] as Map<String, Object?>);
-  }
-
-  NamedTypeDesc get asNamedTypeDesc {
-    if (node['type'] != 'NamedTypeDesc') {
-      throw StateError('Not a NamedTypeDesc.');
-    }
-    return NamedTypeDesc.fromJson(node['value'] as Map<String, Object?>);
   }
 
   RecordTypeDesc get asRecordTypeDesc {
@@ -439,9 +447,11 @@ extension type TypeHierarchyEntry.fromJson(Map<String, Object?> node)
           if (supertypes != null) 'supertypes': supertypes,
         });
 
-  /// Type parameters defined on this interface-defining element..
+  /// Type parameters defined on this interface-defining element.
   List<StaticTypeParameterDesc> get typeParameters =>
       (node['typeParameters'] as List).cast();
+
+  /// The named static type represented by this entry.
   NamedTypeDesc get self => node['self'] as NamedTypeDesc;
 
   /// All direct supertypes of this type.

--- a/pkgs/dart_model/lib/src/dart_model.g.dart
+++ b/pkgs/dart_model/lib/src/dart_model.g.dart
@@ -1,6 +1,6 @@
 // This file is generated. To make changes edit tool/dart_model_generator
 // then run from the repo root: dart tool/dart_model_generator/bin/main.dart
-// ignore: implementation_imports
+
 /// An augmentation to Dart code. TODO(davidmorgan): this is a placeholder.
 extension type Augmentation.fromJson(Map<String, Object?> node)
     implements Object {

--- a/pkgs/macro_service/lib/src/macro_service.g.dart
+++ b/pkgs/macro_service/lib/src/macro_service.g.dart
@@ -1,7 +1,7 @@
-// This file is generated. To make changes edit schemas/*.schema.json
+// This file is generated. To make changes edit tool/dart_model_generator
 // then run from the repo root: dart tool/dart_model_generator/bin/main.dart
-
-import 'package:dart_model/dart_model.dart';
+// ignore: implementation_imports
+import 'package:dart_model/src/dart_model.g.dart';
 
 /// A request to a macro to augment some code.
 extension type AugmentRequest.fromJson(Map<String, Object?> node)
@@ -17,7 +17,7 @@ extension type AugmentRequest.fromJson(Map<String, Object?> node)
   /// Which phase to run: 1, 2 or 3.
   int get phase => node['phase'] as int;
 
-  /// The class to augment. TODO(davidmorgan): expand to more types of target
+  /// The class to augment. TODO(davidmorgan): expand to more types of target.
   QualifiedName get target => node['target'] as QualifiedName;
 }
 
@@ -121,6 +121,8 @@ extension type MacroStartedRequest.fromJson(Map<String, Object?> node)
   }) : this.fromJson({
           if (macroDescription != null) 'macroDescription': macroDescription,
         });
+
+  /// The macro description.
   MacroDescription get macroDescription =>
       node['macroDescription'] as MacroDescription;
 }
@@ -209,6 +211,8 @@ extension type QueryRequest.fromJson(Map<String, Object?> node)
   }) : this.fromJson({
           if (query != null) 'query': query,
         });
+
+  /// The query.
   Query get query => node['query'] as Query;
 }
 
@@ -220,6 +224,8 @@ extension type QueryResponse.fromJson(Map<String, Object?> node)
   }) : this.fromJson({
           if (model != null) 'model': model,
         });
+
+  /// The model.
   Model get model => node['model'] as Model;
 }
 

--- a/pkgs/macro_service/lib/src/macro_service.g.dart
+++ b/pkgs/macro_service/lib/src/macro_service.g.dart
@@ -1,5 +1,6 @@
 // This file is generated. To make changes edit tool/dart_model_generator
 // then run from the repo root: dart tool/dart_model_generator/bin/main.dart
+
 // ignore: implementation_imports
 import 'package:dart_model/src/dart_model.g.dart';
 

--- a/schemas/dart_model.schema.json
+++ b/schemas/dart_model.schema.json
@@ -7,8 +7,8 @@
   ],
   "$defs": {
     "Augmentation": {
-      "description": "An augmentation to Dart code. TODO(davidmorgan): this is a placeholder.",
       "type": "object",
+      "description": "An augmentation to Dart code. TODO(davidmorgan): this is a placeholder.",
       "properties": {
         "code": {
           "type": "string",
@@ -17,23 +17,23 @@
       }
     },
     "DynamicTypeDesc": {
-      "description": "The type-hierarchy representation of the type `dynamic`.",
-      "type": "null"
+      "type": "null",
+      "description": "The type-hierarchy representation of the type `dynamic`."
     },
     "FunctionTypeDesc": {
-      "description": "A static type representation for function types.",
       "type": "object",
+      "description": "A static type representation for function types.",
       "properties": {
         "returnType": {
-          "$ref": "#/$defs/StaticTypeDesc",
-          "description": "The return type of this function type."
+          "$comment": "The return type of this function type.",
+          "$ref": "#/$defs/StaticTypeDesc"
         },
         "typeParameters": {
           "type": "array",
+          "description": "Static type parameters introduced by this function type.",
           "items": {
             "$ref": "#/$defs/StaticTypeParameterDesc"
-          },
-          "description": "Static type parameters introduced by this function type."
+          }
         },
         "requiredPositionalParameters": {
           "type": "array",
@@ -70,8 +70,8 @@
       "description": "An interface.",
       "properties": {
         "metadataAnnotations": {
-          "description": "The metadata annotations attached to this iterface.",
           "type": "array",
+          "description": "The metadata annotations attached to this interface.",
           "items": {
             "$ref": "#/$defs/MetadataAnnotation"
           }
@@ -84,7 +84,7 @@
           }
         },
         "thisType": {
-          "description": "The type of the expression `this` when used in this interface.",
+          "$comment": "The type of the expression `this` when used in this interface.",
           "$ref": "#/$defs/NamedTypeDesc"
         },
         "properties": {
@@ -94,8 +94,8 @@
       }
     },
     "Library": {
-      "description": "Library.",
       "type": "object",
+      "description": "Library.",
       "properties": {
         "scopes": {
           "type": "object",
@@ -128,7 +128,7 @@
           }
         },
         "types": {
-          "description": "The resolved static type hierarchy.",
+          "$comment": "The resolved static type hierarchy.",
           "$ref": "#/$defs/TypeHierarchy"
         }
       }
@@ -162,7 +162,7 @@
     },
     "NamedTypeDesc": {
       "type": "object",
-      "description": "A resolved static type",
+      "description": "A resolved static type.",
       "properties": {
         "name": {
           "$ref": "#/$defs/QualifiedName"
@@ -184,6 +184,7 @@
       "description": "A Dart type of the form `T?` for an inner type `T`.",
       "properties": {
         "inner": {
+          "$comment": "The type T.",
           "$ref": "#/$defs/StaticTypeDesc"
         }
       }
@@ -193,34 +194,34 @@
       "description": "Set of boolean properties.",
       "properties": {
         "isAbstract": {
-          "description": "Whether the entity is abstract, meaning it has no definition.",
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Whether the entity is abstract, meaning it has no definition."
         },
         "isClass": {
-          "description": "Whether the entity is a class.",
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Whether the entity is a class."
         },
         "isGetter": {
-          "description": "Whether the entity is a getter.",
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Whether the entity is a getter."
         },
         "isField": {
-          "description": "Whether the entity is a field.",
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Whether the entity is a field."
         },
         "isMethod": {
-          "description": "Whether the entity is a method.",
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Whether the entity is a method."
         },
         "isStatic": {
-          "description": "Whether the entity is static.",
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Whether the entity is static."
         }
       }
     },
     "QualifiedName": {
-      "description": "A URI combined with a name.",
-      "type": "string"
+      "type": "string",
+      "description": "A URI combined with a name."
     },
     "Query": {
       "type": "object",
@@ -251,6 +252,7 @@
       }
     },
     "StaticTypeDesc": {
+      "type": "object",
       "description": "A partially-resolved description of a type as it appears in Dart's type hierarchy.",
       "properties": {
         "type": {
@@ -258,21 +260,41 @@
         },
         "value": {
           "oneOf": [
-            {"$ref": "#/$defs/DynamicTypeDesc"},
-            {"$ref": "#/$defs/FunctionTypeDesc"},
-            {"$ref": "#/$defs/NeverTypeDesc"},
-            {"$ref": "#/$defs/NullableTypeDesc"},
-            {"$ref": "#/$defs/NamedTypeDesc"},
-            {"$ref": "#/$defs/RecordTypeDesc"},
-            {"$ref": "#/$defs/TypeParameterTypeDesc"},
-            {"$ref": "#/$defs/VoidTypeDesc"}
+            {
+              "$ref": "#/$defs/DynamicTypeDesc"
+            },
+            {
+              "$ref": "#/$defs/FunctionTypeDesc"
+            },
+            {
+              "$ref": "#/$defs/NamedTypeDesc"
+            },
+            {
+              "$ref": "#/$defs/NeverTypeDesc"
+            },
+            {
+              "$ref": "#/$defs/NullableTypeDesc"
+            },
+            {
+              "$ref": "#/$defs/RecordTypeDesc"
+            },
+            {
+              "$ref": "#/$defs/TypeParameterTypeDesc"
+            },
+            {
+              "$ref": "#/$defs/VoidTypeDesc"
+            }
           ]
-        }
+        },
+        "required": [
+          "type",
+          "value"
+        ]
       }
     },
     "StaticTypeParameterDesc": {
-      "description": "A resolved type parameter introduced by a [FunctionTypeDesc].",
       "type": "object",
+      "description": "A resolved type parameter introduced by a [FunctionTypeDesc].",
       "properties": {
         "identifier": {
           "type": "integer"
@@ -283,12 +305,12 @@
       }
     },
     "TypeHierarchy": {
-      "description": "View of a subset of a Dart program's type hierarchy as part of a queried model.",
       "type": "object",
+      "description": "View of a subset of a Dart program's type hierarchy as part of a queried model.",
       "properties": {
         "named": {
-          "description": "Map of qualified interface names to their resolved named type.",
           "type": "object",
+          "description": "Map of qualified interface names to their resolved named type.",
           "additionalProperties": {
             "$ref": "#/$defs/TypeHierarchyEntry"
           }
@@ -296,23 +318,23 @@
       }
     },
     "TypeHierarchyEntry": {
-      "description": "Entry of an interface in Dart's type hierarchy, along with supertypes.",
       "type": "object",
+      "description": "Entry of an interface in Dart's type hierarchy, along with supertypes.",
       "properties": {
         "typeParameters": {
-          "description": "Type parameters defined on this interface-defining element..",
           "type": "array",
+          "description": "Type parameters defined on this interface-defining element.",
           "items": {
             "$ref": "#/$defs/StaticTypeParameterDesc"
           }
         },
         "self": {
-          "description": "The named static type represented by this entry.",
+          "$comment": "The named static type represented by this entry.",
           "$ref": "#/$defs/NamedTypeDesc"
         },
         "supertypes": {
-          "description": "All direct supertypes of this type.",
           "type": "array",
+          "description": "All direct supertypes of this type.",
           "items": {
             "$ref": "#/$defs/NamedTypeDesc"
           }
@@ -320,8 +342,8 @@
       }
     },
     "TypeParameterTypeDesc": {
-      "description": "A type formed by a reference to a type parameter.",
       "type": "object",
+      "description": "A type formed by a reference to a type parameter.",
       "properties": {
         "parameterId": {
           "type": "integer"
@@ -329,8 +351,8 @@
       }
     },
     "VoidTypeDesc": {
-      "description": "The type-hierarchy representation of the type `void`.",
-      "type": "null"
+      "type": "null",
+      "description": "The type-hierarchy representation of the type `void`."
     }
   }
 }

--- a/schemas/macro_service.schema.json
+++ b/schemas/macro_service.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "anyOf": [
+  "oneOf": [
     {
       "$ref": "#/$defs/HostRequest"
     },
@@ -17,11 +17,11 @@
       "description": "A request to a macro to augment some code.",
       "properties": {
         "phase": {
-          "description": "Which phase to run: 1, 2 or 3.",
-          "type": "integer"
+          "type": "integer",
+          "description": "Which phase to run: 1, 2 or 3."
         },
         "target": {
-          "$comment": "The class to augment. TODO(davidmorgan): expand to more types of target",
+          "$comment": "The class to augment. TODO(davidmorgan): expand to more types of target.",
           "$ref": "file:dart_model.schema.json#/$defs/QualifiedName"
         }
       }
@@ -31,8 +31,8 @@
       "description": "Macro's response to an [AugmentRequest]: the resulting augmentations.",
       "properties": {
         "augmentations": {
-          "description": "The augmentations.",
           "type": "array",
+          "description": "The augmentations.",
           "items": {
             "$ref": "file:dart_model.schema.json#/$defs/Augmentation"
           }
@@ -44,8 +44,8 @@
       "description": "Request could not be handled.",
       "properties": {
         "error": {
-          "description": "The error.",
-          "type": "string"
+          "type": "string",
+          "description": "The error."
         }
       }
     },
@@ -54,18 +54,15 @@
       "description": "A macro host server endpoint. TODO(davidmorgan): this should be a oneOf supporting different types of connection. TODO(davidmorgan): it's not clear if this belongs in this package! But, where else?",
       "properties": {
         "port": {
-          "description": "TCP port to connect to.",
-          "type": "integer"
+          "type": "integer",
+          "description": "TCP port to connect to."
         }
       }
     },
     "HostRequest": {
-      "$description": "A request sent from host to macro.",
+      "type": "object",
+      "description": "A request sent from host to macro.",
       "properties": {
-        "id": {
-          "description": "The id of this request, must be returned in responses.",
-          "type": "integer"
-        },
         "type": {
           "type": "string"
         },
@@ -75,21 +72,25 @@
               "$ref": "#/$defs/AugmentRequest"
             }
           ]
-        }
-      },
-      "required": [
-        "id",
-        "type",
-        "value"
-      ]
+        },
+        "id": {
+          "type": "integer",
+          "description": "The id of this request, must be returned in responses."
+        },
+        "required": [
+          "id",
+          "type",
+          "value"
+        ]
+      }
     },
     "MacroDescription": {
       "type": "object",
       "description": "Information about a macro that the macro provides to the host.",
       "properties": {
         "runsInPhases": {
-          "description": "Phases that the macro runs in: 1, 2 and/or 3.",
           "type": "array",
+          "description": "Phases that the macro runs in: 1, 2 and/or 3.",
           "items": {
             "type": "integer"
           }
@@ -101,21 +102,20 @@
       "description": "Informs the host that a macro has started.",
       "properties": {
         "macroDescription": {
+          "$comment": "The macro description.",
           "$ref": "#/$defs/MacroDescription"
         }
       }
     },
     "MacroStartedResponse": {
       "type": "object",
-      "description": "Host's response to a [MacroStartedRequest]."
+      "description": "Host's response to a [MacroStartedRequest].",
+      "properties": {}
     },
     "MacroRequest": {
-      "$description": "A request sent from macro to host.",
+      "type": "object",
+      "description": "A request sent from macro to host.",
       "properties": {
-        "id": {
-          "description": "The id of this request, must be returned in responses.",
-          "type": "integer"
-        },
         "type": {
           "type": "string"
         },
@@ -128,13 +128,17 @@
               "$ref": "#/$defs/QueryRequest"
             }
           ]
-        }
-      },
-      "required": [
-        "id",
-        "type",
-        "value"
-      ]
+        },
+        "id": {
+          "type": "integer",
+          "description": "The id of this request, must be returned in responses."
+        },
+        "required": [
+          "id",
+          "type",
+          "value"
+        ]
+      }
     },
     "Protocol": {
       "type": "object",
@@ -151,6 +155,7 @@
       "description": "Macro's query about the code it should augment.",
       "properties": {
         "query": {
+          "$comment": "The query.",
           "$ref": "file:dart_model.schema.json#/$defs/Query"
         }
       }
@@ -160,17 +165,15 @@
       "description": "Host's response to a [QueryRequest].",
       "properties": {
         "model": {
+          "$comment": "The model.",
           "$ref": "file:dart_model.schema.json#/$defs/Model"
         }
       }
     },
     "Response": {
-      "$description": "A response to a request.",
+      "type": "object",
+      "description": "A response to a request",
       "properties": {
-        "requestId": {
-          "description": "The id of the request this is responding to.",
-          "type": "integer"
-        },
         "type": {
           "type": "string"
         },
@@ -189,13 +192,17 @@
               "$ref": "#/$defs/QueryResponse"
             }
           ]
-        }
-      },
-      "required": [
-        "requestId",
-        "type",
-        "value"
-      ]
+        },
+        "requestId": {
+          "type": "integer",
+          "description": "The id of the request this is responding to."
+        },
+        "required": [
+          "requestId",
+          "type",
+          "value"
+        ]
+      }
     }
   }
 }

--- a/tool/dart_model_generator/bin/main.dart
+++ b/tool/dart_model_generator/bin/main.dart
@@ -2,7 +2,10 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:generate_dart_model/generate_dart_model.dart'
-    as dart_model_generator;
+import 'package:generate_dart_model/definitions.dart';
 
-void main() => dart_model_generator.run();
+void main() {
+  for (final generationResult in schemas.generate()) {
+    generationResult.write();
+  }
+}

--- a/tool/dart_model_generator/lib/definitions.dart
+++ b/tool/dart_model_generator/lib/definitions.dart
@@ -13,111 +13,155 @@ final schemas = Schemas([
         'Model',
       ],
       declarations: [
-        Declaration.clazz(
+        Definition.clazz(
           'Augmentation',
-          'An augmentation to Dart code. '
+          description: 'An augmentation to Dart code. '
               'TODO(davidmorgan): this is a placeholder.',
-          [
-            Field('code', 'String', 'Augmentation code.'),
+          properties: [
+            Property('code', type: 'String', description: 'Augmentation code.'),
           ],
         ),
-        Declaration.nullTypedef('DynamicTypeDesc',
-            'The type-hierarchy representation of the type `dynamic`.'),
-        Declaration.clazz('FunctionTypeDesc',
-            'A static type representation for function types.', [
-          Field('returnType', 'StaticTypeDesc',
-              'The return type of this function type.'),
-          Field('typeParameters', 'List<StaticTypeParameterDesc>',
-              'Static type parameters introduced by this function type.'),
-          Field('requiredPositionalParameters', 'List<StaticTypeDesc>', ''),
-          Field('optionalPositionalParameters', 'List<StaticTypeDesc>', ''),
-          Field('namedParameters', 'List<NamedFunctionTypeParameter>', ''),
-        ]),
-        Declaration.clazz('MetadataAnnotation', 'A metadata annotation.', [
-          Field('type', 'QualifiedName', 'The type of the annotation.'),
-        ]),
-        Declaration.clazz(
-          'Interface',
-          'An interface.',
-          [
-            Field('metadataAnnotations', 'List<MetadataAnnotation>',
-                'The metadata annotations attached to this interface.'),
-            Field('members', 'Map<Member>', 'Map of members by name.'),
-            Field(
-                'thisType',
-                'NamedTypeDesc',
-                'The type of the expression `this` when used in this '
-                    'interface.'),
-            Field('properties', 'Properties',
-                'The properties of this interface.'),
-          ],
-        ),
-        Declaration.clazz('Library', 'Library.', [
-          Field('scopes', 'Map<Interface>', 'Scopes by name.'),
-        ]),
-        Declaration.clazz('Member', 'Member of a scope.', [
-          Field('properties', 'Properties', 'The properties of this member.'),
-        ]),
-        Declaration.clazz(
-            'Model', 'Partial model of a corpus of Dart source code.', [
-          Field('uris', 'Map<Library>', 'Libraries by URI.'),
-          Field(
-              'types', 'TypeHierarchy', 'The resolved static type hierarchy.'),
-        ]),
-        Declaration.clazz('NamedFunctionTypeParameter',
-            'A resolved named parameter as part of a [FunctionTypeDesc].', [
-          Field('name', 'String', ''),
-          Field('required', 'bool', ''),
-          Field('type', 'StaticTypeDesc', ''),
-        ]),
-        Declaration.clazz(
-            'NamedRecordField',
-            'A named field in a [RecordTypeDesc], consisting of the field name '
-                'and the associated type.',
-            [
-              Field('name', 'String', ''),
-              Field('type', 'StaticTypeDesc', ''),
+        Definition.nullTypedef('DynamicTypeDesc',
+            description:
+                'The type-hierarchy representation of the type `dynamic`.'),
+        Definition.clazz('FunctionTypeDesc',
+            description: 'A static type representation for function types.',
+            properties: [
+              Property('returnType',
+                  type: 'StaticTypeDesc',
+                  description: 'The return type of this function type.'),
+              Property('typeParameters',
+                  type: 'List<StaticTypeParameterDesc>',
+                  description:
+                      'Static type parameters introduced by this function '
+                      'type.'),
+              Property('requiredPositionalParameters',
+                  type: 'List<StaticTypeDesc>'),
+              Property('optionalPositionalParameters',
+                  type: 'List<StaticTypeDesc>'),
+              Property('namedParameters',
+                  type: 'List<NamedFunctionTypeParameter>'),
             ]),
-        Declaration.clazz('NamedTypeDesc', 'A resolved static type.', [
-          Field('name', 'QualifiedName', ''),
-          Field('instantiation', 'List<StaticTypeDesc>', ''),
-        ]),
-        Declaration.nullTypedef(
-            'NeverTypeDesc', 'Representation of the bottom type [Never].'),
-        Declaration.clazz(
-          'NullableTypeDesc',
-          'A Dart type of the form `T?` for an inner type `T`.',
-          [Field('inner', 'StaticTypeDesc', 'The type T.')],
+        Definition.clazz('MetadataAnnotation',
+            description: 'A metadata annotation.',
+            properties: [
+              Property('type',
+                  type: 'QualifiedName',
+                  description: 'The type of the annotation.'),
+            ]),
+        Definition.clazz(
+          'Interface',
+          description: 'An interface.',
+          properties: [
+            Property('metadataAnnotations',
+                type: 'List<MetadataAnnotation>',
+                description:
+                    'The metadata annotations attached to this interface.'),
+            Property('members',
+                type: 'Map<Member>', description: 'Map of members by name.'),
+            Property('thisType',
+                type: 'NamedTypeDesc',
+                description:
+                    'The type of the expression `this` when used in this '
+                    'interface.'),
+            Property('properties',
+                type: 'Properties',
+                description: 'The properties of this interface.'),
+          ],
         ),
-        Declaration.clazz('Properties', 'Set of boolean properties.', [
-          Field('isAbstract', 'bool',
-              'Whether the entity is abstract, meaning it has no definition.'),
-          Field('isClass', 'bool', 'Whether the entity is a class.'),
-          Field('isGetter', 'bool', 'Whether the entity is a getter.'),
-          Field('isField', 'bool', 'Whether the entity is a field.'),
-          Field('isMethod', 'bool', 'Whether the entity is a method.'),
-          Field('isStatic', 'bool', 'Whether the entity is static.'),
+        Definition.clazz('Library', description: 'Library.', properties: [
+          Property('scopes',
+              type: 'Map<Interface>', description: 'Scopes by name.'),
         ]),
-        Declaration.stringTypedef(
-            'QualifiedName', 'A URI combined with a name.'),
-        Declaration.clazz(
-            'Query',
-            'Query about a corpus of Dart source code. '
+        Definition.clazz('Member',
+            description: 'Member of a scope.',
+            properties: [
+              Property('properties',
+                  type: 'Properties',
+                  description: 'The properties of this member.'),
+            ]),
+        Definition.clazz('Model',
+            description: 'Partial model of a corpus of Dart source code.',
+            properties: [
+              Property('uris',
+                  type: 'Map<Library>', description: 'Libraries by URI.'),
+              Property('types',
+                  type: 'TypeHierarchy',
+                  description: 'The resolved static type hierarchy.'),
+            ]),
+        Definition.clazz('NamedFunctionTypeParameter',
+            description:
+                'A resolved named parameter as part of a [FunctionTypeDesc].',
+            properties: [
+              Property('name', type: 'String'),
+              Property('required', type: 'bool'),
+              Property('type', type: 'StaticTypeDesc'),
+            ]),
+        Definition.clazz('NamedRecordField',
+            description:
+                'A named field in a [RecordTypeDesc], consisting of the field '
+                'name and the associated type.',
+            properties: [
+              Property('name', type: 'String'),
+              Property('type', type: 'StaticTypeDesc'),
+            ]),
+        Definition.clazz('NamedTypeDesc',
+            description: 'A resolved static type.',
+            properties: [
+              Property('name', type: 'QualifiedName'),
+              Property('instantiation', type: 'List<StaticTypeDesc>'),
+            ]),
+        Definition.nullTypedef('NeverTypeDesc',
+            description: 'Representation of the bottom type [Never].'),
+        Definition.clazz(
+          'NullableTypeDesc',
+          description: 'A Dart type of the form `T?` for an inner type `T`.',
+          properties: [
+            Property('inner',
+                type: 'StaticTypeDesc', description: 'The type T.')
+          ],
+        ),
+        Definition.clazz('Properties',
+            description: 'Set of boolean properties.',
+            properties: [
+              Property('isAbstract',
+                  type: 'bool',
+                  description:
+                      'Whether the entity is abstract, meaning it has no '
+                      'definition.'),
+              Property('isClass',
+                  type: 'bool', description: 'Whether the entity is a class.'),
+              Property('isGetter',
+                  type: 'bool', description: 'Whether the entity is a getter.'),
+              Property('isField',
+                  type: 'bool', description: 'Whether the entity is a field.'),
+              Property('isMethod',
+                  type: 'bool', description: 'Whether the entity is a method.'),
+              Property('isStatic',
+                  type: 'bool', description: 'Whether the entity is static.'),
+            ]),
+        Definition.stringTypedef('QualifiedName',
+            description: 'A URI combined with a name.'),
+        Definition.clazz('Query',
+            description: 'Query about a corpus of Dart source code. '
                 'TODO(davidmorgan): this queries about a single class, expand '
                 'to a union type for different types of queries.',
-            [
-              Field('target', 'QualifiedName', 'The class to query about.'),
+            properties: [
+              Property('target',
+                  type: 'QualifiedName',
+                  description: 'The class to query about.'),
             ]),
-        Declaration.clazz(
-            'RecordTypeDesc', 'A resolved record type in the type hierarchy.', [
-          Field('positional', 'List<StaticTypeDesc>', ''),
-          Field('named', 'List<NamedRecordField>', '')
-        ]),
-        Declaration.union(
-            'StaticTypeDesc',
-            'A partially-resolved description of a type as it appears in '
+        Definition.clazz('RecordTypeDesc',
+            description: 'A resolved record type in the type hierarchy.',
+            properties: [
+              Property('positional', type: 'List<StaticTypeDesc>'),
+              Property('named', type: 'List<NamedRecordField>')
+            ]),
+        Definition.union('StaticTypeDesc',
+            description:
+                'A partially-resolved description of a type as it appears in '
                 "Dart's type hierarchy.",
-            [
+            types: [
               'DynamicTypeDesc',
               'FunctionTypeDesc',
               'NamedTypeDesc',
@@ -127,44 +171,51 @@ final schemas = Schemas([
               'TypeParameterTypeDesc',
               'VoidTypeDesc',
             ],
-            []),
-        Declaration.clazz('StaticTypeParameterDesc',
-            'A resolved type parameter introduced by a [FunctionTypeDesc].', [
-          Field('identifier', 'int', ''),
-          Field('bound', 'StaticTypeDesc', '')
-        ]),
-        Declaration.clazz(
-            'TypeHierarchy',
-            "View of a subset of a Dart program's type hierarchy as part of a "
-                'queried model.',
-            [
-              Field(
-                  'named',
-                  'Map<TypeHierarchyEntry>',
-                  'Map of qualified interface names to their resolved named '
-                      'type.')
+            properties: []),
+        Definition.clazz('StaticTypeParameterDesc',
+            description:
+                'A resolved type parameter introduced by a [FunctionTypeDesc].',
+            properties: [
+              Property('identifier', type: 'int'),
+              Property('bound', type: 'StaticTypeDesc')
             ]),
-        Declaration.clazz(
-            'TypeHierarchyEntry',
-            "Entry of an interface in Dart's type hierarchy, along with "
+        Definition.clazz('TypeHierarchy',
+            description:
+                "View of a subset of a Dart program's type hierarchy as part "
+                'of a queried model.',
+            properties: [
+              Property('named',
+                  type: 'Map<TypeHierarchyEntry>',
+                  description:
+                      'Map of qualified interface names to their resolved '
+                      'named type.')
+            ]),
+        Definition.clazz('TypeHierarchyEntry',
+            description:
+                "Entry of an interface in Dart's type hierarchy, along with "
                 'supertypes.',
-            [
-              Field(
-                  'typeParameters',
-                  'List<StaticTypeParameterDesc>',
-                  'Type parameters defined on this interface-defining '
+            properties: [
+              Property('typeParameters',
+                  type: 'List<StaticTypeParameterDesc>',
+                  description:
+                      'Type parameters defined on this interface-defining '
                       'element.'),
-              Field('self', 'NamedTypeDesc',
-                  'The named static type represented by this entry.'),
-              Field('supertypes', 'List<NamedTypeDesc>',
-                  'All direct supertypes of this type.'),
+              Property('self',
+                  type: 'NamedTypeDesc',
+                  description:
+                      'The named static type represented by this entry.'),
+              Property('supertypes',
+                  type: 'List<NamedTypeDesc>',
+                  description: 'All direct supertypes of this type.'),
             ]),
-        Declaration.clazz('TypeParameterTypeDesc',
-            'A type formed by a reference to a type parameter.', [
-          Field('parameterId', 'int', ''),
-        ]),
-        Declaration.nullTypedef('VoidTypeDesc',
-            'The type-hierarchy representation of the type `void`.'),
+        Definition.clazz('TypeParameterTypeDesc',
+            description: 'A type formed by a reference to a type parameter.',
+            properties: [
+              Property('parameterId', type: 'int'),
+            ]),
+        Definition.nullTypedef('VoidTypeDesc',
+            description:
+                'The type-hierarchy representation of the type `void`.'),
       ]),
   Schema(
       schemaPath: 'macro_service.schema.json',
@@ -176,94 +227,118 @@ final schemas = Schemas([
         'Response',
       ],
       declarations: [
-        Declaration.clazz(
-            'AugmentRequest', 'A request to a macro to augment some code.', [
-          Field('phase', 'int', 'Which phase to run: 1, 2 or 3.'),
-          Field(
-              'target',
-              'QualifiedName',
-              'The class to augment. '
-                  'TODO(davidmorgan): expand to more types of target.'),
-        ]),
-        Declaration.clazz(
-            'AugmentResponse',
-            "Macro's response to an [AugmentRequest]: the resulting "
-                'augmentations.',
-            [
-              Field(
-                  'augmentations', 'List<Augmentation>', 'The augmentations.'),
+        Definition.clazz('AugmentRequest',
+            description: 'A request to a macro to augment some code.',
+            properties: [
+              Property('phase',
+                  type: 'int', description: 'Which phase to run: 1, 2 or 3.'),
+              Property('target',
+                  type: 'QualifiedName',
+                  description: 'The class to augment. '
+                      'TODO(davidmorgan): expand to more types of target.'),
             ]),
-        Declaration.clazz('ErrorResponse', 'Request could not be handled.', [
-          Field('error', 'String', 'The error.'),
-        ]),
-        Declaration.clazz(
-            'HostEndpoint',
-            'A macro host server endpoint. TODO(davidmorgan): this should be a '
-                'oneOf supporting different types of connection. '
+        Definition.clazz('AugmentResponse',
+            description:
+                "Macro's response to an [AugmentRequest]: the resulting "
+                'augmentations.',
+            properties: [
+              Property('augmentations',
+                  type: 'List<Augmentation>',
+                  description: 'The augmentations.'),
+            ]),
+        Definition.clazz('ErrorResponse',
+            description: 'Request could not be handled.',
+            properties: [
+              Property('error', type: 'String', description: 'The error.'),
+            ]),
+        Definition.clazz('HostEndpoint',
+            description:
+                'A macro host server endpoint. TODO(davidmorgan): this should '
+                'be a oneOf supporting different types of connection. '
                 "TODO(davidmorgan): it's not clear if this belongs in this "
                 'package! But, where else?',
-            [
-              Field('port', 'int', 'TCP port to connect to.'),
+            properties: [
+              Property('port',
+                  type: 'int', description: 'TCP port to connect to.'),
             ]),
-        Declaration.union('HostRequest', 'A request sent from host to macro.', [
-          'AugmentRequest'
-        ], [
-          Field('id', 'int',
-              'The id of this request, must be returned in responses.',
-              required: true),
-        ]),
-        Declaration.clazz('MacroDescription',
-            'Information about a macro that the macro provides to the host.', [
-          Field('runsInPhases', 'List<int>',
-              'Phases that the macro runs in: 1, 2 and/or 3.'),
-        ]),
-        Declaration.clazz(
+        Definition.union('HostRequest',
+            description: 'A request sent from host to macro.',
+            types: [
+              'AugmentRequest'
+            ],
+            properties: [
+              Property('id',
+                  type: 'int',
+                  description:
+                      'The id of this request, must be returned in responses.',
+                  required: true),
+            ]),
+        Definition.clazz('MacroDescription',
+            description:
+                'Information about a macro that the macro provides to the '
+                'host.',
+            properties: [
+              Property('runsInPhases',
+                  type: 'List<int>',
+                  description: 'Phases that the macro runs in: 1, 2 and/or 3.'),
+            ]),
+        Definition.clazz(
           'MacroStartedRequest',
-          'Informs the host that a macro has started.',
-          [
-            Field('macroDescription', 'MacroDescription',
-                'The macro description.'),
+          description: 'Informs the host that a macro has started.',
+          properties: [
+            Property('macroDescription',
+                type: 'MacroDescription',
+                description: 'The macro description.'),
           ],
         ),
-        Declaration.clazz('MacroStartedResponse',
-            "Host's response to a [MacroStartedRequest].", []),
-        Declaration.union(
-            'MacroRequest', 'A request sent from macro to host.', [
-          'MacroStartedRequest',
-          'QueryRequest',
-        ], [
-          Field('id', 'int',
-              'The id of this request, must be returned in responses.',
-              required: true),
-        ]),
-        Declaration.clazz(
-            'Protocol',
-            'The macro to host protocol version and encoding. '
+        Definition.clazz('MacroStartedResponse',
+            description: "Host's response to a [MacroStartedRequest].",
+            properties: []),
+        Definition.union('MacroRequest',
+            description: 'A request sent from macro to host.',
+            types: [
+              'MacroStartedRequest',
+              'QueryRequest',
+            ],
+            properties: [
+              Property('id',
+                  type: 'int',
+                  description:
+                      'The id of this request, must be returned in responses.',
+                  required: true),
+            ]),
+        Definition.clazz('Protocol',
+            description: 'The macro to host protocol version and encoding. '
                 'TODO(davidmorgan): add the version.',
-            [
-              Field(
-                  'encoding',
-                  'String',
-                  'The wire format: json or binary. '
+            properties: [
+              Property('encoding',
+                  type: 'String',
+                  description: 'The wire format: json or binary. '
                       'TODO(davidmorgan): use an enum?'),
             ]),
-        Declaration.clazz(
-            'QueryRequest', "Macro's query about the code it should augment.", [
-          Field('query', 'Query', 'The query.'),
-        ]),
-        Declaration.clazz(
-            'QueryResponse', "Host's response to a [QueryRequest].", [
-          Field('model', 'Model', 'The model.'),
-        ]),
-        Declaration.union('Response', 'A response to a request', [
-          'AugmentResponse',
-          'ErrorResponse',
-          'MacroStartedResponse',
-          'QueryResponse',
-        ], [
-          Field('requestId', 'int',
-              'The id of the request this is responding to.',
-              required: true),
-        ]),
+        Definition.clazz('QueryRequest',
+            description: "Macro's query about the code it should augment.",
+            properties: [
+              Property('query', type: 'Query', description: 'The query.'),
+            ]),
+        Definition.clazz('QueryResponse',
+            description: "Host's response to a [QueryRequest].",
+            properties: [
+              Property('model', type: 'Model', description: 'The model.'),
+            ]),
+        Definition.union('Response',
+            description: 'A response to a request',
+            types: [
+              'AugmentResponse',
+              'ErrorResponse',
+              'MacroStartedResponse',
+              'QueryResponse',
+            ],
+            properties: [
+              Property('requestId',
+                  type: 'int',
+                  description: 'The id of the request this is responding to.',
+                  required: true),
+            ]),
       ]),
 ]);

--- a/tool/dart_model_generator/lib/definitions.dart
+++ b/tool/dart_model_generator/lib/definitions.dart
@@ -1,0 +1,269 @@
+// Copyright (c) 2024, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'generate_dart_model.dart';
+
+final schemas = Schemas([
+  Schema(
+      schemaPath: 'dart_model.schema.json',
+      codePackage: 'dart_model',
+      codePath: 'src/dart_model.g.dart',
+      rootTypes: [
+        'Model',
+      ],
+      declarations: [
+        Declaration.clazz(
+          'Augmentation',
+          'An augmentation to Dart code. '
+              'TODO(davidmorgan): this is a placeholder.',
+          [
+            Field('code', 'String', 'Augmentation code.'),
+          ],
+        ),
+        Declaration.nullTypedef('DynamicTypeDesc',
+            'The type-hierarchy representation of the type `dynamic`.'),
+        Declaration.clazz('FunctionTypeDesc',
+            'A static type representation for function types.', [
+          Field('returnType', 'StaticTypeDesc',
+              'The return type of this function type.'),
+          Field('typeParameters', 'List<StaticTypeParameterDesc>',
+              'Static type parameters introduced by this function type.'),
+          Field('requiredPositionalParameters', 'List<StaticTypeDesc>', ''),
+          Field('optionalPositionalParameters', 'List<StaticTypeDesc>', ''),
+          Field('namedParameters', 'List<NamedFunctionTypeParameter>', ''),
+        ]),
+        Declaration.clazz('MetadataAnnotation', 'A metadata annotation.', [
+          Field('type', 'QualifiedName', 'The type of the annotation.'),
+        ]),
+        Declaration.clazz(
+          'Interface',
+          'An interface.',
+          [
+            Field('metadataAnnotations', 'List<MetadataAnnotation>',
+                'The metadata annotations attached to this interface.'),
+            Field('members', 'Map<Member>', 'Map of members by name.'),
+            Field(
+                'thisType',
+                'NamedTypeDesc',
+                'The type of the expression `this` when used in this '
+                    'interface.'),
+            Field('properties', 'Properties',
+                'The properties of this interface.'),
+          ],
+        ),
+        Declaration.clazz('Library', 'Library.', [
+          Field('scopes', 'Map<Interface>', 'Scopes by name.'),
+        ]),
+        Declaration.clazz('Member', 'Member of a scope.', [
+          Field('properties', 'Properties', 'The properties of this member.'),
+        ]),
+        Declaration.clazz(
+            'Model', 'Partial model of a corpus of Dart source code.', [
+          Field('uris', 'Map<Library>', 'Libraries by URI.'),
+          Field(
+              'types', 'TypeHierarchy', 'The resolved static type hierarchy.'),
+        ]),
+        Declaration.clazz('NamedFunctionTypeParameter',
+            'A resolved named parameter as part of a [FunctionTypeDesc].', [
+          Field('name', 'String', ''),
+          Field('required', 'bool', ''),
+          Field('type', 'StaticTypeDesc', ''),
+        ]),
+        Declaration.clazz(
+            'NamedRecordField',
+            'A named field in a [RecordTypeDesc], consisting of the field name '
+                'and the associated type.',
+            [
+              Field('name', 'String', ''),
+              Field('type', 'StaticTypeDesc', ''),
+            ]),
+        Declaration.clazz('NamedTypeDesc', 'A resolved static type.', [
+          Field('name', 'QualifiedName', ''),
+          Field('instantiation', 'List<StaticTypeDesc>', ''),
+        ]),
+        Declaration.nullTypedef(
+            'NeverTypeDesc', 'Representation of the bottom type [Never].'),
+        Declaration.clazz(
+          'NullableTypeDesc',
+          'A Dart type of the form `T?` for an inner type `T`.',
+          [Field('inner', 'StaticTypeDesc', 'The type T.')],
+        ),
+        Declaration.clazz('Properties', 'Set of boolean properties.', [
+          Field('isAbstract', 'bool',
+              'Whether the entity is abstract, meaning it has no definition.'),
+          Field('isClass', 'bool', 'Whether the entity is a class.'),
+          Field('isGetter', 'bool', 'Whether the entity is a getter.'),
+          Field('isField', 'bool', 'Whether the entity is a field.'),
+          Field('isMethod', 'bool', 'Whether the entity is a method.'),
+          Field('isStatic', 'bool', 'Whether the entity is static.'),
+        ]),
+        Declaration.stringTypedef(
+            'QualifiedName', 'A URI combined with a name.'),
+        Declaration.clazz(
+            'Query',
+            'Query about a corpus of Dart source code. '
+                'TODO(davidmorgan): this queries about a single class, expand '
+                'to a union type for different types of queries.',
+            [
+              Field('target', 'QualifiedName', 'The class to query about.'),
+            ]),
+        Declaration.clazz(
+            'RecordTypeDesc', 'A resolved record type in the type hierarchy.', [
+          Field('positional', 'List<StaticTypeDesc>', ''),
+          Field('named', 'List<NamedRecordField>', '')
+        ]),
+        Declaration.union(
+            'StaticTypeDesc',
+            'A partially-resolved description of a type as it appears in '
+                "Dart's type hierarchy.",
+            [
+              'DynamicTypeDesc',
+              'FunctionTypeDesc',
+              'NamedTypeDesc',
+              'NeverTypeDesc',
+              'NullableTypeDesc',
+              'RecordTypeDesc',
+              'TypeParameterTypeDesc',
+              'VoidTypeDesc',
+            ],
+            []),
+        Declaration.clazz('StaticTypeParameterDesc',
+            'A resolved type parameter introduced by a [FunctionTypeDesc].', [
+          Field('identifier', 'int', ''),
+          Field('bound', 'StaticTypeDesc', '')
+        ]),
+        Declaration.clazz(
+            'TypeHierarchy',
+            "View of a subset of a Dart program's type hierarchy as part of a "
+                'queried model.',
+            [
+              Field(
+                  'named',
+                  'Map<TypeHierarchyEntry>',
+                  'Map of qualified interface names to their resolved named '
+                      'type.')
+            ]),
+        Declaration.clazz(
+            'TypeHierarchyEntry',
+            "Entry of an interface in Dart's type hierarchy, along with "
+                'supertypes.',
+            [
+              Field(
+                  'typeParameters',
+                  'List<StaticTypeParameterDesc>',
+                  'Type parameters defined on this interface-defining '
+                      'element.'),
+              Field('self', 'NamedTypeDesc',
+                  'The named static type represented by this entry.'),
+              Field('supertypes', 'List<NamedTypeDesc>',
+                  'All direct supertypes of this type.'),
+            ]),
+        Declaration.clazz('TypeParameterTypeDesc',
+            'A type formed by a reference to a type parameter.', [
+          Field('parameterId', 'int', ''),
+        ]),
+        Declaration.nullTypedef('VoidTypeDesc',
+            'The type-hierarchy representation of the type `void`.'),
+      ]),
+  Schema(
+      schemaPath: 'macro_service.schema.json',
+      codePackage: 'macro_service',
+      codePath: 'src/macro_service.g.dart',
+      rootTypes: [
+        'HostRequest',
+        'MacroRequest',
+        'Response',
+      ],
+      declarations: [
+        Declaration.clazz(
+            'AugmentRequest', 'A request to a macro to augment some code.', [
+          Field('phase', 'int', 'Which phase to run: 1, 2 or 3.'),
+          Field(
+              'target',
+              'QualifiedName',
+              'The class to augment. '
+                  'TODO(davidmorgan): expand to more types of target.'),
+        ]),
+        Declaration.clazz(
+            'AugmentResponse',
+            "Macro's response to an [AugmentRequest]: the resulting "
+                'augmentations.',
+            [
+              Field(
+                  'augmentations', 'List<Augmentation>', 'The augmentations.'),
+            ]),
+        Declaration.clazz('ErrorResponse', 'Request could not be handled.', [
+          Field('error', 'String', 'The error.'),
+        ]),
+        Declaration.clazz(
+            'HostEndpoint',
+            'A macro host server endpoint. TODO(davidmorgan): this should be a '
+                'oneOf supporting different types of connection. '
+                "TODO(davidmorgan): it's not clear if this belongs in this "
+                'package! But, where else?',
+            [
+              Field('port', 'int', 'TCP port to connect to.'),
+            ]),
+        Declaration.union('HostRequest', 'A request sent from host to macro.', [
+          'AugmentRequest'
+        ], [
+          Field('id', 'int',
+              'The id of this request, must be returned in responses.',
+              required: true),
+        ]),
+        Declaration.clazz('MacroDescription',
+            'Information about a macro that the macro provides to the host.', [
+          Field('runsInPhases', 'List<int>',
+              'Phases that the macro runs in: 1, 2 and/or 3.'),
+        ]),
+        Declaration.clazz(
+          'MacroStartedRequest',
+          'Informs the host that a macro has started.',
+          [
+            Field('macroDescription', 'MacroDescription',
+                'The macro description.'),
+          ],
+        ),
+        Declaration.clazz('MacroStartedResponse',
+            "Host's response to a [MacroStartedRequest].", []),
+        Declaration.union(
+            'MacroRequest', 'A request sent from macro to host.', [
+          'MacroStartedRequest',
+          'QueryRequest',
+        ], [
+          Field('id', 'int',
+              'The id of this request, must be returned in responses.',
+              required: true),
+        ]),
+        Declaration.clazz(
+            'Protocol',
+            'The macro to host protocol version and encoding. '
+                'TODO(davidmorgan): add the version.',
+            [
+              Field(
+                  'encoding',
+                  'String',
+                  'The wire format: json or binary. '
+                      'TODO(davidmorgan): use an enum?'),
+            ]),
+        Declaration.clazz(
+            'QueryRequest', "Macro's query about the code it should augment.", [
+          Field('query', 'Query', 'The query.'),
+        ]),
+        Declaration.clazz(
+            'QueryResponse', "Host's response to a [QueryRequest].", [
+          Field('model', 'Model', 'The model.'),
+        ]),
+        Declaration.union('Response', 'A response to a request', [
+          'AugmentResponse',
+          'ErrorResponse',
+          'MacroStartedResponse',
+          'QueryResponse',
+        ], [
+          Field('requestId', 'int',
+              'The id of the request this is responding to.',
+              required: true),
+        ]),
+      ]),
+]);

--- a/tool/dart_model_generator/lib/generate_dart_model.dart
+++ b/tool/dart_model_generator/lib/generate_dart_model.dart
@@ -3,139 +3,408 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:convert';
+import 'dart:core' hide Type;
 import 'dart:io';
 
 import 'package:dart_style/dart_style.dart';
-import 'package:json_schema/json_schema.dart';
-// ignore: implementation_imports
-import 'package:json_schema/src/json_schema/models/ref_provider.dart';
 
-/// Generates `pkgs/dart_model/lib/src/dart_model.g.dart` from
-/// `schemas/dart_model.schema.json`, and similarly for `macro_service`.
-///
-/// Generated types are extension types with JSON maps as the underlying data.
-/// They have a `fromJson` constructor that takes that JSON, and a no-name
-/// constructor that builds it.
-void run() {
-  File('pkgs/dart_model/lib/src/dart_model.g.dart').writeAsStringSync(
-      generate(File('schemas/dart_model.schema.json').readAsStringSync()));
-  File('pkgs/macro_service/lib/src/macro_service.g.dart').writeAsStringSync(
-      generate(File('schemas/macro_service.schema.json').readAsStringSync(),
-          importDartModel: true));
-}
+/// Context for codegen: all the schemas, so types can be looked up.
+class GenerationContext {
+  /// All schemas.
+  final Schemas schemas;
 
-/// Generates and returns code for [schemaJson].
-String generate(String schemaJson,
-    {bool importDartModel = false,
-    bool importMacroService = false,
-    String? dartModelJson}) {
-  final result = <String>[
-    '// This file is generated. To make changes edit schemas/*.schema.json',
-    '// then run from the repo root: '
-        'dart tool/dart_model_generator/bin/main.dart',
-    '',
-    if (importDartModel) "import 'package:dart_model/dart_model.dart';",
-  ];
-  final schema = JsonSchema.create(schemaJson,
-      refProvider: LocalRefProvider(dartModelJson ??
-          File('schemas/dart_model.schema.json').readAsStringSync()));
-  final allDefinitions = <String, JsonSchema>{
-    for (final def in schema.defs.entries) def.key: def.value,
-  };
+  /// The schema codegen is running for.
+  final Schema currentSchema;
 
-  for (final MapEntry(:key, :value) in allDefinitions.entries) {
-    if (_isUnion(value)) {
-      result.add(_generateUnion(
-        key,
-        value,
-        allDefinitions: allDefinitions,
-      ));
+  GenerationContext(this.schemas, this.currentSchema);
+
+  /// Gets the path needed for a `"$ref"` JSON schema reference.
+  ///
+  /// Looks up which schema it's in; if it's not the current schema, returns a
+  /// path with the filename.
+  String lookupReferencePath(String typeName) {
+    final schema = lookupDeclaringSchema(typeName);
+    if (schema == null) {
+      throw ArgumentError('No schema declares type: $typeName');
+    } else if (schema == currentSchema) {
+      // It's in this schema.
+      return '#/\$defs/$typeName';
     } else {
-      result.add(_generateExtensionType(key, value));
+      // It needs a reference to the schema filename.
+      return 'file:${schema.schemaPath}#/\$defs/$typeName';
     }
   }
-  return DartFormatter().formatSource(SourceCode(result.join('\n'))).text;
-}
 
-/// The Dart type used to represent the JSON value for [definition].
-///
-/// This is most commonly a `Map<String, Object?>`, but can also be a JSON
-/// primitive type for simpler definitions.
-String _dartJsonType(JsonSchema definition) {
-  return switch (definition.type) {
-    SchemaType.object => 'Map<String, Object?>',
-    SchemaType.string => 'String',
-    SchemaType.nullValue => 'Null',
-    _ => throw UnsupportedError('Unsupported type: ${definition.type}'),
-  };
-}
-
-String _generateExtensionType(String name, JsonSchema definition) {
-  final result = StringBuffer();
-
-  // Generate the extension type header with `fromJson` constructor and the
-  // appropriate underlying type.
-  final jsonType = switch (definition.type) {
-    SchemaType.object => 'Map<String, Object?> node',
-    SchemaType.string => 'String string',
-    SchemaType.nullValue => 'Null _',
-    _ => throw UnsupportedError('Schema type ${definition.type}.'),
-  };
-  if (definition.description != null) {
-    result.writeln('/// ${definition.description}');
-  }
-  result.write('extension type $name.fromJson($jsonType)');
-  if (definition.type != SchemaType.nullValue) {
-    result.write(' implements Object');
-  }
-  result.writeln(' {');
-
-  // Generate the non-JSON constructor, which accepts an optional value for
-  // every field and constructs JSON from it.
-  final propertyMetadatas = [
-    for (var e in definition.properties.entries)
-      _readPropertyMetadata(e.key, e.value)
-  ];
-  switch (definition.type) {
-    case SchemaType.object:
-      if (propertyMetadatas.isEmpty) {
-        result.writeln('  $name() : this.fromJson({});');
-      } else {
-        result.writeln('  $name({');
-        for (final property in propertyMetadatas) {
-          result.writeParameter(property, definition);
-        }
-        result.writeln('}) : this.fromJson({');
-        for (final property in propertyMetadatas) {
-          result.writeMapElement(property, definition);
-        }
-        result.writeln('});');
+  /// Gets the schema that declares [typeName], or `null` if no schema does.
+  Schema? lookupDeclaringSchema(String typeName) {
+    for (final schema in schemas.schemas) {
+      if (schema.hasType(typeName)) {
+        return schema;
       }
-    case SchemaType.string:
-      result.writeln('$name(String string) : this.fromJson(string);');
-    case SchemaType.nullValue:
-      result.writeln('$name(): this.fromJson(null);');
-    default:
-      throw UnsupportedError('Unsupported type: ${definition.type}');
+    }
+    return null;
   }
 
-  for (final property in propertyMetadatas) {
-    result.writePropertyGetter(property);
+  /// Gets the declaration of the type named [typeName], or throws if it is not
+  /// declared in any schema.
+  Declaration lookupDeclaration(String typeName) {
+    final result = lookupDeclaringSchema(typeName)
+        ?.declarations
+        .where((d) => d.name == typeName)
+        .singleOrNull;
+    if (result == null) throw ArgumentError('Unknown type: $typeName');
+    return result;
   }
-  result.writeln('}');
-  return result.toString();
+
+  /// Generates any needed import statements.
+  Set<String> generateImports() {
+    // Find any types declared in schemas other than the current schema, add
+    // imports for them.
+    final schemas = {
+      for (final typeName in currentSchema.allTypeNames)
+        lookupDeclaringSchema(typeName),
+    }.nonNulls;
+    return {
+      '// ignore: implementation_imports',
+      for (final schema in schemas)
+        if (schema != currentSchema)
+          "import 'package:${schema.codePackage}/${schema.codePath}';",
+    };
+  }
 }
 
-/// Whether [schema] represents a union type.
-///
-/// To be a union type it must have exactly two properties, "type" and "value",
-/// where "type" is a "string" and "value" is a "oneOf".
-bool _isUnion(JsonSchema schema) =>
-    schema.properties['type']?.schemaMap!['type'] == 'string' &&
-    schema.properties['value']?.oneOf != null;
+/// A codegen result and the path it should be written to.
+class GenerationResult {
+  final String path;
+  final String content;
+  GenerationResult({required this.path, required this.content});
 
-/// Generates a type called [name] that is a union of the specified `oneOf`
-/// types, which must all be `$ref`s to class definitions.
+  void write() {
+    File(path).writeAsStringSync(content);
+  }
+}
+
+/// A list of definitions of JSON schemas.
+class Schemas {
+  final List<Schema> schemas;
+  Schemas(this.schemas);
+
+  /// Generates JSON schemas and Dart code.
+  List<GenerationResult> generate() {
+    final result = <GenerationResult>[];
+    for (final schema in schemas) {
+      final context = GenerationContext(this, schema);
+      final generatedSchema = const JsonEncoder.withIndent('  ')
+          .convert(schema.generateSchema(context));
+      result.add(GenerationResult(
+          path: 'schemas/${schema.schemaPath}', content: '$generatedSchema\n'));
+
+      final generatedCode = _format(schema.generateCode(context));
+      result.add(GenerationResult(
+          path: 'pkgs/${schema.codePackage}/lib/${schema.codePath}',
+          content: generatedCode));
+    }
+    return result;
+  }
+}
+
+/// Definition of a JSON schema.
+class Schema {
+  /// The path to write the generated JSON schema to.
+  final String schemaPath;
+
+  /// The package to write the generated Dart code to.
+  final String codePackage;
+
+  /// The path in [codePackage] to write the generated Dart code to.
+  final String codePath;
+
+  /// The top level valid types of the schema.
+  final List<String> rootTypes;
+
+  /// The types declared in the schema.
+  final List<Declaration> declarations;
+
+  Schema({
+    required this.schemaPath,
+    required this.codePackage,
+    required this.codePath,
+    required this.rootTypes,
+    required this.declarations,
+  });
+
+  /// Whether [typeName] is declared in this schema.
+  bool hasType(String typeName) => declarations.any((d) => d.name == typeName);
+
+  /// Generates JSON schema corresponding to this schema definition.
+  Map<String, Object?> generateSchema(GenerationContext context) => {
+        r'$schema': 'https://json-schema.org/draft/2020-12/schema',
+        'oneOf': [
+          for (var type in rootTypes)
+            TypeReference(type).generateSchema(context),
+        ],
+        r'$defs': {
+          for (var declaration in declarations)
+            declaration.name: declaration.generateSchema(context),
+        }
+      };
+
+  /// Generates Dart code corresponding to this schema definition.
+  String generateCode(GenerationContext context) {
+    final result = StringBuffer('''
+// This file is generated. To make changes edit tool/dart_model_generator
+// then run from the repo root: dart tool/dart_model_generator/bin/main.dart
+''');
+
+    for (final import in context.generateImports()) {
+      result.writeln(import);
+    }
+
+    for (final declaration in declarations) {
+      result.writeln(declaration.generateCode(context));
+    }
+
+    return result.toString();
+  }
+
+  /// The names of all types referenced in this schema.
+  Set<String> get allTypeNames => {
+        ...rootTypes,
+        for (final declaration in declarations) ...declaration.allTypeNames
+      };
+}
+
+/// Declaration of a type.
+abstract class Declaration {
+  /// The name of the declared type.
+  String get name;
+
+  /// Declares a class.
+  factory Declaration.clazz(
+    String name,
+    String description,
+    List<Field> properties,
+  ) = ClassTypeDeclaration;
+
+  /// Declares a union.
+  factory Declaration.union(String name, String description, List<String> types,
+      List<Field> fields) = UnionTypeDeclaration;
+
+  /// Declares a named type represented in JSON as a string.
+  factory Declaration.stringTypedef(String name, String description) =
+      StringTypedefDeclaration;
+
+  /// Declares a named type represented in JSON as `null`.
+  factory Declaration.nullTypedef(String name, String description) =
+      NullTypedefDeclaration;
+
+  /// Generates JSON schema for this type.
+  Map<String, Object?> generateSchema(GenerationContext context);
+
+  /// Generates Dart code for this type.
+  String generateCode(GenerationContext context);
+
+  /// The names of all types referenced in this declaration.
+  Set<String> get allTypeNames;
+
+  /// The Dart type name of the wire representation of this type.
+  String get representationTypeName;
+}
+
+/// A field in a declaration.
+class Field {
+  String name;
+  TypeReference type;
+  String description;
+  bool required;
+
+  /// Field with [name], [type], [description] and optionally [required].
+  ///
+  /// Pass empty [description] for no description.
+  Field(this.name, String type, this.description, {this.required = false})
+      : type = TypeReference(type);
+
+  /// Generates JSON schema for this type.
+  Map<String, Object?> generateSchema(GenerationContext context) => {
+        name: type.generateSchema(context,
+            description: description.isEmpty ? null : description),
+      };
+
+  /// Dart code for declaring a parameter corresponding to this field.
+  String get parameterCode => '${required ? 'required ' : ''}'
+      '${type.dartType}${required ? '' : '?'} $name,';
+
+  /// Dart code for passing a named argument corresponding to this field.
+  String get namedArgumentCode =>
+      "${required ? '' : 'if ($name != null) '}'$name': $name,";
+
+  /// Dart code for a getter for this field.
+  String get getterCode {
+    if (type.isMap) {
+      return _describe(
+          "${type.dartType} get $name => (node['$name'] as Map).cast();");
+    } else if (type.isList) {
+      return _describe(
+          "${type.dartType} get $name => (node['$name'] as List).cast();");
+    } else {
+      return _describe(
+          "${type.dartType} get $name => node['$name'] as ${type.dartType};");
+    }
+  }
+
+  String _describe(String code) =>
+      description.isEmpty ? code : '/// $description\n$code';
+
+  /// The names of all types referenced by this field.
+  Set<String> get allTypeNames {
+    if (type.isMap) return {'Map', type.elementType!};
+    if (type.isList) return {'List', type.elementType!};
+    return {type.name};
+  }
+}
+
+/// A reference to a type.
+///
+/// Either a reference to a user type, which will use `$ref` in the generated
+/// schema, or a reference to a built-in type, which can be described directly.
+///
+/// Collections can use names `List<Foo>` and `Map<Foo>`. The `Map` type only
+/// has one parameter because keys are always `String` in JSON.
+class TypeReference {
+  static final RegExp _simpleRegexp = RegExp(r'^[A-Za-z]+$');
+  static final RegExp _mapRegexp = RegExp(r'^Map<([A-Za-z]+)>$');
+  static final RegExp _listRegexp = RegExp(r'^List<([A-Za-z]+)>$');
+
+  String name;
+  late final bool isMap;
+  late final bool isList;
+  late final String? elementType;
+
+  TypeReference(this.name) {
+    if (_simpleRegexp.hasMatch(name)) {
+      isMap = false;
+      isList = false;
+      elementType = null;
+    } else if (_mapRegexp.hasMatch(name)) {
+      isMap = true;
+      isList = false;
+      elementType = _mapRegexp.firstMatch(name)!.group(1);
+    } else if (_listRegexp.hasMatch(name)) {
+      isMap = false;
+      isList = true;
+      elementType = _listRegexp.firstMatch(name)!.group(1);
+    } else {
+      throw ArgumentError('Invalid type name: $name');
+    }
+  }
+
+  /// The Dart type name of this type.
+  String get dartType {
+    if (isMap) return 'Map<String, $elementType>';
+    return name;
+  }
+
+  /// Generates JSON schema for this type.
+  Map<String, Object?> generateSchema(GenerationContext context,
+      {String? description}) {
+    if (isList) {
+      return {
+        'type': 'array',
+        if (description != null) 'description': description,
+        'items': TypeReference(elementType!).generateSchema(context),
+      };
+    } else if (isMap) {
+      return {
+        'type': 'object',
+        if (description != null) 'description': description,
+        'additionalProperties':
+            TypeReference(elementType!).generateSchema(context),
+      };
+    } else if (name == 'String') {
+      return {
+        'type': 'string',
+        if (description != null) 'description': description,
+      };
+    } else if (name == 'bool') {
+      return {
+        'type': 'boolean',
+        if (description != null) 'description': description,
+      };
+    } else if (name == 'int') {
+      return {
+        'type': 'integer',
+        if (description != null) 'description': description,
+      };
+    }
+    // Not a built-in type, look up a user-defined type. This throws if there
+    // is no such type declared.
+    return {
+      if (description != null) r'$comment': description,
+      r'$ref': context.lookupReferencePath(name),
+    };
+  }
+}
+
+/// Declaration of a class type.
+class ClassTypeDeclaration implements Declaration {
+  @override
+  final String name;
+  final String description;
+  final List<Field> fields;
+
+  ClassTypeDeclaration(this.name, this.description, this.fields);
+
+  @override
+  Map<String, Object?> generateSchema(GenerationContext context) => {
+        'type': 'object',
+        'description': description,
+        'properties': {
+          for (final field in fields) ...field.generateSchema(context),
+        }
+      };
+
+  @override
+  String generateCode(GenerationContext context) {
+    final result = StringBuffer();
+
+    result.writeln('/// $description');
+    result.write('extension type $name.fromJson(Map<String, Object?> node)'
+        ' implements Object {');
+
+    // Generate the non-JSON constructor, which accepts an optional value for
+    // every field and constructs JSON from it.
+    if (fields.isEmpty) {
+      result.writeln('  $name() : this.fromJson({});');
+    } else {
+      result.writeln('  $name({');
+      for (final field in fields) {
+        result.writeln(field.parameterCode);
+      }
+      result.writeln('}) : this.fromJson({');
+      for (final field in fields) {
+        result.writeln(field.namedArgumentCode);
+      }
+      result.writeln('});');
+    }
+
+    for (final field in fields) {
+      result.writeln(field.getterCode);
+    }
+    result.writeln('}');
+    return result.toString();
+  }
+
+  @override
+  Set<String> get allTypeNames => fields.expand((f) => f.allTypeNames).toSet();
+
+  @override
+  String get representationTypeName => 'Map<String, Object?>';
+}
+
+/// Declaration of a union type.
+///
+/// It has a list of possible actual types, and optionally properties of its
+/// own like a class.
 ///
 /// An enum is generated next to it called `${name}Type` with one value for
 /// each possible class, plus `unknown`.
@@ -145,267 +414,179 @@ bool _isUnion(JsonSchema schema) =>
 ///
 /// On the wire the union type is: `{"type": <name>, "value": <value>}` and
 /// may have additional properties as well.
-String _generateUnion(
-  String name,
-  JsonSchema definition, {
-  required Map<String, JsonSchema> allDefinitions,
-}) {
-  final oneOf = definition.properties['value']!.oneOf;
-  final result = StringBuffer();
-  final unionEntries = oneOf
-      .map((s) => _refName(s.schemaMap![r'$ref'] as String))
-      .map((name) => (name, allDefinitions[name]!));
+class UnionTypeDeclaration implements Declaration {
+  @override
+  final String name;
+  final String description;
+  final List<String> types;
+  final List<Field> fields;
+  UnionTypeDeclaration(this.name, this.description, this.types, this.fields);
 
-  // TODO(davidmorgan): add description(s).
-  result
-    ..writeln('enum ${name}Type {')
-    ..writeln('  // Private so switches must have a default. See `isKnown`.')
-    ..writeln('_unknown,')
-    ..write(unionEntries.map((e) => _firstToLowerCase(e.$1)).join(', '))
-    ..writeln(';')
-    ..writeln('bool get isKnown => this != _unknown;')
-    ..writeln('}');
+  @override
+  Map<String, Object?> generateSchema(GenerationContext context) => {
+        'type': 'object',
+        'description': description,
+        'properties': {
+          'type': {
+            'type': 'string',
+          },
+          'value': {
+            'oneOf': [
+              for (final type in types)
+                TypeReference(type).generateSchema(context),
+            ],
+          },
+          for (final field in fields) ...field.generateSchema(context),
+          'required': [
+            'type',
+            'value',
+            ...fields.where((e) => e.required).map((e) => e.name)
+          ]..sort(),
+        }
+      };
 
-  final extraPropertyMetadatas = [
-    for (var MapEntry(:key, :value) in definition.properties.entries)
-      // These are handled specially for union types.
-      if (key != 'type' && key != 'value') _readPropertyMetadata(key, value)
-  ];
+  @override
+  String generateCode(GenerationContext context) {
+    final result = StringBuffer();
 
-  // TODO(davidmorgan): add description.
-  result.writeln(
-      'extension type $name.fromJson(Map<String, Object?> node)  implements '
-      'Object {');
-  for (final (type, _) in unionEntries) {
-    final lowerType = _firstToLowerCase(type);
-    result.writeln('static $name $lowerType($type $lowerType');
-    if (extraPropertyMetadatas.isNotEmpty) {
-      result.writeln(', {');
-      for (final property in extraPropertyMetadatas) {
-        result.writeParameter(property, definition);
-      }
-      result.write('}');
-    }
+    // TODO(davidmorgan): add description(s).
     result
-      ..writeln(') =>')
-      ..writeln('$name.fromJson({')
-      ..writeln("'type': '$type',")
-      ..writeln("'value': $lowerType,");
-    for (final property in extraPropertyMetadatas) {
-      result.writeMapElement(property, definition);
-    }
-    result.writeln('});');
-  }
-
-  result
-    ..writeln('${name}Type get type {')
-    ..writeln("switch(node['type'] as String) {");
-  for (final (type, _) in unionEntries) {
-    final lowerType = _firstToLowerCase(type);
-    result.writeln("case '$type': return ${name}Type.$lowerType;");
-  }
-  result
-    ..writeln('default: return ${name}Type._unknown;')
-    ..writeln('}')
-    ..writeln('}');
-
-  for (final (type, schema) in unionEntries) {
-    result
-      ..writeln('$type get as$type {')
-      ..writeln("if (node['type'] != '$type') "
-          "{ throw StateError('Not a $type.'); }")
-      ..writeln(
-          "return $type.fromJson(node['value'] as ${_dartJsonType(schema)});")
+      ..writeln('enum ${name}Type {')
+      ..writeln('  // Private so switches must have a default. See `isKnown`.')
+      ..writeln('_unknown,')
+      ..write(types.map(_firstToLowerCase).join(', '))
+      ..writeln(';')
+      ..writeln('bool get isKnown => this != _unknown;')
       ..writeln('}');
+
+    // TODO(davidmorgan): add description.
+    result.writeln(
+        'extension type $name.fromJson(Map<String, Object?> node)  implements '
+        'Object {');
+    for (final type in types) {
+      final lowerType = _firstToLowerCase(type);
+      result.writeln('static $name $lowerType($type $lowerType');
+      if (fields.isNotEmpty) {
+        result.writeln(', {');
+        for (final field in fields) {
+          result.writeln(field.parameterCode);
+        }
+        result.write('}');
+      }
+      result
+        ..writeln(') =>')
+        ..writeln('$name.fromJson({')
+        ..writeln("'type': '$type',")
+        ..writeln("'value': $lowerType,");
+      for (final field in fields) {
+        result.writeln(field.namedArgumentCode);
+      }
+      result.writeln('});');
+    }
+
+    result
+      ..writeln('${name}Type get type {')
+      ..writeln("switch(node['type'] as String) {");
+    for (final type in types) {
+      final lowerType = _firstToLowerCase(type);
+      result.writeln("case '$type': return ${name}Type.$lowerType;");
+    }
+    result
+      ..writeln('default: return ${name}Type._unknown;')
+      ..writeln('}')
+      ..writeln('}');
+
+    for (final type in types) {
+      result
+        ..writeln('$type get as$type {')
+        ..writeln("if (node['type'] != '$type') "
+            "{ throw StateError('Not a $type.'); }")
+        ..writeln('return $type.fromJson'
+            "(node['value'] as "
+            '${context.lookupDeclaration(type).representationTypeName});')
+        ..writeln('}');
+    }
+
+    for (final field in fields) {
+      result.writeln(field.getterCode);
+    }
+    result.writeln('}');
+    return result.toString();
   }
 
-  for (final property in extraPropertyMetadatas) {
-    result.writePropertyGetter(property);
+  @override
+  Set<String> get allTypeNames =>
+      {...types, ...fields.expand((f) => f.allTypeNames)};
+
+  @override
+  String get representationTypeName => 'Map<String, Object?>';
+}
+
+/// Declaration of a named type that is actually a String.
+class StringTypedefDeclaration implements Declaration {
+  @override
+  String name;
+  String description;
+  StringTypedefDeclaration(this.name, this.description);
+
+  @override
+  Map<String, Object?> generateSchema(GenerationContext context) => {
+        'type': 'string',
+        'description': description,
+      };
+
+  @override
+  String generateCode(GenerationContext context) {
+    return '/// $description\n'
+        'extension type $name.fromJson(String string) implements Object {'
+        '$name(String string) : this.fromJson(string);'
+        '}';
   }
 
-  result.writeln('}');
+  @override
+  Set<String> get allTypeNames => {'String'};
 
-  return result.toString();
+  @override
+  String get representationTypeName => 'String';
+}
+
+/// Declaration of a named type that is actually a null.
+class NullTypedefDeclaration implements Declaration {
+  @override
+  final String name;
+  final String description;
+
+  NullTypedefDeclaration(this.name, this.description);
+
+  @override
+  Map<String, Object?> generateSchema(GenerationContext context) => {
+        'type': 'null',
+        'description': description,
+      };
+
+  @override
+  String generateCode(GenerationContext context) {
+    return '/// $description\n'
+        'extension type $name.fromJson(Null _) {'
+        '$name() : this.fromJson(null);'
+        '}';
+  }
+
+  @override
+  Set<String> get allTypeNames => {'Null'};
+
+  @override
+  String get representationTypeName => 'Null';
 }
 
 String _firstToLowerCase(String string) =>
     string.substring(0, 1).toLowerCase() + string.substring(1);
 
-/// Gets information about an extension type property from [schema].
-PropertyMetadata _readPropertyMetadata(String name, JsonSchema schema) {
-  // Check for a `$ref` to another extension type defined under `$defs`.
-  if (schema.schemaMap!.containsKey(r'$ref')) {
-    final ref = schema.schemaMap![r'$ref'] as String;
-    if (ref.contains(r'#/$defs/')) {
-      final schemaName = _refName(ref);
-      return PropertyMetadata(
-          // The "description" comes from the ref'd schema. But, we want to
-          // describe the property, not the type of the property. It's possible
-          // to use `allOf` to specify a second schema with a second
-          // `description`, but for simplicity use `$comment` which is just
-          // ignored by standard tooling.
-          description: schema.schemaMap![r'$comment'] as String?,
-          name: name,
-          type: PropertyType.object,
-          elementTypeName: schemaName);
-    } else {
-      throw UnsupportedError('Unsupported: $name $schema');
-    }
-  }
-
-  // Otherwise, it's a schema with a type.
-  return switch (schema.type) {
-    SchemaType.boolean => PropertyMetadata(
-        description: schema.description, name: name, type: PropertyType.bool),
-    SchemaType.string => PropertyMetadata(
-        description: schema.description, name: name, type: PropertyType.string),
-    SchemaType.integer => PropertyMetadata(
-        description: schema.description,
-        name: name,
-        type: PropertyType.integer),
-    SchemaType.array => PropertyMetadata(
-        description: schema.description,
-        name: name,
-        type: PropertyType.list,
-        elementTypeName: _readRefNameOrType(schema, 'items')),
-    SchemaType.object => PropertyMetadata(
-        description: schema.description,
-        name: name,
-        type: PropertyType.map,
-        // `additionalProperties` should be a type specified with a `$ref`.
-        elementTypeName: _readRefNameOrType(schema, 'additionalProperties')),
-    _ => throw UnsupportedError('Unsupported schema type: ${schema.type}'),
-  };
-}
-
-/// Reads the type name of a `$ref` to a `$def`.
-///
-/// If it's not there, falls back to `type` mapped to a Dart type name.
-String _readRefNameOrType(JsonSchema schema, String key) {
-  final typeSchema = schema.schemaMap![key] as Map;
-  final ref = typeSchema[r'$ref'] as String?;
-  if (ref != null) {
-    return _refName(ref);
-  } else {
-    final type = typeSchema['type'] as String;
-    switch (type) {
-      case 'integer':
-        return 'int';
-      default:
-        throw UnsupportedError(type);
-    }
-  }
-}
-
-/// Returns the type name from a reference to a type under `$defs`.
-String _refName(String ref) =>
-    ref.substring(ref.indexOf(r'#/$defs/') + r'#/$defs/'.length);
-
-/// The Dart types used in extension types to model JSON types.
-enum PropertyType {
-  object,
-  bool,
-  string,
-  integer,
-  list,
-  map,
-}
-
-/// Metadata about a property in an extension type.
-class PropertyMetadata {
-  String? description;
-  String name;
-  PropertyType type;
-  String? elementTypeName;
-
-  PropertyMetadata(
-      {this.description,
-      required this.name,
-      required this.type,
-      this.elementTypeName});
-}
-
-/// Loads referenced schemas.
-///
-/// No need to connect to servers like the default implementation, just return
-/// the one file we know we need.
-class LocalRefProvider implements RefProvider<SyncJsonProvider> {
-  final String dartModelJson;
-
-  LocalRefProvider(this.dartModelJson);
-
-  @override
-  bool get isSync => true;
-
-  @override
-  SyncJsonProvider get provide => (String path) {
-        if (path != 'file:///dart_model.schema.json') {
-          throw UnsupportedError(
-              'This provider only loads file:///dart_model.schema.json!'
-              ' Got: $path');
-        }
-        return json.decode(dartModelJson) as Map<String, Object?>;
-      };
-}
-
-extension on StringBuffer {
-  void writeType(PropertyMetadata property, {bool nullable = false}) {
-    write(switch (property.type) {
-      PropertyType.object => property.elementTypeName,
-      PropertyType.bool => 'bool',
-      PropertyType.string => 'String',
-      PropertyType.integer => 'int',
-      PropertyType.list => 'List<${property.elementTypeName}>',
-      PropertyType.map => 'Map<String, ${property.elementTypeName}>',
-    });
-    if (nullable) write('?');
-  }
-
-  /// Writes a map element for [property], assuming there is a variable in
-  /// scope with the same name (usually, a function parameter).
-  ///
-  /// If the property is not required, the element will be omitted if the
-  /// variable is null.
-  void writeMapElement(PropertyMetadata property, JsonSchema schema) {
-    if (!schema.propertyRequired(property.name)) {
-      write('if (${property.name} != null) ');
-    }
-    writeln("'${property.name}': ${property.name},");
-  }
-
-  /// Writes a named function parameter for [property].
-  ///
-  /// If the property is required, it will be non-nullable and marked as
-  /// `required`, otherwise it will be nullable and optional.
-  void writeParameter(PropertyMetadata property, JsonSchema schema) {
-    var required = schema.propertyRequired(property.name);
-    if (required) write('required ');
-    writeType(property, nullable: !required);
-    writeln(' ${property.name},');
-  }
-
-  /// Writes a getter for [property] that looks up in the JSON and "creates"
-  /// extension types or casts collections as needed. The getters assume the
-  /// data is present and will throw if it's not, and return types are always
-  /// non-nullable.
-  void writePropertyGetter(PropertyMetadata property) {
-    if (property.description != null) {
-      writeln('/// ${property.description}');
-    }
-    writeType(property);
-    write(' get ${property.name} => ');
-    switch (property.type) {
-      case PropertyType.object ||
-            PropertyType.bool ||
-            PropertyType.string ||
-            PropertyType.integer:
-        write("node['${property.name}'] as ");
-        writeType(property);
-      case PropertyType.list:
-        write("(node['${property.name}'] as List).cast()");
-      case PropertyType.map:
-        write("(node['${property.name}'] as Map).cast()");
-    }
-    writeln(';');
+String _format(String source) {
+  try {
+    return DartFormatter().formatSource(SourceCode(source)).text;
+  } catch (_) {
+    print('Failed to format:\n---\n$source\n---');
+    rethrow;
   }
 }

--- a/tool/dart_model_generator/test/generated_output_test.dart
+++ b/tool/dart_model_generator/test/generated_output_test.dart
@@ -4,20 +4,14 @@
 
 import 'dart:io';
 
-import 'package:generate_dart_model/generate_dart_model.dart'
-    as dart_model_generator;
+import 'package:generate_dart_model/definitions.dart';
 import 'package:test/test.dart';
 
 void main() {
-  for (final package in ['dart_model', 'macro_service']) {
-    test('$package output is up to date', () {
-      final expected = dart_model_generator.generate(
-          File('../../schemas/$package.schema.json').readAsStringSync(),
-          importDartModel: package == 'macro_service',
-          dartModelJson:
-              File('../../schemas/dart_model.schema.json').readAsStringSync());
-      final actual = File('../../pkgs/$package/lib/src/$package.g.dart')
-          .readAsStringSync();
+  for (final generationResult in schemas.generate()) {
+    test('${generationResult.path} is up to date', () {
+      final expected = generationResult.content;
+      final actual = File('../../${generationResult.path}').readAsStringSync();
       // TODO: On windows we get carriage returns, which makes this fail
       // without ignoring white space. In theory this shouldn't happen.
       expect(actual, equalsIgnoringWhitespace(expected), reason: '''


### PR DESCRIPTION
Then generate both schema and code.

This makes it more precise what we are generating, particularly for concepts like unions that are not native to JSON.
