### PR TITLE
Pass target model in AugmentRequest

### DIFF
--- a/pkgs/_analyzer_macros/lib/macro_implementation.dart
+++ b/pkgs/_analyzer_macros/lib/macro_implementation.dart
@@ -84,12 +84,13 @@ class AnalyzerRunningMacro implements injected.RunningMacro {
   /// Queries for [target] and returns the [Model] representing the result.
   ///
   /// TODO: Make this a more limited query which doesn't fetch members.
-  Future<Model> _queryTarget(QualifiedName target) async =>
-      (await _impl._host.hostService.handle(MacroRequest.queryRequest(
-              QueryRequest(query: Query(target: target)),
-              id: nextRequestId)))
+  Future<Model> _queryTarget(QualifiedName target) =>
+      Scope.query.run(() async => (await _impl._host.hostService.handle(
+              MacroRequest.queryRequest(
+                  QueryRequest(query: Query(target: target)),
+                  id: nextRequestId)))
           .asQueryResponse
-          .model;
+          .model);
 
   @override
   Future<AnalyzerMacroExecutionResult> executeDeclarationsPhase(

--- a/pkgs/_analyzer_macros/lib/macro_implementation.dart
+++ b/pkgs/_analyzer_macros/lib/macro_implementation.dart
@@ -81,6 +81,16 @@ class AnalyzerRunningMacro implements injected.RunningMacro {
     return AnalyzerRunningMacro._(impl, name, implementation);
   }
 
+  /// Queries for [target] and returns the [Model] representing the result.
+  ///
+  /// TODO: Make this a more limited query which doesn't fetch members.
+  Future<Model> _queryTarget(QualifiedName target) async =>
+      (await _impl._host.hostService.handle(MacroRequest.queryRequest(
+              QueryRequest(query: Query(target: target)),
+              id: nextRequestId)))
+          .asQueryResponse
+          .model;
+
   @override
   Future<AnalyzerMacroExecutionResult> executeDeclarationsPhase(
       macros_api_v1.MacroTarget target,
@@ -91,7 +101,11 @@ class AnalyzerRunningMacro implements injected.RunningMacro {
     return await AnalyzerMacroExecutionResult.dartModelToInjected(
         target,
         await _impl._host.augment(
-            name, AugmentRequest(phase: 2, target: target.qualifiedName)));
+            name,
+            AugmentRequest(
+                phase: 2,
+                target: target.qualifiedName,
+                model: await _queryTarget(target.qualifiedName))));
   }
 
   @override
@@ -104,7 +118,11 @@ class AnalyzerRunningMacro implements injected.RunningMacro {
     return await AnalyzerMacroExecutionResult.dartModelToInjected(
         target,
         await _impl._host.augment(
-            name, AugmentRequest(phase: 3, target: target.qualifiedName)));
+            name,
+            AugmentRequest(
+                phase: 3,
+                target: target.qualifiedName,
+                model: await _queryTarget(target.qualifiedName))));
   }
 
   @override
@@ -116,7 +134,11 @@ class AnalyzerRunningMacro implements injected.RunningMacro {
     return await AnalyzerMacroExecutionResult.dartModelToInjected(
         target,
         await _impl._host.augment(
-            name, AugmentRequest(phase: 1, target: target.qualifiedName)));
+            name,
+            AugmentRequest(
+                phase: 1,
+                target: target.qualifiedName,
+                model: await _queryTarget(target.qualifiedName))));
   }
 }
 

--- a/pkgs/_analyzer_macros/lib/query_service.dart
+++ b/pkgs/_analyzer_macros/lib/query_service.dart
@@ -36,52 +36,56 @@ class AnalyzerQueryService implements QueryService {
       ..addInterfaceElement(clazz);
 
     final interface = Interface(properties: Properties(isClass: true));
-    for (final constructor in clazz.constructors) {
-      interface.members[constructor.name] = Member(
-          requiredPositionalParameters: constructor
-              .requiredPositionalParameters(types.translator, types.context),
-          optionalPositionalParameters: constructor
-              .optionalPositionalParameters(types.translator, types.context),
-          namedParameters:
-              constructor.namedParameters(types.translator, types.context),
-          properties: Properties(
-            isAbstract: constructor.isAbstract,
-            isConstructor: true,
-            isGetter: false,
-            isField: false,
-            isMethod: false,
-            isStatic: false,
-          ));
-    }
-    for (final field in clazz.fields) {
-      interface.members[field.name] = Member(
-          properties: Properties(
-            isAbstract: field.isAbstract,
-            isConstructor: false,
-            isGetter: false,
-            isField: true,
-            isMethod: false,
-            isStatic: field.isStatic,
-          ),
-          returnType: types.addDartType(field.type));
-    }
-    for (final method in clazz.methods) {
-      interface.members[method.name] = Member(
-          requiredPositionalParameters: method.requiredPositionalParameters(
-              types.translator, types.context),
-          optionalPositionalParameters: method.optionalPositionalParameters(
-              types.translator, types.context),
-          namedParameters:
-              method.namedParameters(types.translator, types.context),
-          properties: Properties(
-            isAbstract: method.isAbstract,
-            isConstructor: false,
-            isGetter: false,
-            isField: false,
-            isMethod: true,
-            isStatic: method.isStatic,
-          ),
-          returnType: types.addDartType(method.returnType));
+    try {
+      for (final constructor in clazz.constructors) {
+        interface.members[constructor.name] = Member(
+            requiredPositionalParameters: constructor
+                .requiredPositionalParameters(types.translator, types.context),
+            optionalPositionalParameters: constructor
+                .optionalPositionalParameters(types.translator, types.context),
+            namedParameters:
+                constructor.namedParameters(types.translator, types.context),
+            properties: Properties(
+              isAbstract: constructor.isAbstract,
+              isConstructor: true,
+              isGetter: false,
+              isField: false,
+              isMethod: false,
+              isStatic: false,
+            ));
+      }
+      for (final field in clazz.fields) {
+        interface.members[field.name] = Member(
+            properties: Properties(
+              isAbstract: field.isAbstract,
+              isConstructor: false,
+              isGetter: false,
+              isField: true,
+              isMethod: false,
+              isStatic: field.isStatic,
+            ),
+            returnType: types.addDartType(field.type));
+      }
+      for (final method in clazz.methods) {
+        interface.members[method.name] = Member(
+            requiredPositionalParameters: method.requiredPositionalParameters(
+                types.translator, types.context),
+            optionalPositionalParameters: method.optionalPositionalParameters(
+                types.translator, types.context),
+            namedParameters:
+                method.namedParameters(types.translator, types.context),
+            properties: Properties(
+              isAbstract: method.isAbstract,
+              isConstructor: false,
+              isGetter: false,
+              isField: false,
+              isMethod: true,
+              isStatic: method.isStatic,
+            ),
+            returnType: types.addDartType(method.returnType));
+      }
+    } catch (_) {
+      // TODO: Fails in types phase, implement fine grained queries.
     }
     return Model(types: types.typeHierarchy)
       ..uris[uri] = (Library()..scopes[clazz.name] = interface);

--- a/pkgs/_cfe_macros/lib/macro_implementation.dart
+++ b/pkgs/_cfe_macros/lib/macro_implementation.dart
@@ -81,6 +81,16 @@ class CfeRunningMacro implements injected.RunningMacro {
     return CfeRunningMacro._(impl, name, implementation);
   }
 
+  /// Queries for [target] and returns the [Model] representing the result.
+  ///
+  /// TODO: Make this a more limited query which doesn't fetch members.
+  Future<Model> _queryTarget(QualifiedName target) async =>
+      (await _impl._host.hostService.handle(MacroRequest.queryRequest(
+              QueryRequest(query: Query(target: target)),
+              id: nextRequestId)))
+          .asQueryResponse
+          .model;
+
   @override
   Future<CfeMacroExecutionResult> executeDeclarationsPhase(
       macros_api_v1.MacroTarget target,
@@ -91,7 +101,11 @@ class CfeRunningMacro implements injected.RunningMacro {
     return await CfeMacroExecutionResult.dartModelToInjected(
         target,
         await _impl._host.augment(
-            name, AugmentRequest(phase: 2, target: target.qualifiedName)));
+            name,
+            AugmentRequest(
+                phase: 2,
+                target: target.qualifiedName,
+                model: await _queryTarget(target.qualifiedName))));
   }
 
   @override
@@ -104,7 +118,11 @@ class CfeRunningMacro implements injected.RunningMacro {
     return await CfeMacroExecutionResult.dartModelToInjected(
         target,
         await _impl._host.augment(
-            name, AugmentRequest(phase: 3, target: target.qualifiedName)));
+            name,
+            AugmentRequest(
+                phase: 3,
+                target: target.qualifiedName,
+                model: await _queryTarget(target.qualifiedName))));
   }
 
   @override
