### PR TITLE
Support nullable definitions in schema

### DIFF
--- a/pkgs/dart_model/lib/src/dart_model.g.dart
+++ b/pkgs/dart_model/lib/src/dart_model.g.dart
@@ -418,7 +418,7 @@ extension type StaticTypeParameterDesc.fromJson(Map<String, Object?> node)
           if (bound != null) 'bound': bound,
         });
   int get identifier => node['identifier'] as int;
-  StaticTypeDesc get bound => node['bound'] as StaticTypeDesc;
+  StaticTypeDesc? get bound => node['bound'] as StaticTypeDesc?;
 }
 
 /// View of a subset of a Dart program's type hierarchy as part of a queried model.

--- a/pkgs/dart_model/lib/src/type.dart
+++ b/pkgs/dart_model/lib/src/type.dart
@@ -344,11 +344,10 @@ final class FunctionType extends StaticType {
       // Now that the mapping from id -> type parameters ready, we translate
       // bounds.
       for (final (i, desc) in desc.typeParameters.indexed) {
-        // TODO(simolus3): Handle nullable fields in schema
-//        if (desc.bound case final bound?) {
-        typeParameters[i].bound =
-            StaticType._translateFromDescription(desc.bound, parameters);
-//        }
+        if (desc.bound case final bound?) {
+          typeParameters[i].bound =
+              StaticType._translateFromDescription(bound, parameters);
+        }
       }
     }
 

--- a/tool/dart_model_generator/lib/definitions.dart
+++ b/tool/dart_model_generator/lib/definitions.dart
@@ -177,7 +177,7 @@ final schemas = Schemas([
                 'A resolved type parameter introduced by a [FunctionTypeDesc].',
             properties: [
               Property('identifier', type: 'int'),
-              Property('bound', type: 'StaticTypeDesc')
+              Property('bound', type: 'StaticTypeDesc', nullable: true),
             ]),
         Definition.clazz('TypeHierarchy',
             description:


### PR DESCRIPTION
This adds support for making some properties nullable in the schema, which is useful to represent things like e.g type parameters which may or may not have an explicit upper bound.
While we technically allow all properties to be absent in the schema to support partial models, nullable properties generate nullable getters in Dart.
An open question is whether we want to distinguish between `null` and "not part of the resolved model" (which we could detect by asserting that the key is present in the map when the getter is invoked).
