### PR TITLE
set tcpNoDelay option on all sockets for 100x speedup

### DIFF
--- a/pkgs/_macro_client/lib/macro_client.dart
+++ b/pkgs/_macro_client/lib/macro_client.dart
@@ -28,6 +28,8 @@ class MacroClient {
   final Map<int, Completer<Response>> _responseCompleters = {};
 
   MacroClient._(this.macros, this.socket) {
+    // Nagle's algorithm slows us down >100x, disable it.
+    socket.setOption(SocketOption.tcpNoDelay, true);
     _host = RemoteMacroHost(this);
     _start();
   }

--- a/pkgs/_macro_server/lib/macro_server.dart
+++ b/pkgs/_macro_server/lib/macro_server.dart
@@ -121,7 +121,10 @@ class _Connection {
   /// Responses to query requests from the macro.
   Stream<Response> get responses => _responsesController.stream;
 
-  _Connection(this.socket);
+  _Connection(this.socket) {
+    // Nagle's algorithm slows us down >100x, disable it.
+    socket.setOption(SocketOption.tcpNoDelay, true);
+  }
 
   @override
   String toString() => '_Connection($descriptions)';


### PR DESCRIPTION
Related to https://github.com/dart-lang/macros/issues/108, makes round trips about 100x faster.

Total speedup is about 20x, which is still slow (200ms for watch mode edit/refresh loop), but much better.