@@ -116,7 +134,11 @@ class CfeRunningMacro implements injected.RunningMacro {
     return await CfeMacroExecutionResult.dartModelToInjected(
         target,
         await _impl._host.augment(
-            name, AugmentRequest(phase: 1, target: target.qualifiedName)));
+            name,
+            AugmentRequest(
+                phase: 1,
+                target: target.qualifiedName,
+                model: await _queryTarget(target.qualifiedName))));
   }
 }
 

--- a/pkgs/_cfe_macros/lib/macro_implementation.dart
+++ b/pkgs/_cfe_macros/lib/macro_implementation.dart
@@ -84,12 +84,13 @@ class CfeRunningMacro implements injected.RunningMacro {
   /// Queries for [target] and returns the [Model] representing the result.
   ///
   /// TODO: Make this a more limited query which doesn't fetch members.
-  Future<Model> _queryTarget(QualifiedName target) async =>
-      (await _impl._host.hostService.handle(MacroRequest.queryRequest(
-              QueryRequest(query: Query(target: target)),
-              id: nextRequestId)))
+  Future<Model> _queryTarget(QualifiedName target) =>
+      Scope.query.run(() async => (await _impl._host.hostService.handle(
+              MacroRequest.queryRequest(
+                  QueryRequest(query: Query(target: target)),
+                  id: nextRequestId)))
           .asQueryResponse
-          .model;
+          .model);
 
   @override
   Future<CfeMacroExecutionResult> executeDeclarationsPhase(

--- a/pkgs/_cfe_macros/lib/query_service.dart
+++ b/pkgs/_cfe_macros/lib/query_service.dart
@@ -57,8 +57,13 @@ class CfeQueryService implements QueryService {
         isStatic: current.isStatic,
       ));
     }
-
-    return Model(types: _buildTypeHierarchy({classBuilder.actualCls}))
+    TypeHierarchy? types;
+    try {
+      types = _buildTypeHierarchy({classBuilder.actualCls});
+    } catch (_) {
+      // TODO: Fails in types phase, implement fine grained queries.
+    }
+    return Model(types: types)
       ..uris[uri] = (Library()
         ..
             // TODO(davidmorgan): return more than just fields.

--- a/pkgs/_macro_client/lib/macro_client.dart
+++ b/pkgs/_macro_client/lib/macro_client.dart
@@ -112,27 +112,29 @@ class MacroClient {
                       '${hostRequest.macroAnnotation.asString}')));
         } else {
           final augmentRequest = hostRequest.asAugmentRequest;
-          await Scope.macro
-              .runAsync(() async => _sendResponse(Response.augmentResponse(
-                  switch (augmentRequest.phase) {
-                        1 => macro.description.runsInPhases.contains(1)
-                            ? await executeTypesMacro(
-                                macro, _host, augmentRequest)
-                            : null,
-                        2 => macro.description.runsInPhases.contains(2)
-                            ? await executeDeclarationsMacro(
-                                macro, _host, augmentRequest)
-                            : null,
-                        3 => macro.description.runsInPhases.contains(3)
-                            ? await executeDefinitionsMacro(
-                                macro, _host, augmentRequest)
-                            : null,
-                        _ => throw StateError(
-                            'Unexpected phase ${augmentRequest.phase}, '
-                            'expected 1, 2, or 3.')
-                      } ??
-                      AugmentResponse(augmentations: []),
-                  requestId: hostRequest.id)));
+          await Scope.macro.runAsync(() async {
+            MacroScope.current.addModel(augmentRequest.model);
+            return _sendResponse(Response.augmentResponse(
+                switch (augmentRequest.phase) {
+                      1 => macro.description.runsInPhases.contains(1)
+                          ? await executeTypesMacro(
+                              macro, _host, augmentRequest)
+                          : null,
+                      2 => macro.description.runsInPhases.contains(2)
+                          ? await executeDeclarationsMacro(
+                              macro, _host, augmentRequest)
+                          : null,
+                      3 => macro.description.runsInPhases.contains(3)
+                          ? await executeDefinitionsMacro(
+                              macro, _host, augmentRequest)
+                          : null,
+                      _ => throw StateError(
+                          'Unexpected phase ${augmentRequest.phase}, '
+                          'expected 1, 2, or 3.')
+                    } ??
+                    AugmentResponse(augmentations: []),
+                requestId: hostRequest.id));
+          });
         }
       default:
       // Ignore unknown request.

