### PR TITLE
Add generation of enums, use an enum for ProtocolEncoding.

### DIFF
--- a/pkgs/_analyzer_macros/test/analyzer_test.dart
+++ b/pkgs/_analyzer_macros/test/analyzer_test.dart
@@ -25,7 +25,7 @@ void main() {
           AnalysisContextCollection(includedPaths: [directory.path]);
       analysisContext = contextCollection.contexts.first;
       injected.macroImplementation = await AnalyzerMacroImplementation.start(
-          protocol: Protocol(encoding: 'binary'),
+          protocol: Protocol(encoding: ProtocolEncoding.binary),
           packageConfig: Isolate.packageConfigSync!);
     });
 

--- a/pkgs/_analyzer_macros/test/golden_test.dart
+++ b/pkgs/_analyzer_macros/test/golden_test.dart
@@ -30,7 +30,7 @@ void main() {
           AnalysisContextCollection(includedPaths: [directory.path]);
       analysisContext = contextCollection.contexts.first;
       injected.macroImplementation = await AnalyzerMacroImplementation.start(
-          protocol: Protocol(encoding: 'binary'),
+          protocol: Protocol(encoding: ProtocolEncoding.binary),
           packageConfig: Isolate.packageConfigSync!);
     });
 

--- a/pkgs/_cfe_macros/test/cfe_test.dart
+++ b/pkgs/_cfe_macros/test/cfe_test.dart
@@ -31,7 +31,7 @@ void main() {
 
       // Inject test macro implementation.
       injected.macroImplementation = await CfeMacroImplementation.start(
-          protocol: Protocol(encoding: 'json'),
+          protocol: Protocol(encoding: ProtocolEncoding.json),
           packageConfig: Isolate.packageConfigSync!);
     });
 

--- a/pkgs/_cfe_macros/test/golden_test.dart
+++ b/pkgs/_cfe_macros/test/golden_test.dart
@@ -38,7 +38,7 @@ void main() {
 
       // Inject test macro implementation.
       injected.macroImplementation = await CfeMacroImplementation.start(
-          protocol: Protocol(encoding: 'json'),
+          protocol: Protocol(encoding: ProtocolEncoding.json),
           packageConfig: Isolate.packageConfigSync!);
     });
 

