### PR TITLE
Add handshake to determine wire encoding and protocol.

### DIFF
--- a/pkgs/_analyzer_macros/lib/macro_implementation.dart
+++ b/pkgs/_analyzer_macros/lib/macro_implementation.dart
@@ -33,8 +33,7 @@ class AnalyzerMacroImplementation implements injected.MacroImplementation {
       AnalyzerMacroImplementation._(
           packageConfig,
           await MacroHost.serve(
-              // TODO(davidmorgan): this should be negotiated per client, not
-              // set here.
+              // TODO(davidmorgan): support serving multiple protocols.
               protocol: protocol,
               packageConfig: packageConfig,
               queryService: AnalyzerQueryService()));

--- a/pkgs/_analyzer_macros/test/analyzer_test.dart
+++ b/pkgs/_analyzer_macros/test/analyzer_test.dart
@@ -25,7 +25,9 @@ void main() {
           AnalysisContextCollection(includedPaths: [directory.path]);
       analysisContext = contextCollection.contexts.first;
       injected.macroImplementation = await AnalyzerMacroImplementation.start(
-          protocol: Protocol(encoding: ProtocolEncoding.binary),
+          protocol: Protocol(
+              encoding: ProtocolEncoding.binary,
+              version: ProtocolVersion.macros1),
           packageConfig: Isolate.packageConfigSync!);
     });
 

--- a/pkgs/_analyzer_macros/test/golden_test.dart
+++ b/pkgs/_analyzer_macros/test/golden_test.dart
@@ -30,7 +30,9 @@ void main() {
           AnalysisContextCollection(includedPaths: [directory.path]);
       analysisContext = contextCollection.contexts.first;
       injected.macroImplementation = await AnalyzerMacroImplementation.start(
-          protocol: Protocol(encoding: ProtocolEncoding.binary),
+          protocol: Protocol(
+              encoding: ProtocolEncoding.binary,
+              version: ProtocolVersion.macros1),
           packageConfig: Isolate.packageConfigSync!);
     });
 

--- a/pkgs/_cfe_macros/lib/macro_implementation.dart
+++ b/pkgs/_cfe_macros/lib/macro_implementation.dart
@@ -27,8 +27,7 @@ class CfeMacroImplementation implements injected.MacroImplementation {
   /// [packageConfig] is the package config of the workspace of the code being
   /// edited.
   static Future<CfeMacroImplementation> start({
-    // TODO(davidmorgan): this should be negotiated per client, not
-    // set here.
+    // TODO(davidmorgan): support serving multiple protocols.
     required Protocol protocol,
     required Uri packageConfig,
   }) async =>

--- a/pkgs/_cfe_macros/test/cfe_test.dart
+++ b/pkgs/_cfe_macros/test/cfe_test.dart
@@ -31,7 +31,9 @@ void main() {
 
       // Inject test macro implementation.
       injected.macroImplementation = await CfeMacroImplementation.start(
-          protocol: Protocol(encoding: ProtocolEncoding.json),
+          protocol: Protocol(
+              encoding: ProtocolEncoding.json,
+              version: ProtocolVersion.macros1),
           packageConfig: Isolate.packageConfigSync!);
     });
 

--- a/pkgs/_cfe_macros/test/golden_test.dart
+++ b/pkgs/_cfe_macros/test/golden_test.dart
@@ -38,7 +38,9 @@ void main() {
 
       // Inject test macro implementation.
       injected.macroImplementation = await CfeMacroImplementation.start(
-          protocol: Protocol(encoding: ProtocolEncoding.json),
+          protocol: Protocol(
+              encoding: ProtocolEncoding.json,
+              version: ProtocolVersion.macros1),
           packageConfig: Isolate.packageConfigSync!);
     });
 

