### PR TITLE
Add Model.qualifiedNameOfMember, add fast way to find the path to JsonBufferBuilder

### DIFF
--- a/pkgs/dart_model/lib/src/dart_model.dart
+++ b/pkgs/dart_model/lib/src/dart_model.dart
@@ -24,20 +24,36 @@ extension ModelExtension on Model {
   /// types of node we want this functionality exposed for.
   /// TODO(davidmorgan): a list of path segments is probably more useful than
   /// `String`.
-  String? pathToMember(Member member) => _pathTo(member.node);
+  QualifiedName? qualifiedNameOfMember(Member member) =>
+      _qualifiedNameOf(member.node);
 
-  /// Returns the path in the model to [node], or `null` if [node] is not in this [Model].
-  String? _pathTo(Map<String, Object?> node) {
-    if (node == this.node) return '';
-    final parent = _getParent(node);
-    if (parent == null) return null;
-    for (final entry in parent.entries) {
-      if (entry.value == node) {
-        final parentPath = _pathTo(parent);
-        return parentPath == null ? null : '$parentPath/${entry.key}';
-      }
+  /// Returns the [QualifiedName] in the model to [node], or `null` if [node] is not in this [Model].
+  QualifiedName? _qualifiedNameOf(Map<String, Object?> node) {
+    final members = _getParent(node);
+    if (members == null) return null;
+    final interface = _getParent(members);
+    if (interface == null) return null;
+    final scopes = _getParent(interface);
+    if (scopes == null) return null;
+    final library = _getParent(scopes);
+    if (library == null) return null;
+    final libraries = _getParent(library);
+    if (libraries == null) return null;
+
+    final uri = _keyOf(library, libraries);
+    final name = _keyOf(interface, scopes);
+
+    return QualifiedName(uri: uri, name: name);
+  }
+
+  /// Returns the key of [value] in [map].
+  ///
+  /// Throws if [value] is not in [map].
+  String _keyOf(Object value, Map<String, Object?> map) {
+    for (final entry in map.entries) {
+      if (entry.value == value) return entry.key;
     }
-    return null;
+    throw ArgumentError('Value not in map: $value, $map');
   }
 
   /// Gets the `Map` that contains [node], or `null` if there isn't one.

--- a/pkgs/dart_model/lib/src/dart_model.dart
+++ b/pkgs/dart_model/lib/src/dart_model.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart_model.g.dart';
+import 'json_buffer/json_buffer_builder.dart';
 
 export 'dart_model.g.dart';
 
@@ -11,3 +12,65 @@ extension QualifiedNameExtension on QualifiedName {
 
   bool equals(QualifiedName other) => other.uri == uri && other.name == name;
 }
+
+extension ModelExtension on Model {
+  /// Returns the path in the model to [member], or `null` if [member] is not in this `Model`.
+  ///
+  /// TODO(davidmorgan): this works for any node, but it's not clear yet which types of
+  /// node we want this functionality exposed for.
+  /// TODO(davidmorgan): a list of path segments is probably more useful than `String`.
+  String? pathToMember(Member member) => _pathTo(member.node);
+
+  /// Returns the path in the model to [node], or `null` if [node] is not in this `Model`.
+  String? _pathTo(Map<String, Object?> node) {
+    if (node == this.node) return '';
+    final parent = _getParent(node);
+    if (parent == null) return null;
+    for (final entry in parent.entries) {
+      if (entry.value == node) {
+        final parentPath = _pathTo(parent);
+        return parentPath == null ? null : '${_pathTo(parent)}/${entry.key}';
+      }
+    }
+    return null;
+  }
+
+  /// Gets the `Map` that contains [node], or `null` if there isn't one.
+  Map<String, Object?>? _getParent(Map<String, Object?> node) {
+    // If both maps are in the same `JsonBufferBuilder` then the parent is
+    // immediately available.
+    if (this is MapInBuffer && node is MapInBuffer) {
+      final thisMapInBuffer = this as MapInBuffer;
+      final thatMapInBuffer = node as MapInBuffer;
+      if (thisMapInBuffer.buffer == thatMapInBuffer.buffer) {
+        return thatMapInBuffer.parent;
+      }
+    }
+    // Otherwise, build a `Map` of references to parents and use that.
+    return _parentsMap[node];
+  }
+
+  /// Gets a `Map` from values to parent `Map`s.
+  Map<Map<String, Object?>, Map<String, Object?>> get _parentsMap {
+    var result = _parentsMaps[this];
+    if (result == null) {
+      result =
+          _parentsMaps[this] = <Map<String, Object?>, Map<String, Object?>>{};
+      _buildParentsMap(node, result);
+    }
+    return result;
+  }
+
+  /// Builds a `Map` from values to parent `Map`s.
+  static void _buildParentsMap(Map<String, Object?> parent,
+      Map<Map<String, Object?>, Map<String, Object?>> result) {
+    for (final child in parent.values.whereType<Map<String, Object?>>()) {
+      result[child] = parent;
+      _buildParentsMap(child, result);
+    }
+  }
+}
+
+/// Expando storing a `Map` from values to parent `Map`s.
+final Expando<Map<Map<String, Object?>, Map<String, Object?>>> _parentsMaps =
+    Expando();

--- a/pkgs/dart_model/lib/src/json_buffer/closed_map.dart
+++ b/pkgs/dart_model/lib/src/json_buffer/closed_map.dart
@@ -114,7 +114,7 @@ class _ClosedMap
       other._pointer == _pointer;
 
   @override
-  int get hashCode => buffer.hashCode ^ _pointer.hashCode;
+  int get hashCode => Object.hash(buffer, _pointer);
 }
 
 /// `Iterator` that reads a "closed map" in a [JsonBufferBuilder].

--- a/pkgs/dart_model/lib/src/json_buffer/growable_map.dart
+++ b/pkgs/dart_model/lib/src/json_buffer/growable_map.dart
@@ -166,7 +166,7 @@ class _GrowableMap<V>
       other._pointer == _pointer;
 
   @override
-  int get hashCode => buffer.hashCode ^ _pointer.hashCode;
+  int get hashCode => Object.hash(buffer, _pointer);
 }
 
 /// `Iterator` that reads a "growable map" in a [JsonBufferBuilder].

--- a/pkgs/dart_model/lib/src/json_buffer/iterables.dart
+++ b/pkgs/dart_model/lib/src/json_buffer/iterables.dart
@@ -39,3 +39,13 @@ class _IteratorFunctionIterable<T> extends Iterable<T> {
   @override
   Iterator<T> get iterator => _function();
 }
+
+/// A `Map` in a `JsonBufferBuilder`.
+abstract interface class MapInBuffer {
+  /// The buffer backing this `Map`.
+  JsonBufferBuilder get buffer;
+
+  /// The `Map` that contains this value, or `null` if this value has not been
+  /// added to a `Map` or is itself the root `Map`.
+  Map<String, Object?>? get parent;
+}

--- a/pkgs/dart_model/lib/src/json_buffer/json_buffer_builder.dart
+++ b/pkgs/dart_model/lib/src/json_buffer/json_buffer_builder.dart
@@ -42,7 +42,7 @@ class JsonBufferBuilder {
   JsonBufferBuilder.deserialize(this._buffer)
       : _allowWrites = false,
         _nextFree = _buffer.length {
-    map = _readGrowableMap<Object?>(0);
+    map = _readGrowableMap<Object?>(0, null);
   }
 
   JsonBufferBuilder()
@@ -63,13 +63,13 @@ class JsonBufferBuilder {
 
   /// Reads the value at [_Pointer], which must have been written with
   /// [_writeAny].
-  Object? _readAny(_Pointer pointer) {
+  Object? _readAny(_Pointer pointer, {Map<String, Object?>? parent}) {
     final type = _readType(pointer);
-    return _read(type, pointer + _typeSize);
+    return _read(type, pointer + _typeSize, parent: parent);
   }
 
   /// Reads the value of type [Type] at [_Pointer].
-  Object? _read(Type type, _Pointer pointer) {
+  Object? _read(Type type, _Pointer pointer, {Map<String, Object?>? parent}) {
     switch (type) {
       case Type.nil:
         return null;
@@ -88,11 +88,11 @@ class JsonBufferBuilder {
       case Type.closedListPointer:
         return _readClosedList(_readPointer(pointer));
       case Type.closedMapPointer:
-        return _readClosedMap(_readPointer(pointer));
+        return _readClosedMap(_readPointer(pointer), parent);
       case Type.growableMapPointer:
-        return _readGrowableMap<Object?>(_readPointer(pointer));
+        return _readGrowableMap<Object?>(_readPointer(pointer), parent);
       case Type.typedMapPointer:
-        return _readTypedMap(_readPointer(pointer));
+        return _readTypedMap(_readPointer(pointer), parent);
     }
   }
 

--- a/pkgs/dart_model/lib/src/json_buffer/type.dart
+++ b/pkgs/dart_model/lib/src/json_buffer/type.dart
@@ -54,11 +54,11 @@ enum Type {
       case List():
         return Type.closedListPointer;
       case _TypedMap():
-        return builder == value._buffer
+        return builder == value.buffer
             ? Type.typedMapPointer
             : Type.closedMapPointer;
       case _GrowableMap():
-        return builder == value._buffer
+        return builder == value.buffer
             ? Type.growableMapPointer
             : Type.closedMapPointer;
       case Map():

--- a/pkgs/dart_model/lib/src/json_buffer/typed_map.dart
+++ b/pkgs/dart_model/lib/src/json_buffer/typed_map.dart
@@ -359,7 +359,7 @@ class _TypedMap
       other._pointer == _pointer;
 
   @override
-  int get hashCode => buffer.hashCode ^ _pointer.hashCode;
+  int get hashCode => Object.hash(buffer, _pointer);
 }
 
 /// `Iterator` that reads a "typed map" in a [JsonBufferBuilder].

--- a/pkgs/dart_model/lib/src/json_buffer/typed_map.dart
+++ b/pkgs/dart_model/lib/src/json_buffer/typed_map.dart
@@ -224,7 +224,7 @@ extension TypedMaps on JsonBufferBuilder {
     }
 
     _explanations?.pop();
-    return _TypedMap(this, pointer);
+    return _TypedMap(this, pointer, null);
   }
 
   /// Returns the [_Pointer] to [map].
@@ -237,23 +237,27 @@ extension TypedMaps on JsonBufferBuilder {
 
   /// Throws if [map is backed by a different buffer to `this`.
   void _checkTypedMapOwnership(_TypedMap map) {
-    if (map._buffer != this) {
+    if (map.buffer != this) {
       throw UnsupportedError('Maps created with `createTypedMap` can only '
           'be added to the JsonBufferBuilder instance that created them.');
     }
   }
 
   /// Returns the [_TypedMap] at [pointer].
-  Map<String, Object?> _readTypedMap(_Pointer pointer) {
-    return _TypedMap(this, pointer);
+  Map<String, Object?> _readTypedMap(
+      _Pointer pointer, Map<String, Object?>? parent) {
+    return _TypedMap(this, pointer, parent);
   }
 }
 
 class _TypedMap
     with MapMixin<String, Object?>, _EntryMapMixin
-    implements Map<String, Object?> {
-  final JsonBufferBuilder _buffer;
+    implements Map<String, Object?>, MapInBuffer {
+  @override
+  final JsonBufferBuilder buffer;
   final _Pointer _pointer;
+  @override
+  final Map<String, Object?>? parent;
 
   // If a `TypedMap` is created then immediately added to another `Map` then
   // these values are never needed, just the `_pointer`. Use `late` so they are
@@ -261,17 +265,17 @@ class _TypedMap
 
   late final _Pointer _schemaPointer =
       // The high byte of the schema pointer indicates "filled", omit it.
-      _buffer._readPointer(_pointer) & 0x7fffffff;
+      buffer._readPointer(_pointer) & 0x7fffffff;
 
   /// The schema of this "typed map" giving its field names and types.
   late final TypedMapSchema _schema =
-      _buffer._schemasByPointer[_schemaPointer] ??=
-          TypedMapSchema(_buffer._readClosedMap(_schemaPointer).cast());
+      buffer._schemasByPointer[_schemaPointer] ??=
+          TypedMapSchema(buffer._readClosedMap(_schemaPointer, null).cast());
 
   /// Whether all fields are present, meaning no explicit field set was written.
-  late final bool filled = (_buffer._readPointer(_pointer) & 0x80000000) != 0;
+  late final bool filled = (buffer._readPointer(_pointer) & 0x80000000) != 0;
 
-  _TypedMap(this._buffer, this._pointer);
+  _TypedMap(this.buffer, this._pointer, this.parent);
 
   /// Whether the field at [index] is present.
   bool _hasField(int index) {
@@ -282,7 +286,7 @@ class _TypedMap
     if (filled) return true;
     final byte = index ~/ 8;
     final bit = index % 8;
-    return _buffer._readBit(_pointer + _pointerSize + byte, bit);
+    return buffer._readBit(_pointer + _pointerSize + byte, bit);
   }
 
   @override
@@ -347,6 +351,15 @@ class _TypedMap
     throw UnsupportedError(
         'This JsonBufferBuilder map is read-only, see "createGrowableMap".');
   }
+
+  @override
+  bool operator ==(Object other) =>
+      other is _TypedMap &&
+      other.buffer == buffer &&
+      other._pointer == _pointer;
+
+  @override
+  int get hashCode => buffer.hashCode ^ _pointer.hashCode;
 }
 
 /// `Iterator` that reads a "typed map" in a [JsonBufferBuilder].
@@ -363,7 +376,7 @@ abstract class _PartialTypedMapIterator<T> implements Iterator<T> {
   int _offset = -1;
 
   _PartialTypedMapIterator(this._map)
-      : _buffer = _map._buffer,
+      : _buffer = _map.buffer,
         _schema = _map._schema,
         _valuesPointer = _map._pointer +
             _pointerSize +
@@ -374,7 +387,8 @@ abstract class _PartialTypedMapIterator<T> implements Iterator<T> {
 
   String get _currentKey => _schema._keys[_index];
   Object? get _currentValue =>
-      _buffer._read(_schema._valueTypes[_index], _valuesPointer + _offset);
+      _buffer._read(_schema._valueTypes[_index], _valuesPointer + _offset,
+          parent: _map);
 
   @override
   bool moveNext() {
@@ -436,7 +450,7 @@ abstract class _AllBoolsTypedMapIterator<T> implements Iterator<T> {
   int _bitOffset = 7;
 
   _AllBoolsTypedMapIterator(this._map)
-      : _buffer = _map._buffer,
+      : _buffer = _map.buffer,
         _schema = _map._schema,
         _valuesPointer = _map._pointer +
             _pointerSize +

--- a/pkgs/dart_model/test/json_buffer/closed_map_test.dart
+++ b/pkgs/dart_model/test/json_buffer/closed_map_test.dart
@@ -20,6 +20,24 @@ void main() {
       printOnFailure(builder.toString());
     });
 
+    test('equality and hashing is by identity', () {
+      builder.map['a'] = <String, Object?>{};
+      final closedMap1 = builder.map['a'] as Map<String, Object?>;
+      builder.map['b'] = <String, Object?>{};
+      final closedMap2 = builder.map['b'] as Map<String, Object?>;
+
+      // Different maps with the same contents are not equal, have different hash codes.
+      // Can't use default `expect` equality check as it special-cases `Map`.
+      expect(closedMap1 == closedMap2, false);
+      expect(closedMap1.hashCode, isNot(closedMap2.hashCode));
+
+      // Map is equal to a reference to itself, has same hash code.
+      builder.map['a'] = closedMap1;
+      final closedMap1Reference = builder.map['a'] as Map<String, Object?>;
+      expect(closedMap1 == closedMap1Reference, true);
+      expect(closedMap1.hashCode, closedMap1Reference.hashCode);
+    });
+
     test('simple write and read', () {
       final value = {'a': 1, 'b': 2};
       builder.map['value'] = value;

--- a/pkgs/dart_model/test/json_buffer/growable_map_test.dart
+++ b/pkgs/dart_model/test/json_buffer/growable_map_test.dart
@@ -20,6 +20,22 @@ void main() {
       printOnFailure(builder.toString());
     });
 
+    test('equality and hashing is by identity', () {
+      final growableMap1 = builder.createGrowableMap<int>();
+      final growableMap2 = builder.createGrowableMap<int>();
+
+      // Different maps with the same contents are not equal, have different hash codes.
+      // Can't use default `expect` equality check as it special-cases `Map`.
+      expect(growableMap1 == growableMap2, false);
+      expect(growableMap1.hashCode, isNot(growableMap2.hashCode));
+
+      // Map is equal to a reference to itself, has same hash code.
+      builder.map['a'] = growableMap1;
+      final growableMap1Reference = builder.map['a'] as Map<String, Object?>;
+      expect(growableMap1 == growableMap1Reference, true);
+      expect(growableMap1.hashCode, growableMap1Reference.hashCode);
+    });
+
     test('can be written and read if empty', () {
       final value = builder.createGrowableMap<int>();
       builder.map['value'] = value;

--- a/pkgs/dart_model/test/json_buffer/typed_map_test.dart
+++ b/pkgs/dart_model/test/json_buffer/typed_map_test.dart
@@ -20,6 +20,23 @@ void main() {
       printOnFailure(builder.toString());
     });
 
+    test('equality and hashing is by identity', () {
+      final schema = TypedMapSchema({});
+      final typedMap1 = builder.createTypedMap(schema);
+      final typedMap2 = builder.createTypedMap(schema);
+
+      // Different maps with the same contents are not equal, have different hash codes.
+      // Can't use default `expect` equality check as it special-cases `Map`.
+      expect(typedMap1 == typedMap2, false);
+      expect(typedMap1.hashCode, isNot(typedMap2.hashCode));
+
+      // Map is equal to a reference to itself, has same hash code.
+      builder.map['a'] = typedMap1;
+      final typedMap1Reference = builder.map['a'] as Map<String, Object?>;
+      expect(typedMap1 == typedMap1Reference, true);
+      expect(typedMap1.hashCode, typedMap1Reference.hashCode);
+    });
+
     test('with some values missing can be written and read', () {
       final schema = TypedMapSchema({
         'a': Type.stringPointer,

--- a/pkgs/dart_model/test/model_test.dart
+++ b/pkgs/dart_model/test/model_test.dart
@@ -123,6 +123,25 @@ void main() {
           '/uris/package:dart_model/dart_model.dart/scopes/JsonData/members/_root');
     });
 
+    test('path to Members throws on cycle', () {
+      final copiedModel = Model.fromJson(_copyMap(model.node));
+      // Add an invalid link creating a loop in the map structure.
+      (copiedModel.node['uris'] as Map<String, Object?>)['loop'] = copiedModel;
+      final member = copiedModel.uris['package:dart_model/dart_model.dart']!
+          .scopes['JsonData']!.members['_root']!;
+      expect(() => copiedModel.pathToMember(member), throwsStateError);
+    });
+
+    test('path to Members throws on reused node', () {
+      final copiedModel = Model.fromJson(_copyMap(model.node));
+      // Reuse a node.
+      copiedModel.uris['duplicate'] =
+          copiedModel.uris['package:dart_model/dart_model.dart']!;
+      final member = copiedModel.uris['package:dart_model/dart_model.dart']!
+          .scopes['JsonData']!.members['_root']!;
+      expect(() => copiedModel.pathToMember(member), throwsStateError);
+    });
+
     test('path to Member returns null for Member in wrong Map', () {
       final copiedModel = Model.fromJson(_copyMap(model.node));
       final member = model.uris['package:dart_model/dart_model.dart']!

--- a/pkgs/dart_model/test/model_test.dart
+++ b/pkgs/dart_model/test/model_test.dart
@@ -111,16 +111,16 @@ void main() {
     test('can give the path to Members in buffer backed maps', () {
       final member = model.uris['package:dart_model/dart_model.dart']!
           .scopes['JsonData']!.members['_root']!;
-      expect(model.pathToMember(member),
-          '/uris/package:dart_model/dart_model.dart/scopes/JsonData/members/_root');
+      expect(model.qualifiedNameOfMember(member)!.asString,
+          'package:dart_model/dart_model.dart#JsonData');
     });
 
     test('can give the path to Members in SDK maps', () {
       final copiedModel = Model.fromJson(_copyMap(model.node));
       final member = copiedModel.uris['package:dart_model/dart_model.dart']!
           .scopes['JsonData']!.members['_root']!;
-      expect(copiedModel.pathToMember(member),
-          '/uris/package:dart_model/dart_model.dart/scopes/JsonData/members/_root');
+      expect(copiedModel.qualifiedNameOfMember(member)!.asString,
+          'package:dart_model/dart_model.dart#JsonData');
     });
 
     test('path to Members throws on cycle', () {
@@ -129,7 +129,7 @@ void main() {
       (copiedModel.node['uris'] as Map<String, Object?>)['loop'] = copiedModel;
       final member = copiedModel.uris['package:dart_model/dart_model.dart']!
           .scopes['JsonData']!.members['_root']!;
-      expect(() => copiedModel.pathToMember(member), throwsStateError);
+      expect(() => copiedModel.qualifiedNameOfMember(member), throwsStateError);
     });
 
     test('path to Members throws on reused node', () {
@@ -139,7 +139,7 @@ void main() {
           copiedModel.uris['package:dart_model/dart_model.dart']!;
       final member = copiedModel.uris['package:dart_model/dart_model.dart']!
           .scopes['JsonData']!.members['_root']!;
-      expect(() => copiedModel.pathToMember(member), throwsStateError);
+      expect(() => copiedModel.qualifiedNameOfMember(member), throwsStateError);
     });
 
     test('path to Member returns null for Member in wrong Map', () {
@@ -151,8 +151,8 @@ void main() {
           .scopes['JsonData']!
           .members['_root']!
           .node));
-      expect(copiedModel.pathToMember(member), null);
-      expect(model.pathToMember(copiedMember), null);
+      expect(copiedModel.qualifiedNameOfMember(member), null);
+      expect(model.qualifiedNameOfMember(copiedMember), null);
     });
   });
 

--- a/pkgs/dart_model/test/model_test.dart
+++ b/pkgs/dart_model/test/model_test.dart
@@ -107,6 +107,34 @@ void main() {
           expected['uris']!['package:dart_model/dart_model.dart']!['scopes']![
               'JsonData']!['members']);
     });
+
+    test('can give the path to Members in buffer backed maps', () {
+      final member = model.uris['package:dart_model/dart_model.dart']!
+          .scopes['JsonData']!.members['_root']!;
+      expect(model.pathToMember(member),
+          '/uris/package:dart_model/dart_model.dart/scopes/JsonData/members/_root');
+    });
+
+    test('can give the path to Members in SDK maps', () {
+      final copiedModel = Model.fromJson(_copyMap(model.node));
+      final member = copiedModel.uris['package:dart_model/dart_model.dart']!
+          .scopes['JsonData']!.members['_root']!;
+      expect(copiedModel.pathToMember(member),
+          '/uris/package:dart_model/dart_model.dart/scopes/JsonData/members/_root');
+    });
+
+    test('path to Member returns null for Member in wrong Map', () {
+      final copiedModel = Model.fromJson(_copyMap(model.node));
+      final member = model.uris['package:dart_model/dart_model.dart']!
+          .scopes['JsonData']!.members['_root']!;
+      final copiedMember = Member.fromJson(_copyMap(model
+          .uris['package:dart_model/dart_model.dart']!
+          .scopes['JsonData']!
+          .members['_root']!
+          .node));
+      expect(copiedModel.pathToMember(member), null);
+      expect(model.pathToMember(copiedMember), null);
+    });
   });
 
   group(QualifiedName, () {
@@ -121,4 +149,16 @@ void main() {
       expect(QualifiedName.parse('package:foo/foo.dart#Foo').name, 'Foo');
     });
   });
+}
+
+Map<String, Object?> _copyMap(Map<String, Object?> map) {
+  final result = <String, Object?>{};
+  for (final entry in map.entries) {
+    if (entry.value is Map<String, Object?>) {
+      result[entry.key] = _copyMap(entry.value as Map<String, Object?>);
+    } else {
+      result[entry.key] = entry.value;
+    }
+  }
+  return result;
 }


### PR DESCRIPTION
For #72, this seems reasonably convincing that we can get the path to a node cheaply, which means we don't have to add it everywhere explicitly in the schema.

This doesn't add a use case yet, probably there will be some tweaks when there is a first use case; one specific note is that the link to parent could also store the key in the parent, which would avoid the search through parent's keys that currently happens. But that's easy to change later.