### PR TITLE
Push resolved model into macro scope

### DIFF
--- a/pkgs/_macro_client/lib/macro_client.dart
+++ b/pkgs/_macro_client/lib/macro_client.dart
@@ -150,10 +150,12 @@ class RemoteMacroHost implements Host {
   Future<Model> query(Query query) async {
     // The macro scope is used to accumulate augment results, drop into
     // "none" scope to avoid clashing with those when sending the query.
-    return (await Scope.none.runAsync(() async => _client._sendRequest(
+    final model = (await Scope.none.runAsync(() async => _client._sendRequest(
             MacroRequest.queryRequest(QueryRequest(query: query),
                 id: nextRequestId))))
         .asQueryResponse
         .model;
+    MacroScope.current.addModel(model);
+    return model;
   }
 }

--- a/pkgs/dart_model/lib/src/type.dart
+++ b/pkgs/dart_model/lib/src/type.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import 'dart_model.dart';
+import 'type_system.dart';
 
 /// A resolved representation of static type extracted from the [StaticTypeDesc]
 /// protocol models.
@@ -81,6 +82,21 @@ sealed class StaticType {
   /// For types that are unknown to this macro client, e.g. because a new type
   /// representation has been added to the SDK, this method throws an error.
   Ret accept<Arg, Ret>(TypeVisitor<Arg, Ret> visitor, Arg arg);
+
+  /// Returns whether `this` type is a subtype of [other] under the type system
+  /// of the current resolved model.
+  bool isSubtypeOf(StaticType other) {
+    return StaticTypeSystem.current.isSubtype(this, other);
+  }
+
+  /// Returns whether `this` type is semantically equal to [other] under the
+  /// type system of the current resolved model.
+  ///
+  /// Two types are equal if they are subtypes of each other. For instance,
+  /// `Never?` and `Null` are equal types.
+  bool isEqualTo(StaticType other) {
+    return StaticTypeSystem.current.areEqual(this, other);
+  }
 }
 
 /// An unknown type from the schema that doesn't have a known representation.

--- a/pkgs/dart_model/lib/src/type_system.dart
+++ b/pkgs/dart_model/lib/src/type_system.dart
@@ -18,6 +18,8 @@ final class StaticTypeSystem {
 
   StaticTypeSystem(this._hierarchy);
 
+  static StaticTypeSystem get current => MacroScope.current.typeSystem;
+
   TypeHierarchyEntry _lookupEntry(String qualifiedName) {
     return _hierarchy.named[qualifiedName]!;
   }

--- a/pkgs/dart_model/test/type_test.dart
+++ b/pkgs/dart_model/test/type_test.dart
@@ -1,0 +1,60 @@
+import 'package:dart_model/dart_model.dart';
+import 'package:test/test.dart';
+
+void main() {
+  void setupTypeHierarchyModel() {
+    final hierarchy = TypeHierarchy();
+
+    void registerCoreType(String name, [String? extending]) {
+      hierarchy.named['dart:core#$name'] = TypeHierarchyEntry(
+        self: NamedTypeDesc(
+          name: QualifiedName(name: name, uri: 'dart:core'),
+          instantiation: [],
+        ),
+        typeParameters: [],
+        supertypes: [
+          if (extending != null)
+            NamedTypeDesc(
+              name: QualifiedName(name: extending, uri: 'dart:core'),
+              instantiation: [],
+            ),
+        ],
+      );
+    }
+
+    registerCoreType('Object');
+    registerCoreType('String', 'Object');
+    MacroScope.current.addModel(Model(types: hierarchy));
+  }
+
+  StaticTypeDesc coreType(String name) {
+    return StaticTypeDesc.namedTypeDesc(NamedTypeDesc(
+      name: QualifiedName(name: name, uri: 'dart:core'),
+      instantiation: [],
+    ));
+  }
+
+  test('isSubtype uses resolved model', () {
+    Scope.macro.run(() {
+      setupTypeHierarchyModel();
+
+      final object = StaticType(coreType('Object'));
+      final string = StaticType(coreType('String'));
+
+      expect(string.isSubtypeOf(object), isTrue);
+      expect(object.isSubtypeOf(string), isFalse);
+    });
+  });
+
+  test('isEqualTo uses resolved model', () {
+    Scope.macro.run(() {
+      setupTypeHierarchyModel();
+
+      final object = StaticType(coreType('Object'));
+      final string = StaticType(coreType('String'));
+
+      expect(string.isEqualTo(string), isTrue);
+      expect(object.isEqualTo(string), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
This adds the `MacroScope` class only exposed publicly via zone values. It has a method to add a new `Model` into an accumulated view that we can expand with multiple resolve calls.

By having this information in the zone, we can make derived utilities (like the `StaticTypeSystem`) available globally, allowing things like `isSubtypeOf` to be added as an extension on static types.

Closes https://github.com/dart-lang/macros/issues/73.