--- a/pkgs/_macro_client/lib/src/execute_macro.dart
+++ b/pkgs/_macro_client/lib/src/execute_macro.dart
@@ -14,11 +14,11 @@ Future<AugmentResponse> executeTypesMacro(
   final target = request.target;
   // TODO: https://github.com/dart-lang/macros/issues/100.
   final queryResult = await host.query(Query(target: target));
-  final properties =
-      queryResult.uris[target.uri]!.scopes[target.name]!.properties;
-  switch ((properties, macro)) {
+  final interface = queryResult.uris[target.uri]!.scopes[target.name]!;
+
+  switch ((interface.properties, macro)) {
     case (Properties(isClass: true), ClassTypesMacro macro):
-      return await macro.buildTypesForClass(host, request);
+      return await macro.buildTypesForClass(interface, queryResult, host);
     case (_, LibraryTypesMacro()):
     case (_, ConstructorTypesMacro()):
     case (_, MethodTypesMacro()):
@@ -44,12 +44,12 @@ Future<AugmentResponse> executeDeclarationsMacro(
   final target = request.target;
   // TODO: https://github.com/dart-lang/macros/issues/100.
   final queryResult = await host.query(Query(target: target));
-  final properties =
-      queryResult.uris[target.uri]!.scopes[target.name]!.properties;
+  final interface = queryResult.uris[target.uri]!.scopes[target.name]!;
 
-  switch ((properties, macro)) {
+  switch ((interface.properties, macro)) {
     case (Properties(isClass: true), ClassDeclarationsMacro macro):
-      return await macro.buildDeclarationsForClass(host, request);
+      return await macro.buildDeclarationsForClass(
+          interface, queryResult, host);
     case (_, LibraryDeclarationsMacro()):
     case (_, EnumDeclarationsMacro()):
     case (_, ExtensionDeclarationsMacro()):
@@ -75,12 +75,11 @@ Future<AugmentResponse> executeDefinitionsMacro(
   final target = request.target;
   // TODO: https://github.com/dart-lang/macros/issues/100.
   final queryResult = await host.query(Query(target: target));
-  final properties =
-      queryResult.uris[target.uri]!.scopes[target.name]!.properties;
+  final interface = queryResult.uris[target.uri]!.scopes[target.name]!;
 
-  switch ((properties, macro)) {
+  switch ((interface.properties, macro)) {
     case (Properties(isClass: true), ClassDefinitionsMacro macro):
-      return await macro.buildDefinitionsForClass(host, request);
+      return await macro.buildDefinitionsForClass(interface, queryResult, host);
     case (_, LibraryDefinitionsMacro()):
     case (_, EnumDefinitionsMacro()):
     case (_, ExtensionDefinitionsMacro()):

--- a/pkgs/_macro_client/lib/src/execute_macro.dart
+++ b/pkgs/_macro_client/lib/src/execute_macro.dart
@@ -12,13 +12,12 @@ import 'package:macro_service/macro_service.dart';
 Future<AugmentResponse> executeTypesMacro(
     Macro macro, Host host, AugmentRequest request) async {
   final target = request.target;
-  // TODO: https://github.com/dart-lang/macros/issues/100.
-  final queryResult = await host.query(Query(target: target));
-  final interface = queryResult.uris[target.uri]!.scopes[target.name]!;
+  final model = request.model;
+  final interface = model.uris[target.uri]!.scopes[target.name]!;
 
   switch ((interface.properties, macro)) {
     case (Properties(isClass: true), ClassTypesMacro macro):
-      return await macro.buildTypesForClass(interface, queryResult, host);
+      return await macro.buildTypesForClass(interface, model, host);
     case (_, LibraryTypesMacro()):
     case (_, ConstructorTypesMacro()):
     case (_, MethodTypesMacro()):
@@ -42,14 +41,12 @@ Future<AugmentResponse> executeTypesMacro(
 Future<AugmentResponse> executeDeclarationsMacro(
     Macro macro, Host host, AugmentRequest request) async {
   final target = request.target;
-  // TODO: https://github.com/dart-lang/macros/issues/100.
-  final queryResult = await host.query(Query(target: target));
-  final interface = queryResult.uris[target.uri]!.scopes[target.name]!;
+  final model = request.model;
+  final interface = model.uris[target.uri]!.scopes[target.name]!;
 
   switch ((interface.properties, macro)) {
     case (Properties(isClass: true), ClassDeclarationsMacro macro):
-      return await macro.buildDeclarationsForClass(
-          interface, queryResult, host);
+      return await macro.buildDeclarationsForClass(interface, model, host);
     case (_, LibraryDeclarationsMacro()):
     case (_, EnumDeclarationsMacro()):
     case (_, ExtensionDeclarationsMacro()):
@@ -73,13 +70,12 @@ Future<AugmentResponse> executeDeclarationsMacro(
 Future<AugmentResponse> executeDefinitionsMacro(
     Macro macro, Host host, AugmentRequest request) async {
   final target = request.target;
-  // TODO: https://github.com/dart-lang/macros/issues/100.
-  final queryResult = await host.query(Query(target: target));
-  final interface = queryResult.uris[target.uri]!.scopes[target.name]!;
+  final model = request.model;
+  final interface = model.uris[target.uri]!.scopes[target.name]!;
 
   switch ((interface.properties, macro)) {
     case (Properties(isClass: true), ClassDefinitionsMacro macro):
-      return await macro.buildDefinitionsForClass(interface, queryResult, host);
+      return await macro.buildDefinitionsForClass(interface, model, host);
     case (_, LibraryDefinitionsMacro()):
     case (_, EnumDefinitionsMacro()):
     case (_, ExtensionDefinitionsMacro()):

--- a/pkgs/_macro_client/test/macro_client_test.dart
+++ b/pkgs/_macro_client/test/macro_client_test.dart
@@ -140,7 +140,7 @@ void main() {
             'interfaceAugmentations': <String, Object?>{},
             'mixinAugmentations': <String, Object?>{},
             'typeAugmentations': {
-              'A': [
+              'Foo': [
                 {
                   'code': [
                     {
@@ -222,7 +222,7 @@ void main() {
               'interfaceAugmentations': <String, Object?>{},
               'mixinAugmentations': <String, Object?>{},
               'typeAugmentations': {
-                'A': [
+                'Foo': [
                   {
                     'code': [
                       {
@@ -302,7 +302,7 @@ void main() {
               'interfaceAugmentations': <String, Object?>{},
               'mixinAugmentations': <String, Object?>{},
               'typeAugmentations': {
-                'A': [
+                'Foo': [
                   {
                     'code': [
                       {
@@ -329,7 +329,7 @@ void main() {
               'interfaceAugmentations': <String, Object?>{},
               'mixinAugmentations': <String, Object?>{},
               'typeAugmentations': {
-                'A': [
+                'Foo': [
                   {
                     'code': [
                       {

--- a/pkgs/_macro_host/lib/macro_host.dart
+++ b/pkgs/_macro_host/lib/macro_host.dart
@@ -23,6 +23,9 @@ class MacroHost {
   final MacroBuilder macroBuilder = MacroBuilder();
   final MacroRunner macroRunner = MacroRunner();
 
+  /// We only want to expose the public interface and not the private impl.
+  HostService get hostService => _hostService;
+
   MacroHost._(this.macroPackageConfig, this.macroServer, this._hostService);
 
   /// Starts a macro host with introspection queries handled by [queryService].

--- a/pkgs/_macro_host/test/macro_host_test.dart
+++ b/pkgs/_macro_host/test/macro_host_test.dart
@@ -10,6 +10,11 @@ import 'package:macro_service/macro_service.dart';
 import 'package:test/test.dart';
 
 void main() {
+  final fooTarget = QualifiedName(name: 'Foo', uri: 'package:foo/foo.dart');
+  final fooModel = Scope.query.run(() => Model()
+    ..uris[fooTarget.uri] = (Library()
+      ..scopes['Foo'] = Interface(properties: Properties(isClass: true))));
+
   for (final protocol in [
     Protocol(encoding: ProtocolEncoding.json, version: ProtocolVersion.macros1),
     Protocol(
@@ -33,12 +38,8 @@ void main() {
             await host.queryMacroPhases(packageConfig, macroAnnotation), {2});
 
         expect(
-            await host.augment(
-                macroAnnotation,
-                AugmentRequest(
-                    phase: 2,
-                    target: QualifiedName(
-                        name: 'Foo', uri: 'package:foo/foo.dart'))),
+            await host.augment(macroAnnotation,
+                AugmentRequest(phase: 2, target: fooTarget, model: fooModel)),
             Scope.macro.run(() => AugmentResponse(augmentations: [
                   Augmentation(code: [Code.string('int get x => 3;')])
                 ])));
@@ -61,12 +62,8 @@ void main() {
             await host.queryMacroPhases(packageConfig, macroAnnotation), {3});
 
         expect(
-            await host.augment(
-                macroAnnotation,
-                AugmentRequest(
-                    phase: 3,
-                    target: QualifiedName(
-                        uri: 'package:foo/foo.dart', name: 'Foo'))),
+            await host.augment(macroAnnotation,
+                AugmentRequest(phase: 3, target: fooTarget, model: fooModel)),
             Scope.macro.run(() => AugmentResponse(augmentations: [
                   Augmentation(code: [
                     Code.string(
@@ -92,12 +89,8 @@ void main() {
             queryService: queryService);
 
         for (final macroName in macroNames) {
-          await host.augment(
-              macroName,
-              AugmentRequest(
-                  phase: 3,
-                  target:
-                      QualifiedName(uri: 'package:foo/foo.dart', name: 'Foo')));
+          await host.augment(macroName,
+              AugmentRequest(phase: 3, target: fooTarget, model: fooModel));
         }
       });
     });

--- a/pkgs/_macro_server/test/macro_server_test.dart
+++ b/pkgs/_macro_server/test/macro_server_test.dart
@@ -13,6 +13,11 @@ import 'package:macro_service/macro_service.dart';
 import 'package:test/test.dart';
 
 void main() {
+  final fooTarget = QualifiedName(name: 'Foo', uri: 'package:foo/foo.dart');
+  final fooModel = Scope.query.run(() => Model()
+    ..uris[fooTarget.uri] = (Library()
+      ..scopes['Foo'] = Interface(properties: Properties(isClass: true))));
+
   for (final protocol in [
     Protocol(encoding: ProtocolEncoding.json, version: ProtocolVersion.macros1),
     Protocol(
@@ -37,7 +42,8 @@ void main() {
         final server =
             await MacroServer.serve(protocol: protocol, service: service);
         expect(
-            server.sendToMacro(HostRequest.augmentRequest(AugmentRequest(),
+            server.sendToMacro(HostRequest.augmentRequest(
+                AugmentRequest(phase: 1, target: fooTarget, model: fooModel),
                 id: 1,
                 macroAnnotation: QualifiedName(
                     uri: 'package:_test_macros/test_macros.dart',
@@ -58,7 +64,7 @@ void main() {
           macroAnnotation: QualifiedName(
               uri: 'package:_test_macros/declare_x_macro.dart',
               name: 'DeclareX'),
-          AugmentRequest(phase: 1),
+          AugmentRequest(phase: 1, target: fooTarget, model: fooModel),
         ));
       });
 
@@ -80,14 +86,14 @@ void main() {
             macroAnnotation: QualifiedName(
                 uri: 'package:_test_macros/declare_x_macro.dart',
                 name: 'DeclareX'),
-            AugmentRequest(phase: 1),
+            AugmentRequest(phase: 1, target: fooTarget, model: fooModel),
           )),
           server.sendToMacro(HostRequest.augmentRequest(
               id: 2,
               macroAnnotation: QualifiedName(
                   uri: 'package:_test_macros/query_class.dart',
                   name: 'QueryClass'),
-              AugmentRequest(phase: 1)))
+              AugmentRequest(phase: 1, target: fooTarget, model: fooModel)))
         ]);
       });
 
@@ -108,14 +114,14 @@ void main() {
             macroAnnotation: QualifiedName(
                 uri: 'package:_test_macros/declare_x_macro.dart',
                 name: 'DeclareX'),
-            AugmentRequest(phase: 1),
+            AugmentRequest(phase: 1, target: fooTarget, model: fooModel),
           )),
           server.sendToMacro(HostRequest.augmentRequest(
             id: 2,
             macroAnnotation: QualifiedName(
                 uri: 'package:_test_macros/query_class.dart',
                 name: 'QueryClass'),
-            AugmentRequest(phase: 1),
+            AugmentRequest(phase: 1, target: fooTarget, model: fooModel),
           ))
         ]);
       });

--- a/pkgs/_test_macros/lib/declare_x_macro.dart
+++ b/pkgs/_test_macros/lib/declare_x_macro.dart
@@ -23,11 +23,7 @@ class DeclareXImplementation implements ClassDeclarationsMacro {
 
   @override
   Future<AugmentResponse> buildDeclarationsForClass(
-      Host host, AugmentRequest request) async {
-    // TODO(davidmorgan): make the host only run in the phases requested so
-    // that this is not needed.
-    if (request.phase != 2) return AugmentResponse(augmentations: []);
-
+      Interface target, Model model, Host host) async {
     // TODO(davidmorgan): still need to pass through the augment target.
     return AugmentResponse(
         augmentations: [Augmentation(code: expandTemplate('int get x => 3;'))]);

--- a/pkgs/_test_macros/lib/json_codable.dart
+++ b/pkgs/_test_macros/lib/json_codable.dart
@@ -28,12 +28,12 @@ class JsonCodableImplementation
 
   @override
   Future<AugmentResponse> buildDeclarationsForClass(
-      Host host, AugmentRequest request) async {
-    final target = request.target;
+      Interface target, Model model, Host host) async {
+    final qualifiedName = model.qualifiedNameOf(target.node)!;
     return AugmentResponse(augmentations: [
       Augmentation(code: expandTemplate('''
 // TODO(davidmorgan): see https://github.com/dart-lang/macros/issues/80.
-// external ${target.name}.fromJson($_jsonMapType json);
+// external ${qualifiedName.name}.fromJson($_jsonMapType json);
 // external $_jsonMapType toJson();
    '''))
     ]);
@@ -41,17 +41,16 @@ class JsonCodableImplementation
 
   @override
   Future<AugmentResponse> buildDefinitionsForClass(
-      Host host, AugmentRequest request) async {
-    final target = request.target;
-    final model = await host.query(Query(target: target));
-    final clazz = model.uris[target.uri]!.scopes[target.name]!;
-
+      Interface target, Model model, Host host) async {
+    final qualifiedName = model.qualifiedNameOf(target.node)!;
     // TODO(davidmorgan): put `extends` information directly in `Interface`.
-    final superclassName = MacroScope.current.typeSystem.supertypeOf(target);
+    final superclassName =
+        MacroScope.current.typeSystem.supertypeOf(qualifiedName);
 
     return AugmentResponse(augmentations: [
-      await _generateFromJson(host, model, target, superclassName, clazz),
-      await _generateToJson(host, model, target, superclassName, clazz)
+      await _generateFromJson(
+          host, model, qualifiedName, superclassName, target),
+      await _generateToJson(host, model, qualifiedName, superclassName, target)
     ]);
   }
 

--- a/pkgs/_test_macros/lib/query_class.dart
+++ b/pkgs/_test_macros/lib/query_class.dart
@@ -26,12 +26,12 @@ class QueryClassImplementation implements ClassDefinitionsMacro {
 
   @override
   Future<AugmentResponse> buildDefinitionsForClass(
-      Host host, AugmentRequest request) async {
-    final model = await host.query(Query(
-      target: request.target,
+      Interface target, Model model, Host host) async {
+    final result = await host.query(Query(
+      target: model.qualifiedNameOf(target.node),
     ));
     return AugmentResponse(augmentations: [
-      Augmentation(code: expandTemplate('// ${json.encode(model)}'))
+      Augmentation(code: expandTemplate('// ${json.encode(result)}'))
     ]);
   }
 }

--- a/pkgs/dart_model/lib/src/dart_model.dart
+++ b/pkgs/dart_model/lib/src/dart_model.dart
@@ -14,18 +14,16 @@ extension QualifiedNameExtension on QualifiedName {
 }
 
 extension ModelExtension on Model {
-  /// Returns the path in the model to [member], or `null` if [member] is not
-  /// in this [Model].
+  /// Returns the path in the model to [node], or `null` if
+  /// [node] is not in this [Model].
   ///
   /// Comparison is by identity, not by value, so the exact instance must be in
   /// this [Model].
   ///
-  /// TODO(davidmorgan): this works for any node, but it's not clear yet which
-  /// types of node we want this functionality exposed for.
-  /// TODO(davidmorgan): a list of path segments is probably more useful than
-  /// `String`.
-  QualifiedName? qualifiedNameOfMember(Member member) =>
-      _qualifiedNameOf(member.node);
+  /// TODO: Should we create a base type called `Declaration` which is
+  /// implemented by the types which are valid to pass here?
+  QualifiedName? qualifiedNameOf(Map<String, Object?> node) =>
+      _qualifiedNameOf(node);
 
   /// Returns the [QualifiedName] in the model to [node], or `null` if [node] is not in this [Model].
   QualifiedName? _qualifiedNameOf(Map<String, Object?> node) {

--- a/pkgs/dart_model/lib/src/dart_model.dart
+++ b/pkgs/dart_model/lib/src/dart_model.dart
@@ -25,23 +25,26 @@ extension ModelExtension on Model {
   QualifiedName? qualifiedNameOf(Map<String, Object?> node) =>
       _qualifiedNameOf(node);
 
-  /// Returns the [QualifiedName] in the model to [node], or `null` if [node] is not in this [Model].
+  /// Returns the [QualifiedName] in the model to [node], or `null` if [node]
+  /// is not in this [Model].
   QualifiedName? _qualifiedNameOf(Map<String, Object?> node) {
-    final members = _getParent(node);
-    if (members == null) return null;
-    final interface = _getParent(members);
-    if (interface == null) return null;
-    final scopes = _getParent(interface);
-    if (scopes == null) return null;
-    final library = _getParent(scopes);
-    if (library == null) return null;
-    final libraries = _getParent(library);
-    if (libraries == null) return null;
+    var parent = _getParent(node);
+    if (parent == null) return null;
+    final path = <String>[];
+    path.add(_keyOf(node, parent));
+    var previousParent = parent;
+    while ((parent = _getParent(previousParent)) != this.node) {
+      if (parent == null) return null;
+      path.insert(0, _keyOf(previousParent, parent));
+      previousParent = parent;
+    }
 
-    final uri = _keyOf(library, libraries);
-    final name = _keyOf(interface, scopes);
-
-    return QualifiedName(uri: uri, name: name);
+    if (path case [String uri, 'scopes', String name]) {
+      return QualifiedName(uri: uri, name: name);
+    }
+    throw UnsupportedError(
+        'Unsupported node type for `qualifiedNameOf`, only top level members '
+        'are supported for now. $path');
   }
 
   /// Returns the key of [value] in [map].

--- a/pkgs/dart_model/lib/src/dart_model.dart
+++ b/pkgs/dart_model/lib/src/dart_model.dart
@@ -39,7 +39,7 @@ extension ModelExtension on Model {
       previousParent = parent;
     }
 
-    if (path case [String uri, 'scopes', String name]) {
+    if (path case [final uri, 'scopes', final name]) {
       return QualifiedName(uri: uri, name: name);
     }
     throw UnsupportedError(

--- a/pkgs/dart_model/test/model_test.dart
+++ b/pkgs/dart_model/test/model_test.dart
@@ -111,7 +111,7 @@ void main() {
     test('can give the path to Members in buffer backed maps', () {
       final member = model.uris['package:dart_model/dart_model.dart']!
           .scopes['JsonData']!.members['_root']!;
-      expect(model.qualifiedNameOfMember(member)!.asString,
+      expect(model.qualifiedNameOf(member.node)!.asString,
           'package:dart_model/dart_model.dart#JsonData');
     });
 
@@ -119,7 +119,7 @@ void main() {
       final copiedModel = Model.fromJson(_copyMap(model.node));
       final member = copiedModel.uris['package:dart_model/dart_model.dart']!
           .scopes['JsonData']!.members['_root']!;
-      expect(copiedModel.qualifiedNameOfMember(member)!.asString,
+      expect(copiedModel.qualifiedNameOf(member.node)!.asString,
           'package:dart_model/dart_model.dart#JsonData');
     });
 
@@ -129,7 +129,7 @@ void main() {
       (copiedModel.node['uris'] as Map<String, Object?>)['loop'] = copiedModel;
       final member = copiedModel.uris['package:dart_model/dart_model.dart']!
           .scopes['JsonData']!.members['_root']!;
-      expect(() => copiedModel.qualifiedNameOfMember(member), throwsStateError);
+      expect(() => copiedModel.qualifiedNameOf(member.node), throwsStateError);
     });
 
     test('path to Members throws on reused node', () {
@@ -139,7 +139,7 @@ void main() {
           copiedModel.uris['package:dart_model/dart_model.dart']!;
       final member = copiedModel.uris['package:dart_model/dart_model.dart']!
           .scopes['JsonData']!.members['_root']!;
-      expect(() => copiedModel.qualifiedNameOfMember(member), throwsStateError);
+      expect(() => copiedModel.qualifiedNameOf(member.node), throwsStateError);
     });
 
     test('path to Member returns null for Member in wrong Map', () {
@@ -151,8 +151,8 @@ void main() {
           .scopes['JsonData']!
           .members['_root']!
           .node));
-      expect(copiedModel.qualifiedNameOfMember(member), null);
-      expect(model.qualifiedNameOfMember(copiedMember), null);
+      expect(copiedModel.qualifiedNameOf(member.node), null);
+      expect(model.qualifiedNameOf(copiedMember.node), null);
     });
   });
 

--- a/pkgs/dart_model/test/model_test.dart
+++ b/pkgs/dart_model/test/model_test.dart
@@ -108,10 +108,26 @@ void main() {
               'JsonData']!['members']);
     });
 
+    test('can give the path to Interfaces in buffer backed maps', () {
+      final interface =
+          model.uris['package:dart_model/dart_model.dart']!.scopes['JsonData']!;
+      expect(model.qualifiedNameOf(interface.node)!.asString,
+          'package:dart_model/dart_model.dart#JsonData');
+    });
+
     test('can give the path to Members in buffer backed maps', () {
       final member = model.uris['package:dart_model/dart_model.dart']!
           .scopes['JsonData']!.members['_root']!;
-      expect(model.qualifiedNameOf(member.node)!.asString,
+      expect(() => model.qualifiedNameOf(member.node)!.asString,
+          throwsUnsupportedError,
+          reason: 'Requires https://github.com/dart-lang/macros/pull/101');
+    });
+
+    test('can give the path to Interfaces in SDK maps', () {
+      final copiedModel = Model.fromJson(_copyMap(model.node));
+      final interface = copiedModel
+          .uris['package:dart_model/dart_model.dart']!.scopes['JsonData']!;
+      expect(copiedModel.qualifiedNameOf(interface.node)!.asString,
           'package:dart_model/dart_model.dart#JsonData');
     });
 
@@ -119,8 +135,9 @@ void main() {
       final copiedModel = Model.fromJson(_copyMap(model.node));
       final member = copiedModel.uris['package:dart_model/dart_model.dart']!
           .scopes['JsonData']!.members['_root']!;
-      expect(copiedModel.qualifiedNameOf(member.node)!.asString,
-          'package:dart_model/dart_model.dart#JsonData');
+      expect(() => copiedModel.qualifiedNameOf(member.node)!.asString,
+          throwsUnsupportedError,
+          reason: 'Requires https://github.com/dart-lang/macros/pull/101');
     });
 
     test('path to Members throws on cycle', () {

--- a/pkgs/macro/lib/macro.dart
+++ b/pkgs/macro/lib/macro.dart
@@ -28,21 +28,30 @@ abstract interface class Macro {
 /// want to contribute new type declarations to the library.
 abstract interface class LibraryTypesMacro implements Macro {
   FutureOr<AugmentResponse> buildTypesForLibrary(
-      Host host, AugmentRequest request);
+      // TODO: Fill in a real type once we have it
+      Object target,
+      Model model,
+      Host host);
 }
 
 /// The interface for [Macro]s that can be applied to a library directive, and
 /// want to contribute new non-type declarations to the library.
 abstract interface class LibraryDeclarationsMacro implements Macro {
   FutureOr<AugmentResponse> buildDeclarationsForLibrary(
-      Host host, AugmentRequest request);
+      // TODO: Fill in a real type once we have it
+      Object target,
+      Model model,
+      Host host);
 }
 
 /// The interface for [Macro]s that can be applied to a library directive, and
 /// want to provide definitions for declarations in the library.
 abstract interface class LibraryDefinitionsMacro implements Macro {
   FutureOr<AugmentResponse> buildDefinitionsForLibrary(
-      Host host, AugmentRequest request);
+      // TODO: Fill in a real type once we have it
+      Object target,
+      Model model,
+      Host host);
 }
 
 /// The interface for [Macro]s that can be applied to any top level function,
@@ -50,7 +59,10 @@ abstract interface class LibraryDefinitionsMacro implements Macro {
 /// declarations to the program.
 abstract interface class FunctionTypesMacro implements Macro {
   FutureOr<AugmentResponse> buildTypesForFunction(
-      Host host, AugmentRequest request);
+      // TODO: Fill in a real type once we have it
+      Object target,
+      Model model,
+      Host host);
 }
 
 /// The interface for [Macro]s that can be applied to any top level function,
@@ -58,7 +70,10 @@ abstract interface class FunctionTypesMacro implements Macro {
 /// declarations to the program.
 abstract interface class FunctionDeclarationsMacro implements Macro {
   FutureOr<AugmentResponse> buildDeclarationsForFunction(
-      Host host, AugmentRequest request);
+      // TODO: Fill in a real type once we have it
+      Object target,
+      Model model,
+      Host host);
 }
 
 /// The interface for [Macro]s that can be applied to any top level function,
@@ -66,7 +81,10 @@ abstract interface class FunctionDeclarationsMacro implements Macro {
 /// definition.
 abstract interface class FunctionDefinitionsMacro implements Macro {
   FutureOr<AugmentResponse> buildDefinitionsForFunction(
-      Host host, AugmentRequest request);
+      // TODO: Fill in a real type once we have it
+      Object target,
+      Model model,
+      Host host);
 }
 
 /// The interface for [Macro]s that can be applied to any top level variable or
@@ -74,7 +92,10 @@ abstract interface class FunctionDefinitionsMacro implements Macro {
 /// program.
 abstract interface class VariableTypesMacro implements Macro {
   FutureOr<AugmentResponse> buildTypesForVariable(
-      Host host, AugmentRequest request);
+      // TODO: Fill in a real type once we have it
+      Object target,
+      Model model,
+      Host host);
 }
 
 /// The interface for [Macro]s that can be applied to any top level variable or
@@ -82,189 +103,261 @@ abstract interface class VariableTypesMacro implements Macro {
 /// program.
 abstract interface class VariableDeclarationsMacro implements Macro {
   FutureOr<AugmentResponse> buildDeclarationsForVariable(
-      Host host, AugmentRequest request);
+      // TODO: Fill in a real type once we have it
+      Object target,
+      Model model,
+      Host host);
 }
 
 /// The interface for [Macro]s that can be applied to any top level variable
 /// or instance field, and want to augment the variable definition.
 abstract interface class VariableDefinitionsMacro implements Macro {
   FutureOr<AugmentResponse> buildDefinitionsForVariable(
-      Host host, AugmentRequest request);
+      // TODO: Fill in a real type once we have it
+      Object target,
+      Model model,
+      Host host);
 }
 
 /// The interface for [Macro]s that can be applied to any class, and want to
 /// contribute new type declarations to the program.
 abstract interface class ClassTypesMacro implements Macro {
   FutureOr<AugmentResponse> buildTypesForClass(
-      Host host, AugmentRequest request);
+      Interface target, Model model, Host host);
 }
 
 /// The interface for [Macro]s that can be applied to any class, and want to
 /// contribute new non-type declarations to the program.
 abstract interface class ClassDeclarationsMacro implements Macro {
   FutureOr<AugmentResponse> buildDeclarationsForClass(
-      Host host, AugmentRequest request);
+      Interface target, Model model, Host host);
 }
 
 /// The interface for [Macro]s that can be applied to any class, and want to
 /// augment the definitions of the members of that class.
 abstract interface class ClassDefinitionsMacro implements Macro {
   FutureOr<AugmentResponse> buildDefinitionsForClass(
-      Host host, AugmentRequest request);
+      Interface target, Model model, Host host);
 }
 
 /// The interface for [Macro]s that can be applied to any enum, and want to
 /// contribute new type declarations to the program.
 abstract interface class EnumTypesMacro implements Macro {
   FutureOr<AugmentResponse> buildTypesForEnum(
-      Host host, AugmentRequest request);
+      // TODO: Fill in a real type once we have it
+      Object target,
+      Model model,
+      Host host);
 }
 
 /// The interface for [Macro]s that can be applied to any enum, and want to
 /// contribute new non-type declarations to the program.
 abstract interface class EnumDeclarationsMacro implements Macro {
   FutureOr<AugmentResponse> buildDeclarationsForEnum(
-      Host host, AugmentRequest request);
+      // TODO: Fill in a real type once we have it
+      Object target,
+      Model model,
+      Host host);
 }
 
 /// The interface for [Macro]s that can be applied to any enum, and want to
 /// augment the definitions of members or values of that enum.
 abstract interface class EnumDefinitionsMacro implements Macro {
   FutureOr<AugmentResponse> buildDefinitionsForEnum(
-      Host host, AugmentRequest request);
+      // TODO: Fill in a real type once we have it
+      Object target,
+      Model model,
+      Host host);
 }
 
 /// The interface for [Macro]s that can be applied to any enum, and want to
 /// contribute new type declarations to the program.
 abstract interface class EnumValueTypesMacro implements Macro {
   FutureOr<AugmentResponse> buildTypesForEnumValue(
-      Host host, AugmentRequest request);
+      // TODO: Fill in a real type once we have it
+      Object target,
+      Model model,
+      Host host);
 }
 
 /// The interface for [Macro]s that can be applied to any enum, and want to
 /// contribute new non-type declarations to the program.
 abstract interface class EnumValueDeclarationsMacro implements Macro {
   FutureOr<AugmentResponse> buildDeclarationsForEnumValue(
-      Host host, AugmentRequest request);
+      // TODO: Fill in a real type once we have it
+      Object target,
+      Model model,
+      Host host);
 }
 
 /// The interface for [Macro]s that can be applied to any enum, and want to
 /// augment the definitions of members or values of that enum.
 abstract interface class EnumValueDefinitionsMacro implements Macro {
   FutureOr<AugmentResponse> buildDefinitionsForEnumValue(
-      Host host, AugmentRequest request);
+      // TODO: Fill in a real type once we have it
+      Object target,
+      Model model,
+      Host host);
 }
 
 /// The interface for [Macro]s that can be applied to any field, and want to
 /// contribute new type declarations to the program.
 abstract interface class FieldTypesMacro implements Macro {
   FutureOr<AugmentResponse> buildTypesForField(
-      Host host, AugmentRequest request);
+      // TODO: Fill in a real type once we have it
+      Object target,
+      Model model,
+      Host host);
 }
 
 /// The interface for [Macro]s that can be applied to any field, and want to
 /// contribute new type declarations to the program.
 abstract interface class FieldDeclarationsMacro implements Macro {
   FutureOr<AugmentResponse> buildDeclarationsForField(
-      Host host, AugmentRequest request);
+      // TODO: Fill in a real type once we have it
+      Object target,
+      Model model,
+      Host host);
 }
 
 /// The interface for [Macro]s that can be applied to any field, and want to
 /// augment the field definition.
 abstract interface class FieldDefinitionsMacro implements Macro {
   FutureOr<AugmentResponse> buildDefinitionsForField(
-      Host host, AugmentRequest request);
+      // TODO: Fill in a real type once we have it
+      Object target,
+      Model model,
+      Host host);
 }
 
 /// The interface for [Macro]s that can be applied to any method, and want to
 /// contribute new type declarations to the program.
 abstract interface class MethodTypesMacro implements Macro {
   FutureOr<AugmentResponse> buildTypesForMethod(
-      Host host, AugmentRequest request);
+      // TODO: Fill in a real type once we have it
+      Object target,
+      Model model,
+      Host host);
 }
 
 /// The interface for [Macro]s that can be applied to any method, and want to
 /// contribute new non-type declarations to the program.
 abstract interface class MethodDeclarationsMacro implements Macro {
   FutureOr<AugmentResponse> buildDeclarationsForMethod(
-      Host host, AugmentRequest request);
+      // TODO: Fill in a real type once we have it
+      Object target,
+      Model model,
+      Host host);
 }
 
 /// The interface for [Macro]s that can be applied to any method, and want to
 /// augment the function definition.
 abstract interface class MethodDefinitionsMacro implements Macro {
   FutureOr<AugmentResponse> buildDefinitionsForMethod(
-      Host host, AugmentRequest request);
+      // TODO: Fill in a real type once we have it
+      Object target,
+      Model model,
+      Host host);
 }
 
 /// The interface for [Macro]s that can be applied to any constructor, and want
 /// to contribute new type declarations to the program.
 abstract interface class ConstructorTypesMacro implements Macro {
   FutureOr<AugmentResponse> buildTypesForConstructor(
-      Host host, AugmentRequest request);
+      // TODO: Fill in a real type once we have it
+      Object target,
+      Model model,
+      Host host);
 }
 
 /// The interface for [Macro]s that can be applied to any constructors, and
 /// want to contribute new non-type declarations to the program.
 abstract interface class ConstructorDeclarationsMacro implements Macro {
   FutureOr<AugmentResponse> buildDeclarationsForConstructor(
-      Host host, AugmentRequest request);
+      // TODO: Fill in a real type once we have it
+      Object target,
+      Model model,
+      Host host);
 }
 
 /// The interface for [Macro]s that can be applied to any constructor, and want
 /// to augment the function definition.
 abstract interface class ConstructorDefinitionsMacro implements Macro {
   FutureOr<AugmentResponse> buildDefinitionsForConstructor(
-      Host host, AugmentRequest request);
+      // TODO: Fill in a real type once we have it
+      Object target,
+      Model model,
+      Host host);
 }
 
 /// The interface for [Macro]s that can be applied to any mixin declaration, and
 /// want to contribute new type declarations to the program.
 abstract interface class MixinTypesMacro implements Macro {
   FutureOr<AugmentResponse> buildTypesForMixin(
-      Host host, AugmentRequest request);
+      // TODO: Fill in a real type once we have it
+      Object target,
+      Model model,
+      Host host);
 }
 
 /// The interface for [Macro]s that can be applied to any mixin declaration, and
 /// want to contribute new non-type declarations to the program.
 abstract interface class MixinDeclarationsMacro implements Macro {
   FutureOr<AugmentResponse> buildDeclarationsForMixin(
-      Host host, AugmentRequest request);
+      // TODO: Fill in a real type once we have it
+      Object target,
+      Model model,
+      Host host);
 }
 
 /// The interface for [Macro]s that can be applied to any mixin declaration, and
 /// want to augment the definitions of the members of that mixin.
 abstract interface class MixinDefinitionsMacro implements Macro {
   FutureOr<AugmentResponse> buildDefinitionsForMixin(
-      Host host, AugmentRequest request);
+      // TODO: Fill in a real type once we have it
+      Object target,
+      Model model,
+      Host host);
 }
 
 /// The interface for [Macro]s that can be applied to any extension declaration,
 /// and want to contribute new type declarations to the program.
 abstract interface class ExtensionTypesMacro implements Macro {
   FutureOr<AugmentResponse> buildTypesForExtension(
-      Host host, AugmentRequest request);
+      // TODO: Fill in a real type once we have it
+      Object target,
+      Model model,
+      Host host);
 }
 
 /// The interface for [Macro]s that can be applied to any extension declaration,
 /// and want to contribute new non-type declarations to the program.
 abstract interface class ExtensionDeclarationsMacro implements Macro {
   FutureOr<AugmentResponse> buildDeclarationsForExtension(
-      Host host, AugmentRequest request);
+      // TODO: Fill in a real type once we have it
+      Object target,
+      Model model,
+      Host host);
 }
 
 /// The interface for [Macro]s that can be applied to any extension declaration,
 /// and want to augment the definitions of the members of that extension.
 abstract interface class ExtensionDefinitionsMacro implements Macro {
   FutureOr<AugmentResponse> buildDefinitionsForExtension(
-      Host host, AugmentRequest request);
+      // TODO: Fill in a real type once we have it
+      Object target,
+      Model model,
+      Host host);
 }
 
 /// The interface for [Macro]s that can be applied to any extension type
 /// declaration, and want to contribute new type declarations to the program.
 abstract interface class ExtensionTypeTypesMacro implements Macro {
   FutureOr<AugmentResponse> buildTypesForExtensionType(
-      Host host, AugmentRequest request);
+      // TODO: Fill in a real type once we have it
+      Object target,
+      Model model,
+      Host host);
 }
 
 /// The interface for [Macro]s that can be applied to any extension type
@@ -272,7 +365,10 @@ abstract interface class ExtensionTypeTypesMacro implements Macro {
 /// program.
 abstract interface class ExtensionTypeDeclarationsMacro implements Macro {
   FutureOr<AugmentResponse> buildDeclarationsForExtensionType(
-      Host host, AugmentRequest request);
+      // TODO: Fill in a real type once we have it
+      Object target,
+      Model model,
+      Host host);
 }
 
 /// The interface for [Macro]s that can be applied to any extension type
@@ -280,14 +376,20 @@ abstract interface class ExtensionTypeDeclarationsMacro implements Macro {
 /// extension.
 abstract interface class ExtensionTypeDefinitionsMacro implements Macro {
   FutureOr<AugmentResponse> buildDefinitionsForExtensionType(
-      Host host, AugmentRequest request);
+      // TODO: Fill in a real type once we have it
+      Object target,
+      Model model,
+      Host host);
 }
 
 /// The interface for [Macro]s that can be applied to any type alias
 /// declaration, and want to contribute new type declarations to the program.
 abstract interface class TypeAliasTypesMacro implements Macro {
   FutureOr<AugmentResponse> buildTypesForTypeAlias(
-      Host host, AugmentRequest request);
+      // TODO: Fill in a real type once we have it
+      Object target,
+      Model model,
+      Host host);
 }
 
 /// The interface for [Macro]s that can be applied to any type alias
@@ -295,5 +397,8 @@ abstract interface class TypeAliasTypesMacro implements Macro {
 /// program.
 abstract interface class TypeAliasDeclarationsMacro implements Macro {
   FutureOr<AugmentResponse> buildDeclarationsForTypeAlias(
-      Host host, AugmentRequest request);
+      // TODO: Fill in a real type once we have it
+      Object target,
+      Model model,
+      Host host);
 }

--- a/pkgs/macro_service/lib/src/macro_service.g.dart
+++ b/pkgs/macro_service/lib/src/macro_service.g.dart
@@ -14,11 +14,13 @@ import 'package:dart_model/src/scopes.dart';
 extension type AugmentRequest.fromJson(Map<String, Object?> node)
     implements Object {
   AugmentRequest({
-    int? phase,
-    QualifiedName? target,
+    required int phase,
+    required QualifiedName target,
+    required Model model,
   }) : this.fromJson({
-          if (phase != null) 'phase': phase,
-          if (target != null) 'target': target,
+          'phase': phase,
+          'target': target,
+          'model': model,
         });
 
   /// Which phase to run: 1, 2 or 3.
@@ -26,6 +28,9 @@ extension type AugmentRequest.fromJson(Map<String, Object?> node)
 
   /// The class to augment. TODO(davidmorgan): expand to more types of target.
   QualifiedName get target => node['target'] as QualifiedName;
+
+  /// A pre-computed query result for the target.
+  Model get model => node['model'] as Model;
 }
 
 /// Macro's response to an [AugmentRequest]: the resulting augmentations.

--- a/schemas/macro_service.schema.json
+++ b/schemas/macro_service.schema.json
@@ -34,11 +34,68 @@
       "type": "object",
       "description": "Macro's response to an [AugmentRequest]: the resulting augmentations.",
       "properties": {
-        "augmentations": {
+        "enumValueAugmentations": {
+          "type": "object",
+          "description": "Any augmentations to enum values that should be applied to an enum as a result of executing a macro, indexed by the name of the enum.",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "$ref": "file:dart_model.schema.json#/$defs/Augmentation"
+            }
+          }
+        },
+        "extendsTypeAugmentations": {
+          "type": "object",
+          "description": "Any extends clauses that should be added to types as a result of executing a macro, indexed by the name of the augmented type declaration.",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "$ref": "file:dart_model.schema.json#/$defs/Augmentation"
+            }
+          }
+        },
+        "interfaceAugmentations": {
+          "type": "object",
+          "description": "Any interfaces that should be added to types as a result of executing a macro, indexed by the name of the augmented type declaration.",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "$ref": "file:dart_model.schema.json#/$defs/Augmentation"
+            }
+          }
+        },
+        "libraryAugmentations": {
           "type": "array",
-          "description": "The augmentations.",
+          "description": "Any augmentations that should be applied to the library as a result of executing a macro.",
           "items": {
             "$ref": "file:dart_model.schema.json#/$defs/Augmentation"
+          }
+        },
+        "mixinAugmentations": {
+          "type": "object",
+          "description": "Any mixins that should be added to types as a result of executing a macro, indexed by the name of the augmented type declaration.",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "$ref": "file:dart_model.schema.json#/$defs/Augmentation"
+            }
+          }
+        },
+        "newTypeNames": {
+          "type": "array",
+          "description": "The names of any new types declared in [libraryAugmentations].",
+          "items": {
+            "type": "string"
+          }
+        },
+        "typeAugmentations": {
+          "type": "object",
+          "description": "Any augmentations that should be applied to a class as a result of executing a macro, indexed by the name of the class.",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "$ref": "file:dart_model.schema.json#/$defs/Augmentation"
+            }
           }
         }
       }

--- a/schemas/macro_service.schema.json
+++ b/schemas/macro_service.schema.json
@@ -23,6 +23,10 @@
         "target": {
           "$comment": "The class to augment. TODO(davidmorgan): expand to more types of target.",
           "$ref": "file:dart_model.schema.json#/$defs/QualifiedName"
+        },
+        "model": {
+          "$comment": "A pre-computed query result for the target.",
+          "$ref": "file:dart_model.schema.json#/$defs/Model"
         }
       }
     },

--- a/tool/dart_model_generator/lib/definitions.dart
+++ b/tool/dart_model_generator/lib/definitions.dart
@@ -349,11 +349,18 @@ static QualifiedName parse(String string) {
             description: 'A request to a macro to augment some code.',
             properties: [
               Property('phase',
-                  type: 'int', description: 'Which phase to run: 1, 2 or 3.'),
+                  type: 'int',
+                  required: true,
+                  description: 'Which phase to run: 1, 2 or 3.'),
               Property('target',
                   type: 'QualifiedName',
+                  required: true,
                   description: 'The class to augment. '
                       'TODO(davidmorgan): expand to more types of target.'),
+              Property('model',
+                  type: 'Model',
+                  required: true,
+                  description: 'A pre-computed query result for the target.'),
             ]),
         Definition.clazz('AugmentResponse',
             description:


### PR DESCRIPTION
Closes https://github.com/dart-lang/macros/issues/100

- Adds `model` field to AugmentRequest, with implementations to pass it (although, these use a host side query).
  - Expose the `hostService` from the `MacroHost` (used to do the query)
- Adds a `Model` parameter to all macro methods (typed as `Object` for right now for most of them, as we don't have better types yet).
- Make all fields on AugmentRequest required (this simplified implementations, but lmk if you want me to revert this).
- Rename the `Model.qualifiedNameOfMember` extension to `qualifiedNameOf` generalizing and fixing it:
  -  Now it actually does what it says 🤣 (it used to return just the qualified name of the type the member is declared in I think?), there was in any case no way to represent members with qualified names, see https://github.com/dart-lang/macros/pull/101 which adds that.
  - It now throws for anything other than types, since they can't be referenced
  - It just accepts a `Map<String, Object?>` now which is the only thing we can generalize on for the moment, but see https://github.com/dart-lang/macros/issues/103 for one possible workaround.
- Fixes up tests and removes expected request/response from the client for the model