### PR TITLE
Add `whereType` extension methods for iterables of union extension types.

### DIFF
--- a/pkgs/dart_model/lib/src/dart_model.g.dart
+++ b/pkgs/dart_model/lib/src/dart_model.g.dart
@@ -514,6 +514,33 @@ extension type StaticTypeDesc.fromJson(Map<String, Object?> node)
   }
 }
 
+extension IterableOfStaticTypeDescExtension on Iterable<StaticTypeDesc> {
+  Iterable<DynamicTypeDesc> whereTypeDynamicTypeDesc() =>
+      where((e) => e.type == StaticTypeDescType.dynamicTypeDesc)
+          .map((e) => e.asDynamicTypeDesc);
+  Iterable<FunctionTypeDesc> whereTypeFunctionTypeDesc() =>
+      where((e) => e.type == StaticTypeDescType.functionTypeDesc)
+          .map((e) => e.asFunctionTypeDesc);
+  Iterable<NamedTypeDesc> whereTypeNamedTypeDesc() =>
+      where((e) => e.type == StaticTypeDescType.namedTypeDesc)
+          .map((e) => e.asNamedTypeDesc);
+  Iterable<NeverTypeDesc> whereTypeNeverTypeDesc() =>
+      where((e) => e.type == StaticTypeDescType.neverTypeDesc)
+          .map((e) => e.asNeverTypeDesc);
+  Iterable<NullableTypeDesc> whereTypeNullableTypeDesc() =>
+      where((e) => e.type == StaticTypeDescType.nullableTypeDesc)
+          .map((e) => e.asNullableTypeDesc);
+  Iterable<RecordTypeDesc> whereTypeRecordTypeDesc() =>
+      where((e) => e.type == StaticTypeDescType.recordTypeDesc)
+          .map((e) => e.asRecordTypeDesc);
+  Iterable<TypeParameterTypeDesc> whereTypeTypeParameterTypeDesc() =>
+      where((e) => e.type == StaticTypeDescType.typeParameterTypeDesc)
+          .map((e) => e.asTypeParameterTypeDesc);
+  Iterable<VoidTypeDesc> whereTypeVoidTypeDesc() =>
+      where((e) => e.type == StaticTypeDescType.voidTypeDesc)
+          .map((e) => e.asVoidTypeDesc);
+}
+
 /// A resolved type parameter introduced by a [FunctionTypeDesc].
 extension type StaticTypeParameterDesc.fromJson(Map<String, Object?> node)
     implements Object {

--- a/pkgs/dart_model/test/model_test.dart
+++ b/pkgs/dart_model/test/model_test.dart
@@ -107,6 +107,26 @@ void main() {
           expected['uris']!['package:dart_model/dart_model.dart']!['scopes']![
               'JsonData']!['members']);
     });
+
+    test('whereType extension methods', () {
+      Scope.macro.run(() {
+        final functionType = FunctionTypeDesc();
+        final namedType = NamedTypeDesc(
+            name: QualifiedName.parse('package:foo/foo.dart#Foo'));
+        final namedType2 = NamedTypeDesc(
+            name: QualifiedName.parse('package:foo/foo.dart#Foo2'));
+        final types = [
+          StaticTypeDesc.functionTypeDesc(functionType),
+          StaticTypeDesc.namedTypeDesc(namedType),
+          StaticTypeDesc.namedTypeDesc(namedType2)
+        ];
+
+        expect(types.whereTypeFunctionTypeDesc(), [functionType]);
+        expect(types.whereTypeNamedTypeDesc(), [namedType, namedType2]);
+
+        expect(types.whereTypeNamedTypeDesc().first.name.name, 'Foo');
+      });
+    });
   });
 
   group(QualifiedName, () {

--- a/pkgs/macro_service/lib/src/macro_service.g.dart
+++ b/pkgs/macro_service/lib/src/macro_service.g.dart
@@ -110,6 +110,12 @@ extension type HostRequest.fromJson(Map<String, Object?> node)
   QualifiedName get macroAnnotation => node['macroAnnotation'] as QualifiedName;
 }
 
+extension IterableOfHostRequestExtension on Iterable<HostRequest> {
+  Iterable<AugmentRequest> whereTypeAugmentRequest() =>
+      where((e) => e.type == HostRequestType.augmentRequest)
+          .map((e) => e.asAugmentRequest);
+}
+
 /// Information about a macro that the macro provides to the host.
 extension type MacroDescription.fromJson(Map<String, Object?> node)
     implements Object {
@@ -204,6 +210,15 @@ extension type MacroRequest.fromJson(Map<String, Object?> node)
 
   /// The id of this request, must be returned in responses.
   int get id => node['id'] as int;
+}
+
+extension IterableOfMacroRequestExtension on Iterable<MacroRequest> {
+  Iterable<MacroStartedRequest> whereTypeMacroStartedRequest() =>
+      where((e) => e.type == MacroRequestType.macroStartedRequest)
+          .map((e) => e.asMacroStartedRequest);
+  Iterable<QueryRequest> whereTypeQueryRequest() =>
+      where((e) => e.type == MacroRequestType.queryRequest)
+          .map((e) => e.asQueryRequest);
 }
 
 /// The macro to host protocol version and encoding. TODO(davidmorgan): add the version.
@@ -344,4 +359,19 @@ extension type Response.fromJson(Map<String, Object?> node) implements Object {
 
   /// The id of the request this is responding to.
   int get requestId => node['requestId'] as int;
+}
+
+extension IterableOfResponseExtension on Iterable<Response> {
+  Iterable<AugmentResponse> whereTypeAugmentResponse() =>
+      where((e) => e.type == ResponseType.augmentResponse)
+          .map((e) => e.asAugmentResponse);
+  Iterable<ErrorResponse> whereTypeErrorResponse() =>
+      where((e) => e.type == ResponseType.errorResponse)
+          .map((e) => e.asErrorResponse);
+  Iterable<MacroStartedResponse> whereTypeMacroStartedResponse() =>
+      where((e) => e.type == ResponseType.macroStartedResponse)
+          .map((e) => e.asMacroStartedResponse);
+  Iterable<QueryResponse> whereTypeQueryResponse() =>
+      where((e) => e.type == ResponseType.queryResponse)
+          .map((e) => e.asQueryResponse);
 }

--- a/tool/dart_model_generator/lib/generate_dart_model.dart
+++ b/tool/dart_model_generator/lib/generate_dart_model.dart
@@ -658,6 +658,16 @@ class UnionTypeDefinition implements Definition {
       result.writeln(property.getterCode);
     }
     result.writeln('}');
+
+    result.writeln('extension IterableOf${name}Extension on Iterable<$name> {');
+    for (final type in types) {
+      final lowerType = _firstToLowerCase(type);
+      result.writeln('Iterable<$type> whereType$type() => '
+          'where((e) => e.type == ${name}Type.$lowerType)'
+          '.map((e) => e.as$type);');
+    }
+    result.writeln('}');
+
     return result.toString();
   }
 


### PR DESCRIPTION
It occurred to me that this might be a useful type of extension method to add, what do you think?