### PR TITLE
Add support for deep collection casting in the generator

### DIFF
--- a/pkgs/dart_model/lib/src/dart_model.g.dart
+++ b/pkgs/dart_model/lib/src/dart_model.g.dart
@@ -2,6 +2,8 @@
 // then run from the repo root: dart tool/dart_model_generator/bin/main.dart
 
 // ignore: implementation_imports,unused_import,prefer_relative_imports
+import 'package:dart_model/src/deep_cast_map.dart';
+// ignore: implementation_imports,unused_import,prefer_relative_imports
 import 'package:dart_model/src/json_buffer/json_buffer_builder.dart';
 // ignore: implementation_imports,unused_import,prefer_relative_imports
 import 'package:dart_model/src/scopes.dart';
@@ -109,7 +111,8 @@ extension type Interface.fromJson(Map<String, Object?> node) implements Object {
       (node['metadataAnnotations'] as List).cast();
 
   /// Map of members by name.
-  Map<String, Member> get members => (node['members'] as Map).cast();
+  Map<String, Member> get members =>
+      (node['members'] as Map).cast<String, Member>();
 
   /// The type of the expression `this` when used in this interface.
   NamedTypeDesc get thisType => node['thisType'] as NamedTypeDesc;
@@ -130,7 +133,8 @@ extension type Library.fromJson(Map<String, Object?> node) implements Object {
         ));
 
   /// Scopes by name.
-  Map<String, Interface> get scopes => (node['scopes'] as Map).cast();
+  Map<String, Interface> get scopes =>
+      (node['scopes'] as Map).cast<String, Interface>();
 }
 
 /// Member of a scope.
@@ -170,7 +174,8 @@ extension type Model.fromJson(Map<String, Object?> node) implements Object {
         ));
 
   /// Libraries by URI.
-  Map<String, Library> get uris => (node['uris'] as Map).cast();
+  Map<String, Library> get uris =>
+      (node['uris'] as Map).cast<String, Library>();
 
   /// The resolved static type hierarchy.
   TypeHierarchy get types => node['types'] as TypeHierarchy;
@@ -552,7 +557,8 @@ extension type TypeHierarchy.fromJson(Map<String, Object?> node)
         ));
 
   /// Map of qualified interface names to their resolved named type.
-  Map<String, TypeHierarchyEntry> get named => (node['named'] as Map).cast();
+  Map<String, TypeHierarchyEntry> get named =>
+      (node['named'] as Map).cast<String, TypeHierarchyEntry>();
 }
 
 /// Entry of an interface in Dart's type hierarchy, along with supertypes.

--- a/pkgs/dart_model/lib/src/deep_cast_map.dart
+++ b/pkgs/dart_model/lib/src/deep_cast_map.dart
@@ -1,0 +1,110 @@
+// Copyright (c) 2024, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:collection';
+
+extension DeepCastMap<SK, SV> on Map<SK, SV> {
+  /// A lazy deep cast map for `this`, where the values are deeply cast using
+  /// the provided [castValue] function, and they keys are normally cast.
+  Map<K, V> deepCast<K, V>(V Function(SV) castValue) =>
+      _DeepCastMap(this, castValue);
+}
+
+/// Like a `CastMap`, except it can perform deep casts on values using a
+/// provided conversion function.
+class _DeepCastMap<SK, SV, K, V> extends MapBase<K, V> {
+  final Map<SK, SV> _source;
+
+  final V Function(SV) _castValue;
+
+  _DeepCastMap(this._source, this._castValue);
+
+  @override
+  bool containsValue(Object? value) => _source.containsValue(value);
+
+  @override
+  bool containsKey(Object? key) => _source.containsKey(key);
+
+  @override
+  V? operator [](Object? key) {
+    final value = _source[key];
+    if (value == null) return null;
+    return _castValue(value);
+  }
+
+  @override
+  void operator []=(K key, V value) {
+    _source[key as SK] = value as SV;
+  }
+
+  @override
+  V putIfAbsent(K key, V Function() ifAbsent) =>
+      _castValue(_source.putIfAbsent(key as SK, () => ifAbsent() as SV));
+
+  @override
+  V? remove(Object? key) {
+    final removed = _source.remove(key);
+    if (removed == null) return null;
+    return _castValue(removed);
+  }
+
+  @override
+  void clear() {
+    _source.clear();
+  }
+
+  @override
+  void forEach(void Function(K key, V value) f) {
+    _source.forEach((SK key, SV value) {
+      f(key as K, _castValue(value));
+    });
+  }
+
+  @override
+  Iterable<K> get keys => _source.keys.cast();
+
+  @override
+  Iterable<V> get values => _source.values.map(_castValue);
+
+  @override
+  int get length => _source.length;
+
+  @override
+  bool get isEmpty => _source.isEmpty;
+
+  @override
+  bool get isNotEmpty => _source.isNotEmpty;
+
+  @override
+  V update(K key, V Function(V value) update, {V Function()? ifAbsent}) {
+    return _castValue(_source.update(
+        key as SK, (SV value) => update(_castValue(value)) as SV,
+        ifAbsent: (ifAbsent == null) ? null : () => ifAbsent() as SV));
+  }
+
+  @override
+  void updateAll(V Function(K key, V value) update) {
+    _source.updateAll(
+        (SK key, SV value) => update(key as K, _castValue(value)) as SV);
+  }
+
+  @override
+  Iterable<MapEntry<K, V>> get entries {
+    return _source.entries.map<MapEntry<K, V>>((MapEntry<SK, SV> e) =>
+        MapEntry<K, V>(e.key as K, _castValue(e.value)));
+  }
+
+  @override
+  void addEntries(Iterable<MapEntry<K, V>> entries) {
+    for (var entry in entries) {
+      _source[entry.key as SK] = entry.value as SV;
+    }
+  }
+
+  @override
+  void removeWhere(bool Function(K key, V value) test) {
+    _source
+        .removeWhere((SK key, SV value) => test(key as K, _castValue(value)));
+  }
+}

