### PR TITLE
@JsonCodable() supports super toJson and fromJson.

### DIFF
--- a/goldens/foo/lib/foo.analyzer.json
+++ b/goldens/foo/lib/foo.analyzer.json
@@ -4,9 +4,85 @@
       "scopes": {
         "Foo": {
           "members": {
+            "construct": {
+              "properties": {
+                "isAbstract": false,
+                "isConstructor": true,
+                "isGetter": false,
+                "isField": false,
+                "isMethod": false,
+                "isStatic": false
+              },
+              "requiredPositionalParameters": [
+                {
+                  "type": "NamedTypeDesc",
+                  "value": {
+                    "name": {
+                      "uri": "dart:core",
+                      "name": "int"
+                    },
+                    "instantiation": []
+                  }
+                }
+              ],
+              "optionalPositionalParameters": [],
+              "namedParameters": [
+                {
+                  "type": "NamedTypeDesc",
+                  "value": {
+                    "name": {
+                      "uri": "dart:core",
+                      "name": "int"
+                    },
+                    "instantiation": []
+                  }
+                }
+              ]
+            },
+            "construct2": {
+              "properties": {
+                "isAbstract": false,
+                "isConstructor": true,
+                "isGetter": false,
+                "isField": false,
+                "isMethod": false,
+                "isStatic": false
+              },
+              "requiredPositionalParameters": [
+                {
+                  "type": "NamedTypeDesc",
+                  "value": {
+                    "name": {
+                      "uri": "dart:core",
+                      "name": "int"
+                    },
+                    "instantiation": []
+                  }
+                }
+              ],
+              "optionalPositionalParameters": [
+                {
+                  "type": "NullableTypeDesc",
+                  "value": {
+                    "inner": {
+                      "type": "NamedTypeDesc",
+                      "value": {
+                        "name": {
+                          "uri": "dart:core",
+                          "name": "String"
+                        },
+                        "instantiation": []
+                      }
+                    }
+                  }
+                }
+              ],
+              "namedParameters": []
+            },
             "bar": {
               "properties": {
                 "isAbstract": false,
+                "isConstructor": false,
                 "isGetter": false,
                 "isField": true,
                 "isMethod": false,
@@ -22,14 +98,126 @@
                   "instantiation": []
                 }
               }
+            },
+            "method": {
+              "properties": {
+                "isAbstract": false,
+                "isConstructor": false,
+                "isGetter": false,
+                "isField": false,
+                "isMethod": true,
+                "isStatic": false
+              },
+              "returnType": {
+                "type": "VoidTypeDesc"
+              },
+              "requiredPositionalParameters": [
+                {
+                  "type": "NamedTypeDesc",
+                  "value": {
+                    "name": {
+                      "uri": "dart:core",
+                      "name": "int"
+                    },
+                    "instantiation": []
+                  }
+                }
+              ],
+              "optionalPositionalParameters": [],
+              "namedParameters": [
+                {
+                  "type": "NullableTypeDesc",
+                  "value": {
+                    "inner": {
+                      "type": "NamedTypeDesc",
+                      "value": {
+                        "name": {
+                          "uri": "dart:core",
+                          "name": "int"
+                        },
+                        "instantiation": []
+                      }
+                    }
+                  }
+                }
+              ]
+            },
+            "method2": {
+              "properties": {
+                "isAbstract": false,
+                "isConstructor": false,
+                "isGetter": false,
+                "isField": false,
+                "isMethod": true,
+                "isStatic": false
+              },
+              "returnType": {
+                "type": "NullableTypeDesc",
+                "value": {
+                  "inner": {
+                    "type": "NamedTypeDesc",
+                    "value": {
+                      "name": {
+                        "uri": "package:foo/foo.dart",
+                        "name": "Bar"
+                      },
+                      "instantiation": []
+                    }
+                  }
+                }
+              },
+              "requiredPositionalParameters": [
+                {
+                  "type": "NamedTypeDesc",
+                  "value": {
+                    "name": {
+                      "uri": "dart:core",
+                      "name": "int"
+                    },
+                    "instantiation": []
+                  }
+                }
+              ],
+              "optionalPositionalParameters": [
+                {
+                  "type": "NullableTypeDesc",
+                  "value": {
+                    "inner": {
+                      "type": "NamedTypeDesc",
+                      "value": {
+                        "name": {
+                          "uri": "dart:core",
+                          "name": "String"
+                        },
+                        "instantiation": []
+                      }
+                    }
+                  }
+                }
+              ],
+              "namedParameters": []
             }
           }
         },
         "Bar": {
           "members": {
+            "": {
+              "properties": {
+                "isAbstract": false,
+                "isConstructor": true,
+                "isGetter": false,
+                "isField": false,
+                "isMethod": false,
+                "isStatic": false
+              },
+              "requiredPositionalParameters": [],
+              "optionalPositionalParameters": [],
+              "namedParameters": []
+            },
             "bar": {
               "properties": {
                 "isAbstract": false,
+                "isConstructor": false,
                 "isGetter": false,
                 "isField": true,
                 "isMethod": false,

--- a/goldens/foo/lib/foo.dart
+++ b/goldens/foo/lib/foo.dart
@@ -7,6 +7,14 @@ import 'package:_test_macros/query_class.dart';
 @QueryClass()
 class Foo {
   final int bar = 3;
+
+  Foo.construct(int x, {required int y});
+  Foo.construct2(int x, [String? y]);
+
+  void method(int x, {int? y}) {}
+  Bar? method2(int x, [String? y]) {
+    return null;
+  }
 }
 
 @QueryClass()

--- a/goldens/foo/lib/json_codable_test.analyzer.augmentations
+++ b/goldens/foo/lib/json_codable_test.analyzer.augmentations
@@ -95,6 +95,23 @@ json[r'x'] = x;
 }
 
 }
+augment class D {
+// TODO(davidmorgan): see https://github.com/dart-lang/macros/issues/80.
+// external D.fromJson(prefix0.Map<prefix0.String, prefix0.Object?> json);
+// external prefix0.Map<prefix0.String, prefix0.Object?> toJson();
+   
+augment D.fromJson(prefix0.Map<prefix0.String, prefix0.Object?> json) :
+y = json[r'y'] as prefix0.String,
+super.fromJson(json);
+
+augment prefix0.Map<prefix0.String, prefix0.Object?> toJson() {
+  final json = super.toJson();
+json[r'y'] = y;
+
+  return json;
+}
+
+}
 augment class E {
 // TODO(davidmorgan): see https://github.com/dart-lang/macros/issues/80.
 // external E.fromJson(prefix0.Map<prefix0.String, prefix0.Object?> json);

--- a/goldens/foo/lib/json_codable_test.dart
+++ b/goldens/foo/lib/json_codable_test.dart
@@ -106,7 +106,6 @@ void main() {
       expect(b.toJson(), isEmpty);
     });
 
-    /* TODO(davidmorgan): make this test work.
     test('class hierarchies', () {
       var json = {
         'x': 1,
@@ -118,7 +117,6 @@ void main() {
 
       expect(d.toJson(), equals(json));
     });
-    */
 
     test('collections of nullable objects', () {
       var json = {
@@ -266,7 +264,6 @@ class C {
   final int x;
 }
 
-/*
 @JsonCodable()
 class D extends C {
   // TODO(davidmorgan): see https://github.com/dart-lang/macros/issues/80.
@@ -275,7 +272,6 @@ class D extends C {
 
   final String y;
 }
-*/
 
 @JsonCodable()
 class E {

--- a/pkgs/_analyzer_macros/lib/query_service.dart
+++ b/pkgs/_analyzer_macros/lib/query_service.dart
@@ -36,16 +36,52 @@ class AnalyzerQueryService implements QueryService {
       ..addInterfaceElement(clazz);
 
     final interface = Interface();
+    for (final constructor in clazz.constructors) {
+      interface.members[constructor.name] = Member(
+          requiredPositionalParameters: constructor
+              .requiredPositionalParameters(types.translator, types.context),
+          optionalPositionalParameters: constructor
+              .optionalPositionalParameters(types.translator, types.context),
+          namedParameters:
+              constructor.namedParameters(types.translator, types.context),
+          properties: Properties(
+            isAbstract: constructor.isAbstract,
+            isConstructor: true,
+            isGetter: false,
+            isField: false,
+            isMethod: false,
+            isStatic: false,
+          ));
+    }
     for (final field in clazz.fields) {
       interface.members[field.name] = Member(
           properties: Properties(
             isAbstract: field.isAbstract,
+            isConstructor: false,
             isGetter: false,
             isField: true,
             isMethod: false,
             isStatic: field.isStatic,
           ),
           returnType: types.addDartType(field.type));
+    }
+    for (final method in clazz.methods) {
+      interface.members[method.name] = Member(
+          requiredPositionalParameters: method.requiredPositionalParameters(
+              types.translator, types.context),
+          optionalPositionalParameters: method.optionalPositionalParameters(
+              types.translator, types.context),
+          namedParameters:
+              method.namedParameters(types.translator, types.context),
+          properties: Properties(
+            isAbstract: method.isAbstract,
+            isConstructor: false,
+            isGetter: false,
+            isField: false,
+            isMethod: true,
+            isStatic: method.isStatic,
+          ),
+          returnType: types.addDartType(method.returnType));
     }
     return Model(types: types.typeHierarchy)
       ..uris[uri] = (Library()..scopes[clazz.name] = interface);
@@ -103,5 +139,32 @@ class AnalyzerTypeHierarchy {
           superType.acceptWithArgument(translator, context).asNamedTypeDesc
       ],
     );
+  }
+}
+
+extension ExecutableElementExtension on ExecutableElement {
+  List<StaticTypeDesc> requiredPositionalParameters(
+      AnalyzerTypesToMacros translator, TypeTranslationContext context) {
+    return parameters
+        .where((p) => p.isRequiredPositional)
+        .map((p) => p.type.acceptWithArgument(translator, context))
+        .toList();
+  }
+
+  List<StaticTypeDesc> optionalPositionalParameters(
+      AnalyzerTypesToMacros translator, TypeTranslationContext context) {
+    return parameters
+        .where((p) => p.isOptionalPositional)
+        .map((p) => p.type.acceptWithArgument(translator, context))
+        .toList();
+  }
+
+  List<NamedFunctionTypeParameter> namedParameters(
+      AnalyzerTypesToMacros translator, TypeTranslationContext context) {
+    return parameters
+        .where((p) => p.isNamed)
+        .map((p) => p.type.acceptWithArgument(translator, context))
+        .cast<NamedFunctionTypeParameter>()
+        .toList();
   }
 }

--- a/pkgs/_analyzer_macros/lib/query_service.dart
+++ b/pkgs/_analyzer_macros/lib/query_service.dart
@@ -144,27 +144,27 @@ class AnalyzerTypeHierarchy {
 
 extension ExecutableElementExtension on ExecutableElement {
   List<StaticTypeDesc> requiredPositionalParameters(
-      AnalyzerTypesToMacros translator, TypeTranslationContext context) {
-    return parameters
-        .where((p) => p.isRequiredPositional)
-        .map((p) => p.type.acceptWithArgument(translator, context))
-        .toList();
-  }
+          AnalyzerTypesToMacros translator, TypeTranslationContext context) =>
+      [
+        for (final parameter in parameters)
+          if (parameter.isRequiredPositional)
+            parameter.type.acceptWithArgument(translator, context)
+      ];
 
   List<StaticTypeDesc> optionalPositionalParameters(
-      AnalyzerTypesToMacros translator, TypeTranslationContext context) {
-    return parameters
-        .where((p) => p.isOptionalPositional)
-        .map((p) => p.type.acceptWithArgument(translator, context))
-        .toList();
-  }
+          AnalyzerTypesToMacros translator, TypeTranslationContext context) =>
+      [
+        for (final parameter in parameters)
+          if (parameter.isOptionalPositional)
+            parameter.type.acceptWithArgument(translator, context)
+      ];
 
   List<NamedFunctionTypeParameter> namedParameters(
-      AnalyzerTypesToMacros translator, TypeTranslationContext context) {
-    return parameters
-        .where((p) => p.isNamed)
-        .map((p) => p.type.acceptWithArgument(translator, context))
-        .cast<NamedFunctionTypeParameter>()
-        .toList();
-  }
+          AnalyzerTypesToMacros translator, TypeTranslationContext context) =>
+      [
+        for (final parameter in parameters)
+          if (parameter.isNamed)
+            parameter.type.acceptWithArgument(translator, context)
+                as NamedFunctionTypeParameter
+      ];
 }

--- a/pkgs/_macro_tool/lib/macro_tool.dart
+++ b/pkgs/_macro_tool/lib/macro_tool.dart
@@ -145,11 +145,8 @@ class MacroTool {
   }
 
   /// Returns [source] with lines added by [_addImportAugment] removed.
-  String _removeToolAddedLinesFromSource(String source) => source
-      .split('\n')
-      .where((l) => !l.endsWith(_addedMarker))
-      .map((l) => '$l\n')
-      .join();
+  String _removeToolAddedLinesFromSource(String source) =>
+      source.split('\n').where((l) => !l.endsWith(_addedMarker)).join('\n');
 }
 
 final String _addedMarker = '// added by macro_tool';

--- a/pkgs/dart_model/lib/src/dart_model.g.dart
+++ b/pkgs/dart_model/lib/src/dart_model.g.dart
@@ -141,7 +141,6 @@ extension type Member.fromJson(Map<String, Object?> node) implements Object {
     'requiredPositionalParameters': Type.closedListPointer,
     'optionalPositionalParameters': Type.closedListPointer,
     'namedParameters': Type.closedListPointer,
-    'parameters': Type.typedMapPointer,
   });
   Member({
     Properties? properties,
@@ -149,7 +148,6 @@ extension type Member.fromJson(Map<String, Object?> node) implements Object {
     List<StaticTypeDesc>? requiredPositionalParameters,
     List<StaticTypeDesc>? optionalPositionalParameters,
     List<NamedFunctionTypeParameter>? namedParameters,
-    Properties? parameters,
   }) : this.fromJson(Scope.createMap(
           _schema,
           properties,
@@ -157,7 +155,6 @@ extension type Member.fromJson(Map<String, Object?> node) implements Object {
           requiredPositionalParameters,
           optionalPositionalParameters,
           namedParameters,
-          parameters,
         ));
 
   /// The properties of this member.
@@ -174,12 +171,9 @@ extension type Member.fromJson(Map<String, Object?> node) implements Object {
   List<StaticTypeDesc> get optionalPositionalParameters =>
       (node['optionalPositionalParameters'] as List).cast();
 
-  /// The named positional parameters of this member, if it has them.
+  /// The named named parameters of this member, if it has them.
   List<NamedFunctionTypeParameter> get namedParameters =>
       (node['namedParameters'] as List).cast();
-
-  /// The properties of this member.
-  Properties get parameters => node['parameters'] as Properties;
 }
 
 /// Partial model of a corpus of Dart source code.

--- a/pkgs/dart_model/lib/src/dart_model.g.dart
+++ b/pkgs/dart_model/lib/src/dart_model.g.dart
@@ -138,14 +138,26 @@ extension type Member.fromJson(Map<String, Object?> node) implements Object {
   static final TypedMapSchema _schema = TypedMapSchema({
     'properties': Type.typedMapPointer,
     'returnType': Type.typedMapPointer,
+    'requiredPositionalParameters': Type.closedListPointer,
+    'optionalPositionalParameters': Type.closedListPointer,
+    'namedParameters': Type.closedListPointer,
+    'parameters': Type.typedMapPointer,
   });
   Member({
     Properties? properties,
     StaticTypeDesc? returnType,
+    List<StaticTypeDesc>? requiredPositionalParameters,
+    List<StaticTypeDesc>? optionalPositionalParameters,
+    List<NamedFunctionTypeParameter>? namedParameters,
+    Properties? parameters,
   }) : this.fromJson(Scope.createMap(
           _schema,
           properties,
           returnType,
+          requiredPositionalParameters,
+          optionalPositionalParameters,
+          namedParameters,
+          parameters,
         ));
 
   /// The properties of this member.
@@ -153,6 +165,21 @@ extension type Member.fromJson(Map<String, Object?> node) implements Object {
 
   /// The return type of this member, if it has one.
   StaticTypeDesc get returnType => node['returnType'] as StaticTypeDesc;
+
+  /// The required positional parameters of this member, if it has them.
+  List<StaticTypeDesc> get requiredPositionalParameters =>
+      (node['requiredPositionalParameters'] as List).cast();
+
+  /// The optional positional parameters of this member, if it has them.
+  List<StaticTypeDesc> get optionalPositionalParameters =>
+      (node['optionalPositionalParameters'] as List).cast();
+
+  /// The named positional parameters of this member, if it has them.
+  List<NamedFunctionTypeParameter> get namedParameters =>
+      (node['namedParameters'] as List).cast();
+
+  /// The properties of this member.
+  Properties get parameters => node['parameters'] as Properties;
 }
 
 /// Partial model of a corpus of Dart source code.
@@ -266,6 +293,7 @@ extension type Properties.fromJson(Map<String, Object?> node)
   static final TypedMapSchema _schema = TypedMapSchema({
     'isAbstract': Type.boolean,
     'isClass': Type.boolean,
+    'isConstructor': Type.boolean,
     'isGetter': Type.boolean,
     'isField': Type.boolean,
     'isMethod': Type.boolean,
@@ -274,6 +302,7 @@ extension type Properties.fromJson(Map<String, Object?> node)
   Properties({
     bool? isAbstract,
     bool? isClass,
+    bool? isConstructor,
     bool? isGetter,
     bool? isField,
     bool? isMethod,
@@ -282,6 +311,7 @@ extension type Properties.fromJson(Map<String, Object?> node)
           _schema,
           isAbstract,
           isClass,
+          isConstructor,
           isGetter,
           isField,
           isMethod,
@@ -293,6 +323,9 @@ extension type Properties.fromJson(Map<String, Object?> node)
 
   /// Whether the entity is a class.
   bool get isClass => node['isClass'] as bool;
+
+  /// Whether the entity is a constructor.
+  bool get isConstructor => node['isConstructor'] as bool;
 
   /// Whether the entity is a getter.
   bool get isGetter => node['isGetter'] as bool;

--- a/pkgs/dart_model/lib/src/dart_model.g.dart
+++ b/pkgs/dart_model/lib/src/dart_model.g.dart
@@ -171,7 +171,7 @@ extension type Member.fromJson(Map<String, Object?> node) implements Object {
   List<StaticTypeDesc> get optionalPositionalParameters =>
       (node['optionalPositionalParameters'] as List).cast();
 
-  /// The named named parameters of this member, if it has them.
+  /// The named parameters of this member, if it has them.
   List<NamedFunctionTypeParameter> get namedParameters =>
       (node['namedParameters'] as List).cast();
 }

--- a/pkgs/dart_model/lib/src/type_system.dart
+++ b/pkgs/dart_model/lib/src/type_system.dart
@@ -64,7 +64,8 @@ final class StaticTypeSystem {
   /// Returns the super type of the type referred to by [name], which must be
   /// part of the model.
   ///
-  /// TODO(davidmorgan): is this the right place to provide access to supertypes?
+  /// TODO(davidmorgan): this is a hack to check "extends" but is not correct,
+  /// see https://github.com/dart-lang/macros/pull/89#discussion_r1791855869
   QualifiedName supertypeOf(QualifiedName name) {
     return _constructSuperTypes(_lookupNamed(name.asString), []).first.name;
   }

--- a/pkgs/dart_model/lib/src/type_system.dart
+++ b/pkgs/dart_model/lib/src/type_system.dart
@@ -61,6 +61,14 @@ final class StaticTypeSystem {
     return Scope.none.run(() => _isSubtype(a, b));
   }
 
+  /// Returns the super type of the type referred to by [name], which must be
+  /// part of the model.
+  ///
+  /// TODO(davidmorgan): is this the right place to provide access to supertypes?
+  QualifiedName supertypeOf(QualifiedName name) {
+    return _constructSuperTypes(_lookupNamed(name.asString), []).first.name;
+  }
+
   bool _isSubtype(StaticType a, StaticType b) {
     // This is using `T0` and `T1` names to make the implementation easier to
     // compare with the specification at

--- a/schemas/dart_model.schema.json
+++ b/schemas/dart_model.schema.json
@@ -134,14 +134,10 @@
         },
         "namedParameters": {
           "type": "array",
-          "description": "The named positional parameters of this member, if it has them.",
+          "description": "The named named parameters of this member, if it has them.",
           "items": {
             "$ref": "#/$defs/NamedFunctionTypeParameter"
           }
-        },
-        "parameters": {
-          "$comment": "The properties of this member.",
-          "$ref": "#/$defs/Properties"
         }
       }
     },

--- a/schemas/dart_model.schema.json
+++ b/schemas/dart_model.schema.json
@@ -117,6 +117,31 @@
         "returnType": {
           "$comment": "The return type of this member, if it has one.",
           "$ref": "#/$defs/StaticTypeDesc"
+        },
+        "requiredPositionalParameters": {
+          "type": "array",
+          "description": "The required positional parameters of this member, if it has them.",
+          "items": {
+            "$ref": "#/$defs/StaticTypeDesc"
+          }
+        },
+        "optionalPositionalParameters": {
+          "type": "array",
+          "description": "The optional positional parameters of this member, if it has them.",
+          "items": {
+            "$ref": "#/$defs/StaticTypeDesc"
+          }
+        },
+        "namedParameters": {
+          "type": "array",
+          "description": "The named positional parameters of this member, if it has them.",
+          "items": {
+            "$ref": "#/$defs/NamedFunctionTypeParameter"
+          }
+        },
+        "parameters": {
+          "$comment": "The properties of this member.",
+          "$ref": "#/$defs/Properties"
         }
       }
     },
@@ -204,6 +229,10 @@
         "isClass": {
           "type": "boolean",
           "description": "Whether the entity is a class."
+        },
+        "isConstructor": {
+          "type": "boolean",
+          "description": "Whether the entity is a constructor."
         },
         "isGetter": {
           "type": "boolean",

--- a/schemas/dart_model.schema.json
+++ b/schemas/dart_model.schema.json
@@ -134,7 +134,7 @@
         },
         "namedParameters": {
           "type": "array",
-          "description": "The named named parameters of this member, if it has them.",
+          "description": "The named parameters of this member, if it has them.",
           "items": {
             "$ref": "#/$defs/NamedFunctionTypeParameter"
           }

--- a/tool/dart_model_generator/lib/definitions.dart
+++ b/tool/dart_model_generator/lib/definitions.dart
@@ -157,7 +157,7 @@ static Protocol handshakeProtocol = Protocol(
                       'if it has them.'),
               Property('namedParameters',
                   type: 'List<NamedFunctionTypeParameter>',
-                  description: 'The named named parameters of this member, '
+                  description: 'The named parameters of this member, '
                       'if it has them.'),
             ]),
         Definition.clazz('Model',

--- a/tool/dart_model_generator/lib/definitions.dart
+++ b/tool/dart_model_generator/lib/definitions.dart
@@ -143,6 +143,24 @@ static Protocol handshakeProtocol = Protocol(
                 type: 'StaticTypeDesc',
                 description: 'The return type of this member, if it has one.',
               ),
+              Property('requiredPositionalParameters',
+                  type: 'List<StaticTypeDesc>',
+                  description:
+                      'The required positional parameters of this member, '
+                      'if it has them.'),
+              Property('optionalPositionalParameters',
+                  type: 'List<StaticTypeDesc>',
+                  description:
+                      'The optional positional parameters of this member, '
+                      'if it has them.'),
+              Property('namedParameters',
+                  type: 'List<NamedFunctionTypeParameter>',
+                  description:
+                      'The named positional parameters of this member, '
+                      'if it has them.'),
+              Property('parameters',
+                  type: 'Properties',
+                  description: 'The properties of this member.'),
             ]),
         Definition.clazz('Model',
             description: 'Partial model of a corpus of Dart source code.',
@@ -201,6 +219,9 @@ static Protocol handshakeProtocol = Protocol(
                       'definition.'),
               Property('isClass',
                   type: 'bool', description: 'Whether the entity is a class.'),
+              Property('isConstructor',
+                  type: 'bool',
+                  description: 'Whether the entity is a constructor.'),
               Property('isGetter',
                   type: 'bool', description: 'Whether the entity is a getter.'),
               Property('isField',

--- a/tool/dart_model_generator/lib/definitions.dart
+++ b/tool/dart_model_generator/lib/definitions.dart
@@ -143,6 +143,8 @@ static Protocol handshakeProtocol = Protocol(
                 type: 'StaticTypeDesc',
                 description: 'The return type of this member, if it has one.',
               ),
+              // TODO(davidmorgan): base on
+              // https://github.com/dart-lang/sdk/blob/main/pkg/_macros/lib/src/api/introspection.dart#L269
               Property('requiredPositionalParameters',
                   type: 'List<StaticTypeDesc>',
                   description:
@@ -155,12 +157,8 @@ static Protocol handshakeProtocol = Protocol(
                       'if it has them.'),
               Property('namedParameters',
                   type: 'List<NamedFunctionTypeParameter>',
-                  description:
-                      'The named positional parameters of this member, '
+                  description: 'The named named parameters of this member, '
                       'if it has them.'),
-              Property('parameters',
-                  type: 'Properties',
-                  description: 'The properties of this member.'),
             ]),
         Definition.clazz('Model',
             description: 'Partial model of a corpus of Dart source code.',


### PR DESCRIPTION
Add checking of the super type for `fromJson` and `toJson`, which requires adding query support for constructors and methods.

I just added them flat in `Member`, there is still the TODO to add more types there, this gives something useful for new types to do, i.e. differentiate constructors, methods and fields :)

This also needs to look up the supertype, @simolus3 I wasn't quite sure where that should go, added to `StaticTypeSystem` [here](https://github.com/dart-lang/macros/pull/89/files#diff-28da2a69e681ea5746235dd3017c9c7ca0c0dc6c1fb535bcdd76d3310f54fdf6), or did you have something else in mind? :)