### PR TITLE
Add a first JSON macro based on package:json/json.dart.

### DIFF
--- a/goldens/foo/lib/foo.analyzer.json
+++ b/goldens/foo/lib/foo.analyzer.json
@@ -11,6 +11,16 @@
                 "isField": true,
                 "isMethod": false,
                 "isStatic": false
+              },
+              "returnType": {
+                "type": "NamedTypeDesc",
+                "value": {
+                  "name": {
+                    "uri": "dart:core",
+                    "name": "int"
+                  },
+                  "instantiation": []
+                }
               }
             }
           }
@@ -24,6 +34,16 @@
                 "isField": true,
                 "isMethod": false,
                 "isStatic": false
+              },
+              "returnType": {
+                "type": "NamedTypeDesc",
+                "value": {
+                  "name": {
+                    "uri": "dart:core",
+                    "name": "int"
+                  },
+                  "instantiation": []
+                }
               }
             }
           }
@@ -33,25 +53,6 @@
   },
   "types": {
     "named": {
-      "package:foo/foo.dart#Foo": {
-        "typeParameters": [],
-        "self": {
-          "name": {
-            "uri": "package:foo/foo.dart",
-            "name": "Foo"
-          },
-          "instantiation": []
-        },
-        "supertypes": [
-          {
-            "name": {
-              "uri": "dart:core",
-              "name": "Object"
-            },
-            "instantiation": []
-          }
-        ]
-      },
       "dart:core#Object": {
         "typeParameters": [],
         "self": {
@@ -101,6 +102,25 @@
               }
             }
           ]
+        },
+        "supertypes": [
+          {
+            "name": {
+              "uri": "dart:core",
+              "name": "Object"
+            },
+            "instantiation": []
+          }
+        ]
+      },
+      "package:foo/foo.dart#Foo": {
+        "typeParameters": [],
+        "self": {
+          "name": {
+            "uri": "package:foo/foo.dart",
+            "name": "Foo"
+          },
+          "instantiation": []
         },
         "supertypes": [
           {

--- a/goldens/foo/lib/json_codable.analyzer.augmentations
+++ b/goldens/foo/lib/json_codable.analyzer.augmentations
@@ -1,0 +1,59 @@
+part of 'package:foo/json_codable.dart';
+
+import 'package:foo/json_codable.dart' as prefix0;
+import 'dart:core' as prefix1;
+
+augment class A {
+external prefix0.A.fromJson(prefix1.Map<prefix1.String, prefix1.Object?> json);
+external prefix1.Map<prefix1.String, prefix1.Object?> toJson();
+   
+augment prefix0.A.fromJson(prefix1.Map<prefix1.String, prefix1.Object?> json) :
+boolField = json[r'boolField'] as prefix1.bool,
+nullableBoolField = json[r'nullableBoolField'] as prefix1.bool?,
+stringField = json[r'stringField'] as prefix1.String,
+nullableStringField = json[r'nullableStringField'] as prefix1.String?,
+intField = json[r'intField'] as prefix1.int,
+nullableIntField = json[r'nullableIntField'] as prefix1.int?,
+doubleField = json[r'doubleField'] as prefix1.double,
+nullableDoubleField = json[r'nullableDoubleField'] as prefix1.double?,
+numField = json[r'numField'] as prefix1.num,
+nullableNumField = json[r'nullableNumField'] as prefix1.num?,
+listOfSerializableField = json[r'listOfSerializableField'] == null ? null :  [for (final item in json[r'listOfSerializableField'] as prefix1.List<prefix1.Object?>) item == null ? null :  prefix0.C.fromJson(item as prefix1.Map<prefix1.String, prefix1.Object?>],
+nullableListOfSerializableField =  [for (final item in json[r'nullableListOfSerializableField'] as prefix1.List<prefix1.Object?>) item == null ? null :  prefix0.C.fromJson(item as prefix1.Map<prefix1.String, prefix1.Object?>],
+setOfSerializableField = json[r'setOfSerializableField'] == null ? null :  {for (final item in json[r'setOfSerializableField'] as prefix1.Set<prefix1.Object?>) item == null ? null :  prefix0.C.fromJson(item as prefix1.Map<prefix1.String, prefix1.Object?>},
+nullableSetOfSerializableField =  {for (final item in json[r'nullableSetOfSerializableField'] as prefix1.Set<prefix1.Object?>) item == null ? null :  prefix0.C.fromJson(item as prefix1.Map<prefix1.String, prefix1.Object?>},
+mapOfSerializableField = json[r'mapOfSerializableField'] == null ? null :  {for (final (:key, :value) in json[r'mapOfSerializableField'] as prefix1.Map<prefix1.String, prefix1.Object?>) key: value == null ? null :  prefix0.C.fromJson(value as prefix1.Map<prefix1.String, prefix1.Object?>},
+nullableMapOfSerializableField =  {for (final (:key, :value) in json[r'nullableMapOfSerializableField'] as prefix1.Map<prefix1.String, prefix1.Object?>) key: value == null ? null :  prefix0.C.fromJson(value as prefix1.Map<prefix1.String, prefix1.Object?>};
+
+prefix1.Map<prefix1.String, prefix1.Object?> toJson() {
+json[r'boolField'] = boolField;
+json[r'nullableBoolField'] = nullableBoolField;
+json[r'stringField'] = stringField;
+json[r'nullableStringField'] = nullableStringField;
+json[r'intField'] = intField;
+json[r'nullableIntField'] = nullableIntField;
+json[r'doubleField'] = doubleField;
+json[r'nullableDoubleField'] = nullableDoubleField;
+json[r'numField'] = numField;
+json[r'nullableNumField'] = nullableNumField;
+json[r'listOfSerializableField'] = listOfSerializableField == null ? null :  {for (final item in listOfSerializableField) item == null ? null :  item.toJson()};
+json[r'nullableListOfSerializableField'] =  {for (final item in nullableListOfSerializableField) item == null ? null :  item.toJson()};
+json[r'setOfSerializableField'] = setOfSerializableField == null ? null :  {for (final item in setOfSerializableField) item == null ? null :  item.toJson()};
+json[r'nullableSetOfSerializableField'] =  {for (final item in nullableSetOfSerializableField) item == null ? null :  item.toJson()};
+json[r'mapOfSerializableField'] = mapOfSerializableField == null ? null :  {for (final (:key, :value) in mapOfSerializableField.entries) key: value == null ? null :  value.toJson()};
+json[r'nullableMapOfSerializableField'] =  {for (final (:key, :value) in nullableMapOfSerializableField.entries) key: value == null ? null :  value.toJson()}
+};
+
+}
+augment class C {
+external prefix0.C.fromJson(prefix1.Map<prefix1.String, prefix1.Object?> json);
+external prefix1.Map<prefix1.String, prefix1.Object?> toJson();
+   
+augment prefix0.C.fromJson(prefix1.Map<prefix1.String, prefix1.Object?> json) :
+boolField = json[r'boolField'] as prefix1.bool;
+
+prefix1.Map<prefix1.String, prefix1.Object?> toJson() {
+json[r'boolField'] = boolField
+};
+
+}

--- a/goldens/foo/lib/json_codable.analyzer.augmentations
+++ b/goldens/foo/lib/json_codable.analyzer.augmentations
@@ -26,6 +26,7 @@ mapOfSerializableField = json[r'mapOfSerializableField'] == null ? null :  {for 
 nullableMapOfSerializableField =  {for (final (:key, :value) in json[r'nullableMapOfSerializableField'] as prefix1.Map<prefix1.String, prefix1.Object?>) key: value == null ? null :  prefix0.C.fromJson(value as prefix1.Map<prefix1.String, prefix1.Object?>};
 
 prefix1.Map<prefix1.String, prefix1.Object?> toJson() {
+  final json = prefix1.Map<prefix1.String, prefix1.Object?>{};
 json[r'boolField'] = boolField;
 json[r'nullableBoolField'] = nullableBoolField;
 json[r'stringField'] = stringField;
@@ -36,12 +37,14 @@ json[r'doubleField'] = doubleField;
 json[r'nullableDoubleField'] = nullableDoubleField;
 json[r'numField'] = numField;
 json[r'nullableNumField'] = nullableNumField;
-json[r'listOfSerializableField'] = listOfSerializableField == null ? null :  {for (final item in listOfSerializableField) item == null ? null :  item.toJson()};
-json[r'nullableListOfSerializableField'] =  {for (final item in nullableListOfSerializableField) item == null ? null :  item.toJson()};
-json[r'setOfSerializableField'] = setOfSerializableField == null ? null :  {for (final item in setOfSerializableField) item == null ? null :  item.toJson()};
-json[r'nullableSetOfSerializableField'] =  {for (final item in nullableSetOfSerializableField) item == null ? null :  item.toJson()};
+json[r'listOfSerializableField'] = listOfSerializableField == null ? null :  [for (final item in listOfSerializableField) item == null ? null :  item.toJson()];
+json[r'nullableListOfSerializableField'] =  [for (final item in nullableListOfSerializableField) item == null ? null :  item.toJson()];
+json[r'setOfSerializableField'] = setOfSerializableField == null ? null :  [for (final item in setOfSerializableField) item == null ? null :  item.toJson()];
+json[r'nullableSetOfSerializableField'] =  [for (final item in nullableSetOfSerializableField) item == null ? null :  item.toJson()];
 json[r'mapOfSerializableField'] = mapOfSerializableField == null ? null :  {for (final (:key, :value) in mapOfSerializableField.entries) key: value == null ? null :  value.toJson()};
-json[r'nullableMapOfSerializableField'] =  {for (final (:key, :value) in nullableMapOfSerializableField.entries) key: value == null ? null :  value.toJson()}
+json[r'nullableMapOfSerializableField'] =  {for (final (:key, :value) in nullableMapOfSerializableField.entries) key: value == null ? null :  value.toJson()};
+
+  return json;
 };
 
 }
@@ -53,7 +56,10 @@ augment prefix0.C.fromJson(prefix1.Map<prefix1.String, prefix1.Object?> json) :
 boolField = json[r'boolField'] as prefix1.bool;
 
 prefix1.Map<prefix1.String, prefix1.Object?> toJson() {
-json[r'boolField'] = boolField
+  final json = prefix1.Map<prefix1.String, prefix1.Object?>{};
+json[r'boolField'] = boolField;
+
+  return json;
 };
 
 }

--- a/goldens/foo/lib/json_codable.dart
+++ b/goldens/foo/lib/json_codable.dart
@@ -1,0 +1,45 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:_test_macros/json_codable.dart';
+
+@JsonCodable()
+class A {
+  final bool boolField;
+
+  final bool? nullableBoolField;
+
+  final String stringField;
+
+  final String? nullableStringField;
+
+  final int intField;
+
+  final int? nullableIntField;
+
+  final double doubleField;
+
+  final double? nullableDoubleField;
+
+  final num numField;
+
+  final num? nullableNumField;
+
+  final List<C> listOfSerializableField;
+
+  final List<C>? nullableListOfSerializableField;
+
+  final Set<C> setOfSerializableField;
+
+  final Set<C>? nullableSetOfSerializableField;
+
+  final Map<String, C> mapOfSerializableField;
+
+  final Map<String, C>? nullableMapOfSerializableField;
+}
+
+@JsonCodable()
+class C {
+  final bool boolField;
+}

--- a/pkgs/_analyzer_macros/lib/macro_implementation.dart
+++ b/pkgs/_analyzer_macros/lib/macro_implementation.dart
@@ -144,8 +144,6 @@ class AnalyzerMacroExecutionResult implements injected.MacroExecutionResult {
     return AnalyzerMacroExecutionResult(target, declarations);
   }
 
-  Future<void> resolveTypes() async {}
-
   @override
   List<Diagnostic> get diagnostics => [];
 
@@ -188,6 +186,8 @@ extension MacroTargetExtension on MacroTarget {
 /// Converts [code] to a mix of `Identifier` and `String`.
 ///
 /// Looks up references of the form `{{uri#name}}` using `resolveIdentifier`.
+///
+/// TODO(davidmorgan): move to the client side.
 Future<List<Object>> _expandTemplates(String code) async {
   final result = <Object>[];
   var index = 0;

--- a/pkgs/_analyzer_macros/test/golden_test.dart
+++ b/pkgs/_analyzer_macros/test/golden_test.dart
@@ -67,10 +67,6 @@ void main() {
         } else {
           applicationGoldenFile = null;
         }
-
-        if (introspectionGoldenFile == null && applicationGoldenFile == null) {
-          throw StateError('Setup failed, no goldens for $path');
-        }
       });
 
       if (updateGoldens) {
@@ -97,6 +93,11 @@ void main() {
       }
 
       test(relativePath, () async {
+        if (introspectionGoldenFile == null && applicationGoldenFile == null) {
+          // Nothing to check.
+          return;
+        }
+
         final resolvedLibrary = (await analysisContext.currentSession
             .getResolvedLibrary(path)) as ResolvedLibraryResult;
         final augmentationUnit =

--- a/pkgs/_cfe_macros/test/golden_test.dart
+++ b/pkgs/_cfe_macros/test/golden_test.dart
@@ -76,10 +76,6 @@ void main() {
         } else {
           applicationGoldenFile = null;
         }
-
-        if (introspectionGoldenFile == null && applicationGoldenFile == null) {
-          throw StateError('Setup failed, no goldens for $path');
-        }
       });
       if (updateGoldens) {
         tearDown(() {
@@ -105,6 +101,11 @@ void main() {
       }
 
       test(relativePath, () async {
+        if (introspectionGoldenFile == null && applicationGoldenFile == null) {
+          // Nothing to check.
+          return;
+        }
+
         final packagesUri = Isolate.packageConfigSync;
         final outputFile = File('${tempDir.path}/$relativePath.dill');
 

--- a/pkgs/_test_macros/lib/json_codable.dart
+++ b/pkgs/_test_macros/lib/json_codable.dart
@@ -79,7 +79,7 @@ ${initializers.join(',\n')};
     result.add(Augmentation(code: '''
 $_jsonMapType toJson() {
   final json = $_jsonMapType{};
-${serializers.map((s) =>'$s;\n').join('')}
+${serializers.map((s) => '$s;\n').join('')}
   return json;
 };
 '''));
@@ -110,16 +110,16 @@ ${serializers.map((s) =>'$s;\n').join('')}
           case 'num':
             return '$reference as ${namedType.name.code}$orNull';
           case 'List':
+            final type = namedType.instantiation.single;
             return '$nullCheck [for (final item in $reference '
                 'as {{dart:core#List}}<{{dart:core#Object}}?>) '
-                '${_convertTypeFromJson(
-                  'item', namedType.instantiation.single)}'
+                '${_convertTypeFromJson('item', type)}'
                 ']';
           case 'Set':
+            final type = namedType.instantiation.single;
             return '$nullCheck {for (final item in $reference '
                 'as {{dart:core#Set}}<{{dart:core#Object}}?>) '
-                '${_convertTypeFromJson(
-                  'item', namedType.instantiation.single)}'
+                '${_convertTypeFromJson('item', type)}'
                 '}';
           case 'Map':
             // TODO(davidmorgan): check for and handle wrong key type.

--- a/pkgs/_test_macros/lib/json_codable.dart
+++ b/pkgs/_test_macros/lib/json_codable.dart
@@ -1,0 +1,170 @@
+// Copyright (c) 2024, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:dart_model/dart_model.dart';
+import 'package:macro/macro.dart';
+import 'package:macro_service/macro_service.dart';
+
+/// A macro which adds a `fromJson(Map<String, Object?> json)` JSON decoding
+/// constructor to a class.
+class JsonCodable {
+  const JsonCodable();
+}
+
+final _jsonMapType =
+    '{{dart:core#Map}}<{{dart:core#String}}, {{dart:core#Object}}?>';
+
+class JsonCodableImplementation implements Macro {
+  @override
+  MacroDescription get description => MacroDescription(
+      annotation: QualifiedName(
+          uri: 'package:_test_macros/json_codable.dart', name: 'JsonCodable'),
+      runsInPhases: [2, 3]);
+
+  @override
+  Future<AugmentResponse> augment(Host host, AugmentRequest request) async {
+    return switch (request.phase) {
+      1 => phase1(host, request),
+      2 => phase2(host, request),
+      _ => AugmentResponse(augmentations: []),
+    };
+  }
+
+  Future<AugmentResponse> phase1(Host host, AugmentRequest request) async {
+    final target = request.target;
+    return AugmentResponse(augmentations: [
+      Augmentation(code: '''
+external ${target.code}.fromJson($_jsonMapType json);
+external $_jsonMapType toJson();
+   '''),
+    ]);
+  }
+
+  Future<AugmentResponse> phase2(Host host, AugmentRequest request) async {
+    final result = <Augmentation>[];
+
+    final target = request.target;
+    final model = await host.query(Query(target: target));
+    final clazz = model.uris[target.uri]!.scopes[target.name]!;
+    final initializers = <String>[];
+    for (final field
+        in clazz.members.entries.where((m) => m.value.properties.isField)) {
+      final name = field.key;
+      final type = field.value.returnType;
+      initializers
+          .add('$name = ${_convertTypeFromJson("json[r'$name']", type)}');
+    }
+
+    // TODO(davidmorgan): helper for augmenting initializers.
+    result.add(Augmentation(code: '''
+augment ${target.code}.fromJson($_jsonMapType json) :
+${initializers.join(',\n')};
+'''));
+
+    final serializers = <String>[];
+    for (final field
+        in clazz.members.entries.where((m) => m.value.properties.isField)) {
+      final name = field.key;
+      final type = field.value.returnType;
+      serializers.add("json[r'$name'] = ${_convertTypeToJson(name, type)}");
+    }
+
+    // TODO(davidmorgan): helper for augmenting methods.
+    result.add(Augmentation(code: '''
+$_jsonMapType toJson() {
+${serializers.join(';\n')}
+};
+'''));
+
+    return AugmentResponse(augmentations: result);
+  }
+
+  String _convertTypeFromJson(String reference, StaticTypeDesc type) {
+    // TODO(davidmorgan): _checkNamedType equivalent.
+    final nullable = type.type == StaticTypeDescType.nullableTypeDesc;
+    final orNull = nullable ? '?' : '';
+    final nullCheck = nullable ? '' : '$reference == null ? null : ';
+    final underlyingType = type.type == StaticTypeDescType.nullableTypeDesc
+        ? type.asNullableTypeDesc.inner
+        : type;
+
+    if (underlyingType.type == StaticTypeDescType.namedTypeDesc) {
+      final namedType = underlyingType.asNamedTypeDesc;
+      if (namedType.name.uri == 'dart:core') {
+        switch (namedType.name.name) {
+          case 'bool':
+          case 'String':
+          case 'int':
+          case 'double':
+          case 'num':
+            return '$reference as ${namedType.name.code}$orNull';
+          case 'List':
+            return '$nullCheck [for (final item in $reference '
+                'as {{dart:core#List}}<{{dart:core#Object}}?>) '
+                '${_convertTypeFromJson('item', namedType.instantiation.first)}'
+                ']';
+          case 'Set':
+            return '$nullCheck {for (final item in $reference '
+                'as {{dart:core#Set}}<{{dart:core#Object}}?>) '
+                '${_convertTypeFromJson('item', namedType.instantiation.first)}'
+                '}';
+          case 'Map':
+            return '$nullCheck {for (final (:key, :value) in $reference '
+                'as $_jsonMapType) key: '
+                '${_convertTypeFromJson('value', namedType.instantiation.last)}'
+                '}';
+        }
+      }
+      // TODO(davidmorgan): check for fromJson constructor.
+      return '$nullCheck ${namedType.name.code}.fromJson($reference as '
+          '$_jsonMapType';
+    }
+
+    // TODO(davidmorgan): error reporting.
+    throw UnsupportedError('$type');
+  }
+
+  String _convertTypeToJson(String reference, StaticTypeDesc type) {
+    // TODO(davidmorgan): add _checkNamedType equivalent.
+    final nullable = type.type == StaticTypeDescType.nullableTypeDesc;
+    final nullCheck = nullable ? '' : '$reference == null ? null : ';
+    final underlyingType = type.type == StaticTypeDescType.nullableTypeDesc
+        ? type.asNullableTypeDesc.inner
+        : type;
+
+    if (underlyingType.type == StaticTypeDescType.namedTypeDesc) {
+      final namedType = underlyingType.asNamedTypeDesc;
+      if (namedType.name.uri == 'dart:core') {
+        switch (namedType.name.name) {
+          case 'bool':
+          case 'String':
+          case 'int':
+          case 'double':
+          case 'num':
+            return reference;
+          case 'List':
+          case 'Set':
+            return '$nullCheck {for (final item in $reference) '
+                '${_convertTypeToJson('item', namedType.instantiation.first)}'
+                '}';
+          case 'Map':
+            return '$nullCheck {for (final (:key, :value) in '
+                '$reference.entries) key: '
+                '${_convertTypeToJson('value', namedType.instantiation.last)}'
+                '}';
+        }
+      }
+      // TODO(davidmorgan): check for toJson method.
+      return '$nullCheck $reference.toJson()';
+    }
+
+    // TODO(davidmorgan): error reporting.
+    throw UnsupportedError('$type');
+  }
+}
+
+// TODO(davidmorgan): figure out where this should go.
+extension TemplatingExtension on QualifiedName {
+  String get code => '{{$uri#$name}}';
+}

--- a/pkgs/_test_macros/pubspec.yaml
+++ b/pkgs/_test_macros/pubspec.yaml
@@ -19,4 +19,5 @@ dev_dependencies:
 
 # TODO(language/3728): use the real feature when there is one.
 # macro lib/declare_x_macro.dart#DeclareX package:_test_macros/declare_x_macro.dart#DeclareXImplementation
+# macro lib/json_codable.dart#JsonCodable package:_test_macros/json_codable.dart#JsonCodableImplementation
 # macro lib/query_class.dart#QueryClass package:_test_macros/query_class.dart#QueryClassImplementation

--- a/pkgs/dart_model/lib/src/dart_model.g.dart
+++ b/pkgs/dart_model/lib/src/dart_model.g.dart
@@ -137,16 +137,22 @@ extension type Library.fromJson(Map<String, Object?> node) implements Object {
 extension type Member.fromJson(Map<String, Object?> node) implements Object {
   static final TypedMapSchema _schema = TypedMapSchema({
     'properties': Type.typedMapPointer,
+    'returnType': Type.typedMapPointer,
   });
   Member({
     Properties? properties,
+    StaticTypeDesc? returnType,
   }) : this.fromJson(Scope.createMap(
           _schema,
           properties,
+          returnType,
         ));
 
   /// The properties of this member.
   Properties get properties => node['properties'] as Properties;
+
+  /// The return type of this member, if it has one.
+  StaticTypeDesc get returnType => node['returnType'] as StaticTypeDesc;
 }
 
 /// Partial model of a corpus of Dart source code.

--- a/schemas/dart_model.schema.json
+++ b/schemas/dart_model.schema.json
@@ -113,6 +113,10 @@
         "properties": {
           "$comment": "The properties of this member.",
           "$ref": "#/$defs/Properties"
+        },
+        "returnType": {
+          "$comment": "The return type of this member, if it has one.",
+          "$ref": "#/$defs/StaticTypeDesc"
         }
       }
     },

--- a/tool/dart_model_generator/lib/definitions.dart
+++ b/tool/dart_model_generator/lib/definitions.dart
@@ -80,6 +80,7 @@ final schemas = Schemas([
               Property('scopes',
                   type: 'Map<Interface>', description: 'Scopes by name.'),
             ]),
+        // TODO(davidmorgan): make `Member` a union.
         Definition.clazz('Member',
             description: 'Member of a scope.',
             createInBuffer: true,

--- a/tool/dart_model_generator/lib/definitions.dart
+++ b/tool/dart_model_generator/lib/definitions.dart
@@ -87,6 +87,11 @@ final schemas = Schemas([
               Property('properties',
                   type: 'Properties',
                   description: 'The properties of this member.'),
+              Property(
+                'returnType',
+                type: 'StaticTypeDesc',
+                description: 'The return type of this member, if it has one.',
+              ),
             ]),
         Definition.clazz('Model',
             description: 'Partial model of a corpus of Dart source code.',


### PR DESCRIPTION
Adds a minimal JSON macro, lots of TODOs.

Adds return types for fields to the model + (analyzer only) query handling.

Skip golden tests for analyzer/CFE if there are no goldens, instead of failing.

Uses templating for identifiers as suggested in https://github.com/dart-lang/language/issues/1989#issuecomment-2329438841 ... this is just a proof of concept, we should discuss whether we want templating and if so how it fits into the overall design: it could be client side only or we make the template format part of the protocol. (In the sense of "this string has this specified format which won't change, if you want something different add a new type / field").

I didn't look too closely at the augmentation golden file, just make it approximately match the package:json/json.dart output for the same code. I realize we need yet another type of test, to compile the code with macro applications and then test with it, which in this case would test the JSON produced by the JSON macro. I'll look at how to add that...