--- a/pkgs/_macro_client/test/macro_client_test.dart
+++ b/pkgs/_macro_client/test/macro_client_test.dart
@@ -15,8 +15,8 @@ import 'package:test/test.dart';
 
 void main() {
   for (final protocol in [
-    Protocol(encoding: 'json'),
-    Protocol(encoding: 'binary')
+    Protocol(encoding: ProtocolEncoding.json),
+    Protocol(encoding: ProtocolEncoding.binary)
   ]) {
     group('MacroClient using ${protocol.encoding}', () {
       test('connects to service', () async {

--- a/pkgs/_macro_host/test/macro_host_test.dart
+++ b/pkgs/_macro_host/test/macro_host_test.dart
@@ -11,8 +11,8 @@ import 'package:test/test.dart';
 
 void main() {
   for (final protocol in [
-    Protocol(encoding: 'json'),
-    Protocol(encoding: 'binary')
+    Protocol(encoding: ProtocolEncoding.json),
+    Protocol(encoding: ProtocolEncoding.binary)
   ]) {
     group('MacroHost using ${protocol.encoding}', () {
       test('hosts a macro, receives augmentations', () async {

--- a/pkgs/_macro_runner/test/macro_runner_test.dart
+++ b/pkgs/_macro_runner/test/macro_runner_test.dart
@@ -13,8 +13,8 @@ import 'package:test/test.dart';
 
 void main() {
   for (final protocol in [
-    Protocol(encoding: 'json'),
-    Protocol(encoding: 'binary')
+    Protocol(encoding: ProtocolEncoding.json),
+    Protocol(encoding: ProtocolEncoding.binary)
   ]) {
     group('MacroRunner with ${protocol.encoding}', () {
       test('runs macros', () async {

--- a/pkgs/_macro_server/test/macro_server_test.dart
+++ b/pkgs/_macro_server/test/macro_server_test.dart
@@ -12,8 +12,8 @@ import 'package:test/test.dart';
 
 void main() {
   for (final protocol in [
-    Protocol(encoding: 'json'),
-    Protocol(encoding: 'binary')
+    Protocol(encoding: ProtocolEncoding.json),
+    Protocol(encoding: ProtocolEncoding.binary)
   ]) {
     group('MacroServer using ${protocol.encoding}', () {
       test('serves a macro service', () async {

--- a/pkgs/macro_service/lib/src/macro_service.g.dart
+++ b/pkgs/macro_service/lib/src/macro_service.g.dart
@@ -199,13 +199,20 @@ extension type MacroRequest.fromJson(Map<String, Object?> node)
 /// The macro to host protocol version and encoding. TODO(davidmorgan): add the version.
 extension type Protocol.fromJson(Map<String, Object?> node) implements Object {
   Protocol({
-    String? encoding,
+    ProtocolEncoding? encoding,
   }) : this.fromJson({
           if (encoding != null) 'encoding': encoding,
         });
 
-  /// The wire format: json or binary. TODO(davidmorgan): use an enum?
-  String get encoding => node['encoding'] as String;
+  /// The wire format: json or binary.
+  ProtocolEncoding get encoding => node['encoding'] as ProtocolEncoding;
+}
+
+/// The wire encoding used.
+extension type const ProtocolEncoding.fromJson(String string)
+    implements Object {
+  static const ProtocolEncoding json = ProtocolEncoding.fromJson('json');
+  static const ProtocolEncoding binary = ProtocolEncoding.fromJson('binary');
 }
 
 /// Macro's query about the code it should augment.

--- a/pkgs/macro_service/test/protocol_test.dart
+++ b/pkgs/macro_service/test/protocol_test.dart
@@ -11,8 +11,8 @@ import 'package:test/test.dart';
 
 void main() {
   for (final protocol in [
-    Protocol(encoding: 'json'),
-    Protocol(encoding: 'binary')
+    Protocol(encoding: ProtocolEncoding.json),
+    Protocol(encoding: ProtocolEncoding.binary)
   ]) {
     group('Protocol using ${protocol.encoding}', () {
       test('can round trip JSON data', () async {

--- a/schemas/macro_service.schema.json
+++ b/schemas/macro_service.schema.json
@@ -145,10 +145,14 @@
       "description": "The macro to host protocol version and encoding. TODO(davidmorgan): add the version.",
       "properties": {
         "encoding": {
-          "type": "string",
-          "description": "The wire format: json or binary. TODO(davidmorgan): use an enum?"
+          "$comment": "The wire format: json or binary.",
+          "$ref": "#/$defs/ProtocolEncoding"
         }
       }
+    },
+    "ProtocolEncoding": {
+      "type": "string",
+      "description": "The wire encoding used."
     },
     "QueryRequest": {
       "type": "object",

--- a/tool/dart_model_generator/lib/definitions.dart
+++ b/tool/dart_model_generator/lib/definitions.dart
@@ -332,10 +332,11 @@ final schemas = Schemas([
                 'TODO(davidmorgan): add the version.',
             properties: [
               Property('encoding',
-                  type: 'String',
-                  description: 'The wire format: json or binary. '
-                      'TODO(davidmorgan): use an enum?'),
+                  type: 'ProtocolEncoding',
+                  description: 'The wire format: json or binary.'),
             ]),
+        Definition.$enum('ProtocolEncoding',
+            description: 'The wire encoding used.', values: ['json', 'binary']),
         Definition.clazz('QueryRequest',
             description: "Macro's query about the code it should augment.",
             properties: [

--- a/tool/dart_model_generator/lib/generate_dart_model.dart
+++ b/tool/dart_model_generator/lib/generate_dart_model.dart
@@ -209,6 +209,11 @@ abstract class Definition {
       required List<Property> properties,
       bool createInBuffer}) = UnionTypeDefinition;
 
+  /// Defines an enum.
+  factory Definition.$enum(String name,
+      {required String description,
+      required List<String> values}) = EnumTypeDefinition;
+
   /// Defines a named type represented in JSON as a string.
   factory Definition.stringTypedef(String name, {required String description}) =
       StringTypedefDefinition;
@@ -649,6 +654,43 @@ class UnionTypeDefinition implements Definition {
 
   @override
   String get representationTypeName => 'Map<String, Object?>';
+}
+
+/// Definition of an enum type.
+class EnumTypeDefinition implements Definition {
+  @override
+  final String name;
+  final String description;
+  final List<String> values;
+
+  EnumTypeDefinition(this.name,
+      {required this.description, required this.values});
+
+  @override
+  Map<String, Object?> generateSchema(GenerationContext context) => {
+        'type': 'string',
+        'description': description,
+      };
+
+  @override
+  String generateCode(GenerationContext context) {
+    final result = StringBuffer();
+
+    result.writeln('/// $description');
+    result.write('extension type const $name.fromJson(String string)'
+        ' implements Object {');
+    for (final value in values) {
+      result.writeln("static const $name $value = $name.fromJson('$value');");
+    }
+    result.writeln('}');
+    return result.toString();
+  }
+
+  @override
+  Set<String> get allTypeNames => {};
+
+  @override
+  String get representationTypeName => 'String';
 }
 
 /// Definition of a named type that is actually a String.


### PR DESCRIPTION
This seems to work pretty well right up to the point where you try to use `==`, which will likely fail: there is no way to make deserialized strings match the constants.

That seems to be a general problem of extension types: I am thinking we might want a lint that says "never compare or hash extension types". So I guess if we can live with it elsewhere we can live with it for enums.

But, suggestions welcome :)