--- a/pkgs/dart_model/test/deep_cast_test.dart
+++ b/pkgs/dart_model/test/deep_cast_test.dart
@@ -1,0 +1,42 @@
+// Copyright (c) 2024, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:dart_model/src/deep_cast_map.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('can perform deep casts on maps', () {
+    final initial = <dynamic, dynamic>{
+      'x': <dynamic>[1, 2, 3]
+    };
+    expect(initial, isNot(isA<Map<String, List<int>>>()));
+    final typed =
+        initial.deepCast<String, List<int>>((v) => (v as List).cast<int>());
+    expect(typed, isA<Map<String, List<int>>>());
+    expect(typed['x']!, isA<List<int>>());
+    expect(typed['x']!, [1, 2, 3]);
+  });
+
+  test('can perform really deep casts on maps', () {
+    final initial = <dynamic, dynamic>{
+      'x': <dynamic, dynamic>{
+        'y': <dynamic>[1, 2, 3]
+      },
+    };
+    expect(initial, isNot(isA<Map<String, Map<String, List<int>>>>()));
+
+    final typed = initial.deepCast<String, Map<String, List<int>>>((v) =>
+        (v as Map).deepCast<String, List<int>>((v) => (v as List).cast()));
+    expect(typed, isA<Map<String, Map<String, List<int>>>>());
+
+    expect(initial['x'], isNot(isA<Map<String, List<int>>>()));
+    final x = typed['x']!;
+    expect(x, isA<Map<String, List<int>>>());
+
+    expect((initial['x'] as Map)['y'], isNot(isA<List<int>>()));
+    final y = x['y']!;
+    expect(y, isA<List<int>>());
+    expect(y, [1, 2, 3]);
+  });
+}

--- a/pkgs/macro_service/lib/src/handshake.g.dart
+++ b/pkgs/macro_service/lib/src/handshake.g.dart
@@ -2,6 +2,8 @@
 // then run from the repo root: dart tool/dart_model_generator/bin/main.dart
 
 // ignore: implementation_imports,unused_import,prefer_relative_imports
+import 'package:dart_model/src/deep_cast_map.dart';
+// ignore: implementation_imports,unused_import,prefer_relative_imports
 import 'package:dart_model/src/json_buffer/json_buffer_builder.dart';
 // ignore: implementation_imports,unused_import,prefer_relative_imports
 import 'package:dart_model/src/scopes.dart';

--- a/pkgs/macro_service/lib/src/macro_service.g.dart
+++ b/pkgs/macro_service/lib/src/macro_service.g.dart
@@ -4,6 +4,8 @@
 // ignore: implementation_imports,unused_import,prefer_relative_imports
 import 'package:dart_model/src/dart_model.g.dart';
 // ignore: implementation_imports,unused_import,prefer_relative_imports
+import 'package:dart_model/src/deep_cast_map.dart';
+// ignore: implementation_imports,unused_import,prefer_relative_imports
 import 'package:dart_model/src/json_buffer/json_buffer_builder.dart';
 // ignore: implementation_imports,unused_import,prefer_relative_imports
 import 'package:dart_model/src/scopes.dart';


### PR DESCRIPTION
Closes https://github.com/dart-lang/macros/issues/92

- Adds a `deepCast` extension on maps which takes a function for deep casting values.
- Add support in the generator for using it.
- As a part of this, it also explicitly passes type arguments to `cast` and `deepCast` always, instead of relying on inference.

There is no testing of the generator code itself, since it is only tested by essentially validating actual output, but I manually tested it, and it will be used in a follow-up.