--- a/pkgs/_macro_builder/lib/src/bootstrap.dart
+++ b/pkgs/_macro_builder/lib/src/bootstrap.dart
@@ -20,11 +20,8 @@ import 'package:macro_service/macro_service.dart' as macro_service;
 
 void main(List<String> arguments) {
    macro_client.MacroClient.run(
-      // TODO(davidmorgan): this should be negotiated, not passed here.
-      protocol: macro_service.Protocol.fromJson(
-        convert.json.decode(arguments[0])),
       endpoint: macro_service.HostEndpoint.fromJson(
-        convert.json.decode(arguments[1])),
+        convert.json.decode(arguments[0])),
       macros: [''');
   for (var i = 0; i != macros.length; ++i) {
     final macro = macros[i];

--- a/pkgs/_macro_builder/test/macro_builder_test.dart
+++ b/pkgs/_macro_builder/test/macro_builder_test.dart
@@ -34,11 +34,8 @@ import 'package:macro_service/macro_service.dart' as macro_service;
 
 void main(List<String> arguments) {
    macro_client.MacroClient.run(
-      // TODO(davidmorgan): this should be negotiated, not passed here.
-      protocol: macro_service.Protocol.fromJson(
-        convert.json.decode(arguments[0])),
       endpoint: macro_service.HostEndpoint.fromJson(
-        convert.json.decode(arguments[1])),
+        convert.json.decode(arguments[0])),
       macros: [m0.DeclareX(), m1.DeclareY(), m2.OtherMacroImplementation()]);
 }
 ''');

--- a/pkgs/_macro_host/lib/macro_host.dart
+++ b/pkgs/_macro_host/lib/macro_host.dart
@@ -27,7 +27,7 @@ class MacroHost {
 
   /// Starts a macro host with introspection queries handled by [queryService].
   static Future<MacroHost> serve({
-    // TODO(davidmorgan): this should be negotiated per client, not set here.
+    // TODO(davidmorgan): support serving multiple protocols.
     required Protocol protocol,
     required Uri packageConfig,
     required QueryService queryService,
@@ -86,10 +86,7 @@ class MacroHost {
     _hostService._macroState[annotation.asString] = _MacroState();
     final macroBundle = await macroBuilder.build(
         macroPackageConfig.uri, [lookupMacroImplementation(annotation)!]);
-    macroRunner.start(
-        macroBundle: macroBundle,
-        protocol: macroServer.protocol,
-        endpoint: macroServer.endpoint);
+    macroRunner.start(macroBundle: macroBundle, endpoint: macroServer.endpoint);
   }
 }
 

--- a/pkgs/_macro_host/test/macro_host_test.dart
+++ b/pkgs/_macro_host/test/macro_host_test.dart
@@ -11,8 +11,9 @@ import 'package:test/test.dart';
 
 void main() {
   for (final protocol in [
-    Protocol(encoding: ProtocolEncoding.json),
-    Protocol(encoding: ProtocolEncoding.binary)
+    Protocol(encoding: ProtocolEncoding.json, version: ProtocolVersion.macros1),
+    Protocol(
+        encoding: ProtocolEncoding.binary, version: ProtocolVersion.macros1)
   ]) {
     group('MacroHost using ${protocol.encoding}', () {
       test('hosts a macro, receives augmentations', () async {

--- a/pkgs/_macro_runner/lib/macro_runner.dart
+++ b/pkgs/_macro_runner/lib/macro_runner.dart
@@ -14,12 +14,9 @@ import 'package:macro_service/macro_service.dart';
 class MacroRunner {
   /// Starts [macroBundle] connected to [endpoint].
   void start(
-      {required BuiltMacroBundle macroBundle,
-      // TODO(davidmorgan): this should be negotiated, not passed here.
-      required Protocol protocol,
-      required HostEndpoint endpoint}) {
-    Process.run(macroBundle.executablePath,
-        [json.encode(protocol), json.encode(endpoint)]).then((result) {
+      {required BuiltMacroBundle macroBundle, required HostEndpoint endpoint}) {
+    Process.run(macroBundle.executablePath, [json.encode(endpoint)])
+        .then((result) {
       if (result.exitCode != 0) {
         print('Macro process exited with error: ${result.stderr}');
       }

--- a/pkgs/_macro_runner/test/macro_runner_test.dart
+++ b/pkgs/_macro_runner/test/macro_runner_test.dart
@@ -31,7 +31,6 @@ void main() {
         final runner = MacroRunner();
         runner.start(
             macroBundle: bundle,
-            protocol: protocol,
             endpoint: HostEndpoint(port: serverSocket.port));
 
         expect(

--- a/pkgs/_macro_server/test/macro_server_test.dart
+++ b/pkgs/_macro_server/test/macro_server_test.dart
@@ -14,8 +14,9 @@ import 'package:test/test.dart';
 
 void main() {
   for (final protocol in [
-    Protocol(encoding: ProtocolEncoding.json),
-    Protocol(encoding: ProtocolEncoding.binary)
+    Protocol(encoding: ProtocolEncoding.json, version: ProtocolVersion.macros1),
+    Protocol(
+        encoding: ProtocolEncoding.binary, version: ProtocolVersion.macros1)
   ]) {
     group('MacroServer using ${protocol.encoding}', () {
       test('serves a macro service', () async {
@@ -24,10 +25,7 @@ void main() {
             await MacroServer.serve(protocol: protocol, service: service);
 
         await MacroClient.run(
-            // TODO(davidmorgan): this should be negotiated, not set here.
-            protocol: protocol,
-            endpoint: server.endpoint,
-            macros: [DeclareXImplementation()]);
+            endpoint: server.endpoint, macros: [DeclareXImplementation()]);
 
         // Check that the macro sent its description to the host on startup.
         expect((await service.macroStartedRequests.first).macroDescription,
@@ -53,10 +51,7 @@ void main() {
             await MacroServer.serve(protocol: protocol, service: service);
 
         unawaited(MacroClient.run(
-            // TODO(davidmorgan): this should be negotiated, not set here.
-            protocol: protocol,
-            endpoint: server.endpoint,
-            macros: [DeclareXImplementation()]));
+            endpoint: server.endpoint, macros: [DeclareXImplementation()]));
 
         await server.sendToMacro(HostRequest.augmentRequest(
           id: 1,
@@ -74,16 +69,10 @@ void main() {
             await MacroServer.serve(protocol: protocol, service: service);
 
         unawaited(MacroClient.run(
-            // TODO(davidmorgan): this should be negotiated, not set here.
-            protocol: protocol,
-            endpoint: server.endpoint,
-            macros: [DeclareXImplementation()]));
+            endpoint: server.endpoint, macros: [DeclareXImplementation()]));
 
         unawaited(MacroClient.run(
-            // TODO(davidmorgan): this should be negotiated, not set here.
-            protocol: protocol,
-            endpoint: server.endpoint,
-            macros: [QueryClassImplementation()]));
+            endpoint: server.endpoint, macros: [QueryClassImplementation()]));
 
         await Future.wait([
           server.sendToMacro(HostRequest.augmentRequest(
@@ -110,8 +99,6 @@ void main() {
             await MacroServer.serve(protocol: protocol, service: service);
 
         unawaited(MacroClient.run(
-            // TODO(davidmorgan): this should be negotiated, not set here.
-            protocol: protocol,
             endpoint: server.endpoint,
             macros: [DeclareXImplementation(), QueryClassImplementation()]));
 

--- a/pkgs/macro_service/lib/macro_service.dart
+++ b/pkgs/macro_service/lib/macro_service.dart
@@ -2,5 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+export 'src/handshake.g.dart';
 export 'src/macro_service.dart';
 export 'src/macro_service.g.dart';

--- a/pkgs/macro_service/lib/src/handshake.g.dart
+++ b/pkgs/macro_service/lib/src/handshake.g.dart
@@ -1,0 +1,68 @@
+// This file is generated. To make changes edit tool/dart_model_generator
+// then run from the repo root: dart tool/dart_model_generator/bin/main.dart
+
+// ignore: implementation_imports,unused_import,prefer_relative_imports
+import 'package:dart_model/src/json_buffer/json_buffer_builder.dart';
+// ignore: implementation_imports,unused_import,prefer_relative_imports
+import 'package:dart_model/src/scopes.dart';
+
+/// Request to pick a protocol.
+extension type HandshakeRequest.fromJson(Map<String, Object?> node)
+    implements Object {
+  HandshakeRequest({
+    List<Protocol>? protocols,
+  }) : this.fromJson({
+          if (protocols != null) 'protocols': protocols,
+        });
+
+  /// Supported protocols.
+  List<Protocol> get protocols => (node['protocols'] as List).cast();
+}
+
+/// The picked protocol, or `null` if no requested protocol is supported.
+extension type HandshakeResponse.fromJson(Map<String, Object?> node)
+    implements Object {
+  HandshakeResponse({
+    Protocol? protocol,
+  }) : this.fromJson({
+          if (protocol != null) 'protocol': protocol,
+        });
+
+  /// Supported protocol.
+  Protocol? get protocol => node['protocol'] as Protocol?;
+}
+
+/// The macro to host protocol version and encoding. TODO(davidmorgan): add the version.
+extension type Protocol.fromJson(Map<String, Object?> node) implements Object {
+  Protocol({
+    ProtocolEncoding? encoding,
+    ProtocolVersion? version,
+  }) : this.fromJson({
+          if (encoding != null) 'encoding': encoding,
+          if (version != null) 'version': version,
+        });
+
+  /// The initial protocol for any `host<->macro` connection.
+  static Protocol handshakeProtocol = Protocol(
+      encoding: ProtocolEncoding.json, version: ProtocolVersion.handshake);
+
+  /// The wire format: json or binary.
+  ProtocolEncoding get encoding => node['encoding'] as ProtocolEncoding;
+
+  /// The protocol version, a name and number.
+  ProtocolVersion get version => node['version'] as ProtocolVersion;
+}
+
+/// The wire encoding used.
+extension type const ProtocolEncoding.fromJson(String string)
+    implements Object {
+  static const ProtocolEncoding json = ProtocolEncoding.fromJson('json');
+  static const ProtocolEncoding binary = ProtocolEncoding.fromJson('binary');
+}
+
+/// The protocol version.
+extension type const ProtocolVersion.fromJson(String string) implements Object {
+  static const ProtocolVersion handshake =
+      ProtocolVersion.fromJson('handshake');
+  static const ProtocolVersion macros1 = ProtocolVersion.fromJson('macros1');
+}

--- a/pkgs/macro_service/lib/src/macro_service.dart
+++ b/pkgs/macro_service/lib/src/macro_service.dart
@@ -8,6 +8,7 @@ import 'dart:typed_data';
 
 import 'package:dart_model/serialization.dart';
 
+import 'handshake.g.dart';
 import 'macro_service.g.dart';
 import 'message_grouper.dart';
 
@@ -81,6 +82,7 @@ extension ProtocolExtension on Protocol {
             .bind(stream)
             .transform(const LineSplitter())
             .map((line) => json.decode(line) as Map<String, Object?>);
+
       case ProtocolEncoding.binary:
         return MessageGrouper(stream)
             .messageStream
@@ -89,6 +91,9 @@ extension ProtocolExtension on Protocol {
         throw StateError('Unsupported protocol: $this');
     }
   }
+
+  bool equals(Protocol other) =>
+      encoding == other.encoding && version == other.version;
 }
 
 final _utf8Newline = const Utf8Encoder().convert('\n');

--- a/pkgs/macro_service/lib/src/macro_service.g.dart
+++ b/pkgs/macro_service/lib/src/macro_service.g.dart
@@ -206,25 +206,6 @@ extension type MacroRequest.fromJson(Map<String, Object?> node)
   int get id => node['id'] as int;
 }
 
-/// The macro to host protocol version and encoding. TODO(davidmorgan): add the version.
-extension type Protocol.fromJson(Map<String, Object?> node) implements Object {
-  Protocol({
-    ProtocolEncoding? encoding,
-  }) : this.fromJson({
-          if (encoding != null) 'encoding': encoding,
-        });
-
-  /// The wire format: json or binary.
-  ProtocolEncoding get encoding => node['encoding'] as ProtocolEncoding;
-}
-
-/// The wire encoding used.
-extension type const ProtocolEncoding.fromJson(String string)
-    implements Object {
-  static const ProtocolEncoding json = ProtocolEncoding.fromJson('json');
-  static const ProtocolEncoding binary = ProtocolEncoding.fromJson('binary');
-}
-
 /// Macro's query about the code it should augment.
 extension type QueryRequest.fromJson(Map<String, Object?> node)
     implements Object {

--- a/schemas/handshake.schema.json
+++ b/schemas/handshake.schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "oneOf": [
+    {
+      "$ref": "#/$defs/HandshakeRequest"
+    },
+    {
+      "$ref": "#/$defs/HandshakeResponse"
+    }
+  ],
+  "$defs": {
+    "HandshakeRequest": {
+      "type": "object",
+      "description": "Request to pick a protocol.",
+      "properties": {
+        "protocols": {
+          "type": "array",
+          "description": "Supported protocols.",
+          "items": {
+            "$ref": "#/$defs/Protocol"
+          }
+        }
+      }
+    },
+    "HandshakeResponse": {
+      "type": "object",
+      "description": "The picked protocol, or `null` if no requested protocol is supported.",
+      "properties": {
+        "protocol": {
+          "$comment": "Supported protocol.",
+          "$ref": "#/$defs/Protocol"
+        }
+      }
+    },
+    "Protocol": {
+      "type": "object",
+      "description": "The macro to host protocol version and encoding. TODO(davidmorgan): add the version.",
+      "properties": {
+        "encoding": {
+          "$comment": "The wire format: json or binary.",
+          "$ref": "#/$defs/ProtocolEncoding"
+        },
+        "version": {
+          "$comment": "The protocol version, a name and number.",
+          "$ref": "#/$defs/ProtocolVersion"
+        }
+      }
+    },
+    "ProtocolEncoding": {
+      "type": "string",
+      "description": "The wire encoding used."
+    },
+    "ProtocolVersion": {
+      "type": "string",
+      "description": "The protocol version."
+    }
+  }
+}

--- a/schemas/macro_service.schema.json
+++ b/schemas/macro_service.schema.json
@@ -148,20 +148,6 @@
         ]
       }
     },
-    "Protocol": {
-      "type": "object",
-      "description": "The macro to host protocol version and encoding. TODO(davidmorgan): add the version.",
-      "properties": {
-        "encoding": {
-          "$comment": "The wire format: json or binary.",
-          "$ref": "#/$defs/ProtocolEncoding"
-        }
-      }
-    },
-    "ProtocolEncoding": {
-      "type": "string",
-      "description": "The wire encoding used."
-    },
     "QueryRequest": {
       "type": "object",
       "description": "Macro's query about the code it should augment.",

--- a/tool/dart_model_generator/lib/definitions.dart
+++ b/tool/dart_model_generator/lib/definitions.dart
@@ -6,6 +6,56 @@ import 'generate_dart_model.dart';
 
 final schemas = Schemas([
   Schema(
+    schemaPath: 'handshake.schema.json',
+    codePackage: 'macro_service',
+    codePath: 'src/handshake.g.dart',
+    rootTypes: ['HandshakeRequest', 'HandshakeResponse'],
+    declarations: [
+      Definition.clazz('HandshakeRequest',
+          description: 'Request to pick a protocol.',
+          properties: [
+            Property(
+              'protocols',
+              type: 'List<Protocol>',
+              description: 'Supported protocols.',
+            ),
+          ]),
+      Definition.clazz('HandshakeResponse',
+          description:
+              'The picked protocol, or `null` if no requested protocol '
+              'is supported.',
+          properties: [
+            Property(
+              'protocol',
+              type: 'Protocol',
+              description: 'Supported protocol.',
+              nullable: true,
+            ),
+          ]),
+      Definition.clazz('Protocol',
+          description: 'The macro to host protocol version and encoding. '
+              'TODO(davidmorgan): add the version.',
+          properties: [
+            Property('encoding',
+                type: 'ProtocolEncoding',
+                description: 'The wire format: json or binary.'),
+            Property('version',
+                type: 'ProtocolVersion',
+                description: 'The protocol version, a name and number.'),
+          ],
+          extraCode: '''
+/// The initial protocol for any `host<->macro` connection.
+static Protocol handshakeProtocol = Protocol(
+    encoding: ProtocolEncoding.json, version: ProtocolVersion.handshake);
+'''),
+      Definition.$enum('ProtocolEncoding',
+          description: 'The wire encoding used.', values: ['json', 'binary']),
+      Definition.$enum('ProtocolVersion',
+          description: 'The protocol version.',
+          values: ['handshake', 'macros1']),
+    ],
+  ),
+  Schema(
       schemaPath: 'dart_model.schema.json',
       codePackage: 'dart_model',
       codePath: 'src/dart_model.g.dart',
@@ -353,16 +403,6 @@ static QualifiedName parse(String string) {
                       'The id of this request, must be returned in responses.',
                   required: true),
             ]),
-        Definition.clazz('Protocol',
-            description: 'The macro to host protocol version and encoding. '
-                'TODO(davidmorgan): add the version.',
-            properties: [
-              Property('encoding',
-                  type: 'ProtocolEncoding',
-                  description: 'The wire format: json or binary.'),
-            ]),
-        Definition.$enum('ProtocolEncoding',
-            description: 'The wire encoding used.', values: ['json', 'binary']),
         Definition.clazz('QueryRequest',
             description: "Macro's query about the code it should augment.",
             properties: [


### PR DESCRIPTION
For now the host simply has one encoding+protocol that it wants to use and it will only use that.

The next PR in this area should be able to add support for actual protocol breaking changes.

This is an important thing to get right so it should come with a design doc :)

I don't think anything else is blocked on this so it's relatively low priority.