### PR TITLE
Add macro metadata `dart_model` types and converter.

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -38,16 +38,16 @@ jobs:
       - name: mono_repo self validate
         run: dart pub global run mono_repo generate --validate
   job_002:
-    name: "analyze_and_format; linux; Dart 3.7.0-39.0.dev; PKGS: pkgs/_analyzer_macros, pkgs/_cfe_macros, pkgs/_macro_builder, pkgs/_macro_client, pkgs/_macro_host, pkgs/_macro_runner, pkgs/_macro_server, pkgs/_macro_tool, pkgs/_test_macros, pkgs/dart_model, pkgs/macro, pkgs/macro_service, tool/dart_model_generator; `dart analyze --fatal-infos .`"
+    name: "analyze_and_format; linux; Dart 3.7.0-39.0.dev; PKGS: pkgs/_analyzer_cfe_macros, pkgs/_analyzer_macros, pkgs/_cfe_macros, pkgs/_macro_builder, pkgs/_macro_client, pkgs/_macro_host, pkgs/_macro_runner, pkgs/_macro_server, pkgs/_macro_tool, pkgs/_test_macros, pkgs/dart_model, pkgs/macro, pkgs/macro_service, tool/dart_model_generator; `dart analyze --fatal-infos .`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-39.0.dev;packages:pkgs/_analyzer_macros-pkgs/_cfe_macros-pkgs/_macro_builder-pkgs/_macro_client-pkgs/_macro_host-pkgs/_macro_runner-pkgs/_macro_server-pkgs/_macro_tool-pkgs/_test_macros-pkgs/dart_model-pkgs/macro-pkgs/macro_service-tool/dart_model_generator;commands:analyze"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-39.0.dev;packages:pkgs/_analyzer_cfe_macros-pkgs/_analyzer_macros-pkgs/_cfe_macros-pkgs/_macro_builder-pkgs/_macro_client-pkgs/_macro_host-pkgs/_macro_runner-pkgs/_macro_server-pkgs/_macro_tool-pkgs/_test_macros-pkgs/dart_model-pkgs/macro-pkgs/macro_service-tool/dart_model_generator;commands:analyze"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-39.0.dev;packages:pkgs/_analyzer_macros-pkgs/_cfe_macros-pkgs/_macro_builder-pkgs/_macro_client-pkgs/_macro_host-pkgs/_macro_runner-pkgs/_macro_server-pkgs/_macro_tool-pkgs/_test_macros-pkgs/dart_model-pkgs/macro-pkgs/macro_service-tool/dart_model_generator
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-39.0.dev;packages:pkgs/_analyzer_cfe_macros-pkgs/_analyzer_macros-pkgs/_cfe_macros-pkgs/_macro_builder-pkgs/_macro_client-pkgs/_macro_host-pkgs/_macro_runner-pkgs/_macro_server-pkgs/_macro_tool-pkgs/_test_macros-pkgs/dart_model-pkgs/macro-pkgs/macro_service-tool/dart_model_generator
             os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-39.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
@@ -58,6 +58,15 @@ jobs:
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
+      - id: pkgs__analyzer_cfe_macros_pub_upgrade
+        name: pkgs/_analyzer_cfe_macros; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/_analyzer_cfe_macros
+      - name: "pkgs/_analyzer_cfe_macros; dart analyze --fatal-infos ."
+        run: dart analyze --fatal-infos .
+        if: "always() && steps.pkgs__analyzer_cfe_macros_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/_analyzer_cfe_macros
       - id: pkgs__analyzer_macros_pub_upgrade
         name: pkgs/_analyzer_macros; dart pub upgrade
         run: dart pub upgrade
@@ -176,6 +185,153 @@ jobs:
         if: "always() && steps.tool_dart_model_generator_pub_upgrade.conclusion == 'success'"
         working-directory: tool/dart_model_generator
   job_003:
+    name: "analyze_and_format; linux; Dart dev; PKGS: pkgs/_analyzer_cfe_macros, pkgs/_analyzer_macros, pkgs/_cfe_macros, pkgs/_macro_builder, pkgs/_macro_client, pkgs/_macro_host, pkgs/_macro_runner, pkgs/_macro_server, pkgs/_macro_tool, pkgs/_test_macros, pkgs/dart_model, pkgs/macro, pkgs/macro_service, tool/dart_model_generator; `dart format --output=none --set-exit-if-changed .`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/_analyzer_cfe_macros-pkgs/_analyzer_macros-pkgs/_cfe_macros-pkgs/_macro_builder-pkgs/_macro_client-pkgs/_macro_host-pkgs/_macro_runner-pkgs/_macro_server-pkgs/_macro_tool-pkgs/_test_macros-pkgs/dart_model-pkgs/macro-pkgs/macro_service-tool/dart_model_generator;commands:format"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/_analyzer_cfe_macros-pkgs/_analyzer_macros-pkgs/_cfe_macros-pkgs/_macro_builder-pkgs/_macro_client-pkgs/_macro_host-pkgs/_macro_runner-pkgs/_macro_server-pkgs/_macro_tool-pkgs/_test_macros-pkgs/dart_model-pkgs/macro-pkgs/macro_service-tool/dart_model_generator
+            os:ubuntu-latest;pub-cache-hosted;sdk:dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
+        with:
+          sdk: dev
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
+      - id: pkgs__analyzer_cfe_macros_pub_upgrade
+        name: pkgs/_analyzer_cfe_macros; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/_analyzer_cfe_macros
+      - name: "pkgs/_analyzer_cfe_macros; dart format --output=none --set-exit-if-changed ."
+        run: "dart format --output=none --set-exit-if-changed ."
+        if: "always() && steps.pkgs__analyzer_cfe_macros_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/_analyzer_cfe_macros
+      - id: pkgs__analyzer_macros_pub_upgrade
+        name: pkgs/_analyzer_macros; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/_analyzer_macros
+      - name: "pkgs/_analyzer_macros; dart format --output=none --set-exit-if-changed ."
+        run: "dart format --output=none --set-exit-if-changed ."
+        if: "always() && steps.pkgs__analyzer_macros_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/_analyzer_macros
+      - id: pkgs__cfe_macros_pub_upgrade
+        name: pkgs/_cfe_macros; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/_cfe_macros
+      - name: "pkgs/_cfe_macros; dart format --output=none --set-exit-if-changed ."
+        run: "dart format --output=none --set-exit-if-changed ."
+        if: "always() && steps.pkgs__cfe_macros_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/_cfe_macros
+      - id: pkgs__macro_builder_pub_upgrade
+        name: pkgs/_macro_builder; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/_macro_builder
+      - name: "pkgs/_macro_builder; dart format --output=none --set-exit-if-changed ."
+        run: "dart format --output=none --set-exit-if-changed ."
+        if: "always() && steps.pkgs__macro_builder_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/_macro_builder
+      - id: pkgs__macro_client_pub_upgrade
+        name: pkgs/_macro_client; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/_macro_client
+      - name: "pkgs/_macro_client; dart format --output=none --set-exit-if-changed ."
+        run: "dart format --output=none --set-exit-if-changed ."
+        if: "always() && steps.pkgs__macro_client_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/_macro_client
+      - id: pkgs__macro_host_pub_upgrade
+        name: pkgs/_macro_host; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/_macro_host
+      - name: "pkgs/_macro_host; dart format --output=none --set-exit-if-changed ."
+        run: "dart format --output=none --set-exit-if-changed ."
+        if: "always() && steps.pkgs__macro_host_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/_macro_host
+      - id: pkgs__macro_runner_pub_upgrade
+        name: pkgs/_macro_runner; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/_macro_runner
+      - name: "pkgs/_macro_runner; dart format --output=none --set-exit-if-changed ."
+        run: "dart format --output=none --set-exit-if-changed ."
+        if: "always() && steps.pkgs__macro_runner_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/_macro_runner
+      - id: pkgs__macro_server_pub_upgrade
+        name: pkgs/_macro_server; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/_macro_server
+      - name: "pkgs/_macro_server; dart format --output=none --set-exit-if-changed ."
+        run: "dart format --output=none --set-exit-if-changed ."
+        if: "always() && steps.pkgs__macro_server_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/_macro_server
+      - id: pkgs__macro_tool_pub_upgrade
+        name: pkgs/_macro_tool; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/_macro_tool
+      - name: "pkgs/_macro_tool; dart format --output=none --set-exit-if-changed ."
+        run: "dart format --output=none --set-exit-if-changed ."
+        if: "always() && steps.pkgs__macro_tool_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/_macro_tool
+      - id: pkgs__test_macros_pub_upgrade
+        name: pkgs/_test_macros; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/_test_macros
+      - name: "pkgs/_test_macros; dart format --output=none --set-exit-if-changed ."
+        run: "dart format --output=none --set-exit-if-changed ."
+        if: "always() && steps.pkgs__test_macros_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/_test_macros
+      - id: pkgs_dart_model_pub_upgrade
+        name: pkgs/dart_model; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/dart_model
+      - name: "pkgs/dart_model; dart format --output=none --set-exit-if-changed ."
+        run: "dart format --output=none --set-exit-if-changed ."
+        if: "always() && steps.pkgs_dart_model_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/dart_model
+      - id: pkgs_macro_pub_upgrade
+        name: pkgs/macro; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/macro
+      - name: "pkgs/macro; dart format --output=none --set-exit-if-changed ."
+        run: "dart format --output=none --set-exit-if-changed ."
+        if: "always() && steps.pkgs_macro_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/macro
+      - id: pkgs_macro_service_pub_upgrade
+        name: pkgs/macro_service; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/macro_service
+      - name: "pkgs/macro_service; dart format --output=none --set-exit-if-changed ."
+        run: "dart format --output=none --set-exit-if-changed ."
+        if: "always() && steps.pkgs_macro_service_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/macro_service
+      - id: tool_dart_model_generator_pub_upgrade
+        name: tool/dart_model_generator; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: tool/dart_model_generator
+      - name: "tool/dart_model_generator; dart format --output=none --set-exit-if-changed ."
+        run: "dart format --output=none --set-exit-if-changed ."
+        if: "always() && steps.tool_dart_model_generator_pub_upgrade.conclusion == 'success'"
+        working-directory: tool/dart_model_generator
+  job_004:
     name: "analyze_and_format; linux; Dart dev; PKGS: pkgs/_analyzer_macros, pkgs/_macro_builder, pkgs/_macro_client, pkgs/_macro_host, pkgs/_macro_runner, pkgs/_macro_server, pkgs/_macro_tool, pkgs/_test_macros, pkgs/dart_model, pkgs/macro, pkgs/macro_service, tool/dart_model_generator; `dart analyze --fatal-infos .`"
     runs-on: ubuntu-latest
     steps:
@@ -304,144 +460,6 @@ jobs:
         run: dart analyze --fatal-infos .
         if: "always() && steps.tool_dart_model_generator_pub_upgrade.conclusion == 'success'"
         working-directory: tool/dart_model_generator
-  job_004:
-    name: "analyze_and_format; linux; Dart dev; PKGS: pkgs/_analyzer_macros, pkgs/_cfe_macros, pkgs/_macro_builder, pkgs/_macro_client, pkgs/_macro_host, pkgs/_macro_runner, pkgs/_macro_server, pkgs/_macro_tool, pkgs/_test_macros, pkgs/dart_model, pkgs/macro, pkgs/macro_service, tool/dart_model_generator; `dart format --output=none --set-exit-if-changed .`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/_analyzer_macros-pkgs/_cfe_macros-pkgs/_macro_builder-pkgs/_macro_client-pkgs/_macro_host-pkgs/_macro_runner-pkgs/_macro_server-pkgs/_macro_tool-pkgs/_test_macros-pkgs/dart_model-pkgs/macro-pkgs/macro_service-tool/dart_model_generator;commands:format"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/_analyzer_macros-pkgs/_cfe_macros-pkgs/_macro_builder-pkgs/_macro_client-pkgs/_macro_host-pkgs/_macro_runner-pkgs/_macro_server-pkgs/_macro_tool-pkgs/_test_macros-pkgs/dart_model-pkgs/macro-pkgs/macro_service-tool/dart_model_generator
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
-        with:
-          sdk: dev
-      - id: checkout
-        name: Checkout repository
-        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
-      - id: pkgs__analyzer_macros_pub_upgrade
-        name: pkgs/_analyzer_macros; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/_analyzer_macros
-      - name: "pkgs/_analyzer_macros; dart format --output=none --set-exit-if-changed ."
-        run: "dart format --output=none --set-exit-if-changed ."
-        if: "always() && steps.pkgs__analyzer_macros_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/_analyzer_macros
-      - id: pkgs__cfe_macros_pub_upgrade
-        name: pkgs/_cfe_macros; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/_cfe_macros
-      - name: "pkgs/_cfe_macros; dart format --output=none --set-exit-if-changed ."
-        run: "dart format --output=none --set-exit-if-changed ."
-        if: "always() && steps.pkgs__cfe_macros_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/_cfe_macros
-      - id: pkgs__macro_builder_pub_upgrade
-        name: pkgs/_macro_builder; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/_macro_builder
-      - name: "pkgs/_macro_builder; dart format --output=none --set-exit-if-changed ."
-        run: "dart format --output=none --set-exit-if-changed ."
-        if: "always() && steps.pkgs__macro_builder_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/_macro_builder
-      - id: pkgs__macro_client_pub_upgrade
-        name: pkgs/_macro_client; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/_macro_client
-      - name: "pkgs/_macro_client; dart format --output=none --set-exit-if-changed ."
-        run: "dart format --output=none --set-exit-if-changed ."
-        if: "always() && steps.pkgs__macro_client_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/_macro_client
-      - id: pkgs__macro_host_pub_upgrade
-        name: pkgs/_macro_host; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/_macro_host
-      - name: "pkgs/_macro_host; dart format --output=none --set-exit-if-changed ."
-        run: "dart format --output=none --set-exit-if-changed ."
-        if: "always() && steps.pkgs__macro_host_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/_macro_host
-      - id: pkgs__macro_runner_pub_upgrade
-        name: pkgs/_macro_runner; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/_macro_runner
-      - name: "pkgs/_macro_runner; dart format --output=none --set-exit-if-changed ."
-        run: "dart format --output=none --set-exit-if-changed ."
-        if: "always() && steps.pkgs__macro_runner_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/_macro_runner
-      - id: pkgs__macro_server_pub_upgrade
-        name: pkgs/_macro_server; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/_macro_server
-      - name: "pkgs/_macro_server; dart format --output=none --set-exit-if-changed ."
-        run: "dart format --output=none --set-exit-if-changed ."
-        if: "always() && steps.pkgs__macro_server_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/_macro_server
-      - id: pkgs__macro_tool_pub_upgrade
-        name: pkgs/_macro_tool; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/_macro_tool
-      - name: "pkgs/_macro_tool; dart format --output=none --set-exit-if-changed ."
-        run: "dart format --output=none --set-exit-if-changed ."
-        if: "always() && steps.pkgs__macro_tool_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/_macro_tool
-      - id: pkgs__test_macros_pub_upgrade
-        name: pkgs/_test_macros; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/_test_macros
-      - name: "pkgs/_test_macros; dart format --output=none --set-exit-if-changed ."
-        run: "dart format --output=none --set-exit-if-changed ."
-        if: "always() && steps.pkgs__test_macros_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/_test_macros
-      - id: pkgs_dart_model_pub_upgrade
-        name: pkgs/dart_model; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/dart_model
-      - name: "pkgs/dart_model; dart format --output=none --set-exit-if-changed ."
-        run: "dart format --output=none --set-exit-if-changed ."
-        if: "always() && steps.pkgs_dart_model_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/dart_model
-      - id: pkgs_macro_pub_upgrade
-        name: pkgs/macro; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/macro
-      - name: "pkgs/macro; dart format --output=none --set-exit-if-changed ."
-        run: "dart format --output=none --set-exit-if-changed ."
-        if: "always() && steps.pkgs_macro_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/macro
-      - id: pkgs_macro_service_pub_upgrade
-        name: pkgs/macro_service; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/macro_service
-      - name: "pkgs/macro_service; dart format --output=none --set-exit-if-changed ."
-        run: "dart format --output=none --set-exit-if-changed ."
-        if: "always() && steps.pkgs_macro_service_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/macro_service
-      - id: tool_dart_model_generator_pub_upgrade
-        name: tool/dart_model_generator; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: tool/dart_model_generator
-      - name: "tool/dart_model_generator; dart format --output=none --set-exit-if-changed ."
-        run: "dart format --output=none --set-exit-if-changed ."
-        if: "always() && steps.tool_dart_model_generator_pub_upgrade.conclusion == 'success'"
-        working-directory: tool/dart_model_generator
   job_005:
     name: "unit_test; linux; Dart 3.7.0-39.0.dev; PKG: goldens/foo; `../../tool/run_e2e_tests.sh`"
     runs-on: ubuntu-latest
@@ -478,6 +496,41 @@ jobs:
       - job_003
       - job_004
   job_006:
+    name: "unit_test; linux; Dart 3.7.0-39.0.dev; PKG: pkgs/_analyzer_cfe_macros; `dart test --test-randomize-ordering-seed=random`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-39.0.dev;packages:pkgs/_analyzer_cfe_macros;commands:test"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-39.0.dev;packages:pkgs/_analyzer_cfe_macros
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-39.0.dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
+        with:
+          sdk: "3.7.0-39.0.dev"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
+      - id: pkgs__analyzer_cfe_macros_pub_upgrade
+        name: pkgs/_analyzer_cfe_macros; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/_analyzer_cfe_macros
+      - name: "pkgs/_analyzer_cfe_macros; dart test --test-randomize-ordering-seed=random"
+        run: "dart test --test-randomize-ordering-seed=random"
+        if: "always() && steps.pkgs__analyzer_cfe_macros_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/_analyzer_cfe_macros
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+  job_007:
     name: "unit_test; linux; Dart 3.7.0-39.0.dev; PKG: pkgs/_analyzer_macros; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -512,7 +565,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_007:
+  job_008:
     name: "unit_test; linux; Dart 3.7.0-39.0.dev; PKG: pkgs/_cfe_macros; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -547,7 +600,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_008:
+  job_009:
     name: "unit_test; linux; Dart 3.7.0-39.0.dev; PKG: pkgs/_macro_builder; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -582,7 +635,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_009:
+  job_010:
     name: "unit_test; linux; Dart 3.7.0-39.0.dev; PKG: pkgs/_macro_client; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -617,7 +670,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_010:
+  job_011:
     name: "unit_test; linux; Dart 3.7.0-39.0.dev; PKG: pkgs/_macro_host; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -652,7 +705,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_011:
+  job_012:
     name: "unit_test; linux; Dart 3.7.0-39.0.dev; PKG: pkgs/_macro_runner; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -687,7 +740,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_012:
+  job_013:
     name: "unit_test; linux; Dart 3.7.0-39.0.dev; PKG: pkgs/_macro_server; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -722,7 +775,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_013:
+  job_014:
     name: "unit_test; linux; Dart 3.7.0-39.0.dev; PKG: pkgs/macro_service; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -757,7 +810,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_014:
+  job_015:
     name: "unit_test; linux; Dart 3.7.0-39.0.dev; PKG: tool/dart_model_generator; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -792,7 +845,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_015:
+  job_016:
     name: "unit_test; linux; Dart 3.7.0-39.0.dev; PKG: pkgs/dart_model; `dart -Ddebug_json_buffer=true test --test-randomize-ordering-seed=random -c source`"
     runs-on: ubuntu-latest
     steps:
@@ -827,7 +880,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_016:
+  job_017:
     name: "unit_test; linux; Dart dev; PKG: goldens/foo; `../../tool/run_e2e_tests.sh`"
     runs-on: ubuntu-latest
     steps:
@@ -862,7 +915,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_017:
+  job_018:
     name: "unit_test; linux; Dart dev; PKG: pkgs/_analyzer_macros; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -897,7 +950,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_018:
+  job_019:
     name: "unit_test; linux; Dart dev; PKG: pkgs/_macro_builder; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -932,7 +985,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_019:
+  job_020:
     name: "unit_test; linux; Dart dev; PKG: pkgs/_macro_client; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -967,7 +1020,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_020:
+  job_021:
     name: "unit_test; linux; Dart dev; PKG: pkgs/_macro_host; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -1002,7 +1055,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_021:
+  job_022:
     name: "unit_test; linux; Dart dev; PKG: pkgs/_macro_runner; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -1037,7 +1090,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_022:
+  job_023:
     name: "unit_test; linux; Dart dev; PKG: pkgs/_macro_server; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -1072,7 +1125,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_023:
+  job_024:
     name: "unit_test; linux; Dart dev; PKG: pkgs/macro_service; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -1107,7 +1160,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_024:
+  job_025:
     name: "unit_test; linux; Dart dev; PKG: tool/dart_model_generator; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -1142,7 +1195,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_025:
+  job_026:
     name: "unit_test; linux; Dart dev; PKG: pkgs/dart_model; `dart -Ddebug_json_buffer=true test --test-randomize-ordering-seed=random -c source`"
     runs-on: ubuntu-latest
     steps:
@@ -1177,7 +1230,32 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_026:
+  job_027:
+    name: "unit_test; windows; Dart 3.7.0-39.0.dev; PKG: pkgs/_analyzer_cfe_macros; `dart test --test-randomize-ordering-seed=random`"
+    runs-on: windows-latest
+    steps:
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
+        with:
+          sdk: "3.7.0-39.0.dev"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
+      - id: pkgs__analyzer_cfe_macros_pub_upgrade
+        name: pkgs/_analyzer_cfe_macros; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/_analyzer_cfe_macros
+      - name: "pkgs/_analyzer_cfe_macros; dart test --test-randomize-ordering-seed=random"
+        run: "dart test --test-randomize-ordering-seed=random"
+        if: "always() && steps.pkgs__analyzer_cfe_macros_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/_analyzer_cfe_macros
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+  job_028:
     name: "unit_test; windows; Dart 3.7.0-39.0.dev; PKG: pkgs/_analyzer_macros; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1202,7 +1280,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_027:
+  job_029:
     name: "unit_test; windows; Dart 3.7.0-39.0.dev; PKG: pkgs/_cfe_macros; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1227,7 +1305,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_028:
+  job_030:
     name: "unit_test; windows; Dart 3.7.0-39.0.dev; PKG: pkgs/_macro_builder; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1252,7 +1330,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_029:
+  job_031:
     name: "unit_test; windows; Dart 3.7.0-39.0.dev; PKG: pkgs/_macro_client; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1277,7 +1355,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_030:
+  job_032:
     name: "unit_test; windows; Dart 3.7.0-39.0.dev; PKG: pkgs/_macro_host; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1302,7 +1380,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_031:
+  job_033:
     name: "unit_test; windows; Dart 3.7.0-39.0.dev; PKG: pkgs/_macro_runner; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1327,7 +1405,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_032:
+  job_034:
     name: "unit_test; windows; Dart 3.7.0-39.0.dev; PKG: pkgs/_macro_server; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1352,7 +1430,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_033:
+  job_035:
     name: "unit_test; windows; Dart 3.7.0-39.0.dev; PKG: pkgs/macro_service; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1377,7 +1455,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_034:
+  job_036:
     name: "unit_test; windows; Dart 3.7.0-39.0.dev; PKG: tool/dart_model_generator; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1402,7 +1480,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_035:
+  job_037:
     name: "unit_test; windows; Dart 3.7.0-39.0.dev; PKG: pkgs/dart_model; `dart -Ddebug_json_buffer=true test --test-randomize-ordering-seed=random -c source`"
     runs-on: windows-latest
     steps:
@@ -1427,7 +1505,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_036:
+  job_038:
     name: "unit_test; windows; Dart dev; PKG: pkgs/_analyzer_macros; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1452,7 +1530,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_037:
+  job_039:
     name: "unit_test; windows; Dart dev; PKG: pkgs/_macro_builder; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1477,7 +1555,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_038:
+  job_040:
     name: "unit_test; windows; Dart dev; PKG: pkgs/_macro_client; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1502,7 +1580,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_039:
+  job_041:
     name: "unit_test; windows; Dart dev; PKG: pkgs/_macro_host; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1527,7 +1605,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_040:
+  job_042:
     name: "unit_test; windows; Dart dev; PKG: pkgs/_macro_runner; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1552,7 +1630,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_041:
+  job_043:
     name: "unit_test; windows; Dart dev; PKG: pkgs/_macro_server; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1577,7 +1655,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_042:
+  job_044:
     name: "unit_test; windows; Dart dev; PKG: pkgs/macro_service; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1602,7 +1680,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_043:
+  job_045:
     name: "unit_test; windows; Dart dev; PKG: tool/dart_model_generator; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1627,7 +1705,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_044:
+  job_046:
     name: "unit_test; windows; Dart dev; PKG: pkgs/dart_model; `dart -Ddebug_json_buffer=true test --test-randomize-ordering-seed=random -c source`"
     runs-on: windows-latest
     steps:

--- a/pkgs/_analyzer_cfe_macros/analysis_options.yaml
+++ b/pkgs/_analyzer_cfe_macros/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:dart_flutter_team_lints/analysis_options.yaml

--- a/pkgs/_analyzer_cfe_macros/lib/metadata_converter.dart
+++ b/pkgs/_analyzer_cfe_macros/lib/metadata_converter.dart
@@ -1,0 +1,413 @@
+// Copyright (c) 2024, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// ignore_for_file: implementation_imports, unused_local_variable
+import 'package:_fe_analyzer_shared/src/metadata/ast.dart' as front_end;
+import 'package:dart_model/src/macro_metadata.g.dart' as dart_model;
+
+// This code is generated and experimental, talk to davidmorgan@ before making
+// any manual changes.
+// TODO(davidmorgan): determine how this will be maintained.
+
+dart_model.Argument? convertToArgument(Object? object) => switch (object) {
+      front_end.PositionalArgument o => dart_model.Argument.positionalArgument(
+          convert<dart_model.PositionalArgument>(o)!),
+      front_end.NamedArgument o => dart_model.Argument.namedArgument(
+          convert<dart_model.NamedArgument>(o)!),
+      null => null,
+      _ => throw ArgumentError(object),
+    };
+dart_model.Element? convertToElement(Object? object) => switch (object) {
+      front_end.ExpressionElement o => dart_model.Element.expressionElement(
+          convert<dart_model.ExpressionElement>(o)!),
+      front_end.MapEntryElement o => dart_model.Element.mapEntryElement(
+          convert<dart_model.MapEntryElement>(o)!),
+      front_end.SpreadElement o =>
+        dart_model.Element.spreadElement(convert<dart_model.SpreadElement>(o)!),
+      front_end.IfElement o =>
+        dart_model.Element.ifElement(convert<dart_model.IfElement>(o)!),
+      null => null,
+      _ => throw ArgumentError(object),
+    };
+dart_model.Expression? convertToExpression(Object? object) => switch (object) {
+      front_end.InvalidExpression o => dart_model.Expression.invalidExpression(
+          convert<dart_model.InvalidExpression>(o)!),
+      front_end.StaticGet o =>
+        dart_model.Expression.staticGet(convert<dart_model.StaticGet>(o)!),
+      front_end.FunctionTearOff o => dart_model.Expression.functionTearOff(
+          convert<dart_model.FunctionTearOff>(o)!),
+      front_end.ConstructorTearOff o =>
+        dart_model.Expression.constructorTearOff(
+            convert<dart_model.ConstructorTearOff>(o)!),
+      front_end.ConstructorInvocation o =>
+        dart_model.Expression.constructorInvocation(
+            convert<dart_model.ConstructorInvocation>(o)!),
+      front_end.IntegerLiteral o => dart_model.Expression.integerLiteral(
+          convert<dart_model.IntegerLiteral>(o)!),
+      front_end.DoubleLiteral o => dart_model.Expression.doubleLiteral(
+          convert<dart_model.DoubleLiteral>(o)!),
+      front_end.BooleanLiteral o => dart_model.Expression.booleanLiteral(
+          convert<dart_model.BooleanLiteral>(o)!),
+      front_end.NullLiteral o =>
+        dart_model.Expression.nullLiteral(convert<dart_model.NullLiteral>(o)!),
+      front_end.SymbolLiteral o => dart_model.Expression.symbolLiteral(
+          convert<dart_model.SymbolLiteral>(o)!),
+      front_end.StringLiteral o => dart_model.Expression.stringLiteral(
+          convert<dart_model.StringLiteral>(o)!),
+      front_end.AdjacentStringLiterals o =>
+        dart_model.Expression.adjacentStringLiterals(
+            convert<dart_model.AdjacentStringLiterals>(o)!),
+      front_end.ImplicitInvocation o =>
+        dart_model.Expression.implicitInvocation(
+            convert<dart_model.ImplicitInvocation>(o)!),
+      front_end.StaticInvocation o => dart_model.Expression.staticInvocation(
+          convert<dart_model.StaticInvocation>(o)!),
+      front_end.Instantiation o => dart_model.Expression.instantiation(
+          convert<dart_model.Instantiation>(o)!),
+      front_end.MethodInvocation o => dart_model.Expression.methodInvocation(
+          convert<dart_model.MethodInvocation>(o)!),
+      front_end.PropertyGet o =>
+        dart_model.Expression.propertyGet(convert<dart_model.PropertyGet>(o)!),
+      front_end.NullAwarePropertyGet o =>
+        dart_model.Expression.nullAwarePropertyGet(
+            convert<dart_model.NullAwarePropertyGet>(o)!),
+      front_end.TypeLiteral o =>
+        dart_model.Expression.typeLiteral(convert<dart_model.TypeLiteral>(o)!),
+      front_end.ParenthesizedExpression o =>
+        dart_model.Expression.parenthesizedExpression(
+            convert<dart_model.ParenthesizedExpression>(o)!),
+      front_end.ConditionalExpression o =>
+        dart_model.Expression.conditionalExpression(
+            convert<dart_model.ConditionalExpression>(o)!),
+      front_end.ListLiteral o =>
+        dart_model.Expression.listLiteral(convert<dart_model.ListLiteral>(o)!),
+      front_end.SetOrMapLiteral o => dart_model.Expression.setOrMapLiteral(
+          convert<dart_model.SetOrMapLiteral>(o)!),
+      front_end.RecordLiteral o => dart_model.Expression.recordLiteral(
+          convert<dart_model.RecordLiteral>(o)!),
+      front_end.IfNull o =>
+        dart_model.Expression.ifNull(convert<dart_model.IfNull>(o)!),
+      front_end.LogicalExpression o => dart_model.Expression.logicalExpression(
+          convert<dart_model.LogicalExpression>(o)!),
+      front_end.EqualityExpression o =>
+        dart_model.Expression.equalityExpression(
+            convert<dart_model.EqualityExpression>(o)!),
+      front_end.BinaryExpression o => dart_model.Expression.binaryExpression(
+          convert<dart_model.BinaryExpression>(o)!),
+      front_end.UnaryExpression o => dart_model.Expression.unaryExpression(
+          convert<dart_model.UnaryExpression>(o)!),
+      front_end.IsTest o =>
+        dart_model.Expression.isTest(convert<dart_model.IsTest>(o)!),
+      front_end.AsExpression o => dart_model.Expression.asExpression(
+          convert<dart_model.AsExpression>(o)!),
+      front_end.NullCheck o =>
+        dart_model.Expression.nullCheck(convert<dart_model.NullCheck>(o)!),
+      front_end.UnresolvedExpression o =>
+        dart_model.Expression.unresolvedExpression(
+            convert<dart_model.UnresolvedExpression>(o)!),
+      null => null,
+      _ => throw ArgumentError(object),
+    };
+dart_model.RecordField? convertToRecordField(Object? object) =>
+    switch (object) {
+      front_end.RecordNamedField o => dart_model.RecordField.recordNamedField(
+          convert<dart_model.RecordNamedField>(o)!),
+      front_end.RecordPositionalField o =>
+        dart_model.RecordField.recordPositionalField(
+            convert<dart_model.RecordPositionalField>(o)!),
+      null => null,
+      _ => throw ArgumentError(object),
+    };
+dart_model.Reference? convertToReference(Object? object) => switch (object) {
+      front_end.FieldReference o => dart_model.Reference.fieldReference(
+          convert<dart_model.FieldReference>(o)!),
+      front_end.FunctionReference o => dart_model.Reference.functionReference(
+          convert<dart_model.FunctionReference>(o)!),
+      front_end.ConstructorReference o =>
+        dart_model.Reference.constructorReference(
+            convert<dart_model.ConstructorReference>(o)!),
+      front_end.TypeReference o => dart_model.Reference.typeReference(
+          convert<dart_model.TypeReference>(o)!),
+      front_end.ClassReference o => dart_model.Reference.classReference(
+          convert<dart_model.ClassReference>(o)!),
+      front_end.TypedefReference o => dart_model.Reference.typedefReference(
+          convert<dart_model.TypedefReference>(o)!),
+      front_end.ExtensionReference o => dart_model.Reference.extensionReference(
+          convert<dart_model.ExtensionReference>(o)!),
+      front_end.ExtensionTypeReference o =>
+        dart_model.Reference.extensionTypeReference(
+            convert<dart_model.ExtensionTypeReference>(o)!),
+      front_end.EnumReference o => dart_model.Reference.enumReference(
+          convert<dart_model.EnumReference>(o)!),
+      front_end.FunctionTypeParameterReference o =>
+        dart_model.Reference.functionTypeParameterReference(
+            convert<dart_model.FunctionTypeParameterReference>(o)!),
+      null => null,
+      _ => throw ArgumentError(object),
+    };
+dart_model.StringLiteralPart? convertToStringLiteralPart(Object? object) =>
+    switch (object) {
+      front_end.StringPart o => dart_model.StringLiteralPart.stringPart(
+          convert<dart_model.StringPart>(o)!),
+      front_end.InterpolationPart o =>
+        dart_model.StringLiteralPart.interpolationPart(
+            convert<dart_model.InterpolationPart>(o)!),
+      null => null,
+      _ => throw ArgumentError(object),
+    };
+dart_model.TypeAnnotation? convertToTypeAnnotation(Object? object) =>
+    switch (object) {
+      front_end.NamedTypeAnnotation o =>
+        dart_model.TypeAnnotation.namedTypeAnnotation(
+            convert<dart_model.NamedTypeAnnotation>(o)!),
+      front_end.NullableTypeAnnotation o =>
+        dart_model.TypeAnnotation.nullableTypeAnnotation(
+            convert<dart_model.NullableTypeAnnotation>(o)!),
+      front_end.VoidTypeAnnotation o =>
+        dart_model.TypeAnnotation.voidTypeAnnotation(
+            convert<dart_model.VoidTypeAnnotation>(o)!),
+      front_end.DynamicTypeAnnotation o =>
+        dart_model.TypeAnnotation.dynamicTypeAnnotation(
+            convert<dart_model.DynamicTypeAnnotation>(o)!),
+      front_end.InvalidTypeAnnotation o =>
+        dart_model.TypeAnnotation.invalidTypeAnnotation(
+            convert<dart_model.InvalidTypeAnnotation>(o)!),
+      front_end.UnresolvedTypeAnnotation o =>
+        dart_model.TypeAnnotation.unresolvedTypeAnnotation(
+            convert<dart_model.UnresolvedTypeAnnotation>(o)!),
+      front_end.FunctionTypeAnnotation o =>
+        dart_model.TypeAnnotation.functionTypeAnnotation(
+            convert<dart_model.FunctionTypeAnnotation>(o)!),
+      front_end.FunctionTypeParameterType o =>
+        dart_model.TypeAnnotation.functionTypeParameterType(
+            convert<dart_model.FunctionTypeParameterType>(o)!),
+      front_end.RecordTypeAnnotation o =>
+        dart_model.TypeAnnotation.recordTypeAnnotation(
+            convert<dart_model.RecordTypeAnnotation>(o)!),
+      null => null,
+      _ => throw ArgumentError(object),
+    };
+T? convert<T>(Object? object) => switch (object) {
+      front_end.BinaryOperator o => o.name as T,
+      front_end.LogicalOperator o => o.name as T,
+      front_end.UnaryOperator o => o.name as T,
+      front_end.AsExpression o => dart_model.AsExpression(
+          expression: convertToExpression(o.expression),
+          type: convert(o.type),
+        ) as T,
+      front_end.BinaryExpression o => dart_model.BinaryExpression(
+          left: convertToExpression(o.left),
+          operator: convert(o.operator),
+          right: convertToExpression(o.right),
+        ) as T,
+      front_end.BooleanLiteral o => dart_model.BooleanLiteral(
+          text: convert(o.text),
+        ) as T,
+      front_end.ClassReference o => dart_model.ClassReference() as T,
+      front_end.ConditionalExpression o => dart_model.ConditionalExpression(
+          condition: convertToExpression(o.condition),
+          then: convertToExpression(o.then),
+          otherwise: convertToExpression(o.otherwise),
+        ) as T,
+      front_end.ConstructorInvocation o => dart_model.ConstructorInvocation(
+          type: convert(o.type),
+          constructor: convertToReference(o.constructor),
+          arguments: convert(o.arguments),
+        ) as T,
+      front_end.ConstructorReference o =>
+        dart_model.ConstructorReference() as T,
+      front_end.ConstructorTearOff o => dart_model.ConstructorTearOff(
+          type: convert(o.type),
+          reference: convert(o.reference),
+        ) as T,
+      front_end.DoubleLiteral o => dart_model.DoubleLiteral(
+          text: convert(o.text),
+        ) as T,
+      front_end.DynamicTypeAnnotation o => dart_model.DynamicTypeAnnotation(
+          reference: convertToReference(o.reference),
+        ) as T,
+      front_end.EnumReference o => dart_model.EnumReference() as T,
+      front_end.EqualityExpression o => dart_model.EqualityExpression(
+          left: convertToExpression(o.left),
+          right: convertToExpression(o.right),
+          isNotEquals: convert(o.isNotEquals),
+        ) as T,
+      front_end.ExpressionElement o => dart_model.ExpressionElement(
+          expression: convertToExpression(o.expression),
+          isNullAware: convert(o.isNullAware),
+        ) as T,
+      front_end.ExtensionReference o => dart_model.ExtensionReference() as T,
+      front_end.ExtensionTypeReference o =>
+        dart_model.ExtensionTypeReference() as T,
+      front_end.FieldReference o => dart_model.FieldReference() as T,
+      front_end.FormalParameter o => dart_model.FormalParameter() as T,
+      front_end.FormalParameterGroup o =>
+        dart_model.FormalParameterGroup() as T,
+      front_end.FunctionReference o => dart_model.FunctionReference() as T,
+      front_end.FunctionTearOff o => dart_model.FunctionTearOff(
+          reference: convert(o.reference),
+        ) as T,
+      front_end.FunctionTypeAnnotation o => dart_model.FunctionTypeAnnotation(
+          returnType: convert(o.returnType),
+          typeParameters: convert(o.typeParameters),
+          formalParameters: convert(o.formalParameters),
+        ) as T,
+      front_end.FunctionTypeParameter o =>
+        dart_model.FunctionTypeParameter() as T,
+      front_end.FunctionTypeParameterReference o =>
+        dart_model.FunctionTypeParameterReference() as T,
+      front_end.FunctionTypeParameterType o =>
+        dart_model.FunctionTypeParameterType(
+          functionTypeParameter: convert(o.functionTypeParameter),
+        ) as T,
+      front_end.IfElement o => dart_model.IfElement(
+          condition: convertToExpression(o.condition),
+          then: convertToElement(o.then),
+          otherwise: convert(o.otherwise),
+        ) as T,
+      front_end.IfNull o => dart_model.IfNull(
+          left: convertToExpression(o.left),
+          right: convertToExpression(o.right),
+        ) as T,
+      front_end.ImplicitInvocation o => dart_model.ImplicitInvocation(
+          receiver: convertToExpression(o.receiver),
+          typeArguments: convert(o.typeArguments),
+          arguments: convert(o.arguments),
+        ) as T,
+      front_end.Instantiation o => dart_model.Instantiation(
+          receiver: convertToExpression(o.receiver),
+          typeArguments: convert(o.typeArguments),
+        ) as T,
+      front_end.IntegerLiteral o => dart_model.IntegerLiteral(
+          text: convert(o.text),
+        ) as T,
+      front_end.InterpolationPart o => dart_model.InterpolationPart(
+          expression: convertToExpression(o.expression),
+        ) as T,
+      front_end.InvalidExpression o => dart_model.InvalidExpression() as T,
+      front_end.InvalidTypeAnnotation o =>
+        dart_model.InvalidTypeAnnotation() as T,
+      front_end.IsTest o => dart_model.IsTest(
+          expression: convertToExpression(o.expression),
+          type: convert(o.type),
+          isNot: convert(o.isNot),
+        ) as T,
+      front_end.ListLiteral o => dart_model.ListLiteral(
+          typeArguments: convert(o.typeArguments),
+          elements: convert(o.elements),
+        ) as T,
+      front_end.LogicalExpression o => dart_model.LogicalExpression(
+          left: convertToExpression(o.left),
+          operator: convert(o.operator),
+          right: convertToExpression(o.right),
+        ) as T,
+      front_end.MapEntryElement o => dart_model.MapEntryElement(
+          key: convertToExpression(o.key),
+          value: convertToExpression(o.value),
+          isNullAwareKey: convert(o.isNullAwareKey),
+          isNullAwareValue: convert(o.isNullAwareValue),
+        ) as T,
+      front_end.MethodInvocation o => dart_model.MethodInvocation(
+          receiver: convertToExpression(o.receiver),
+          name: convert(o.name),
+          typeArguments: convert(o.typeArguments),
+          arguments: convert(o.arguments),
+        ) as T,
+      front_end.NamedArgument o => dart_model.NamedArgument(
+          name: convert(o.name),
+          expression: convertToExpression(o.expression),
+        ) as T,
+      front_end.NamedTypeAnnotation o => dart_model.NamedTypeAnnotation(
+          reference: convertToReference(o.reference),
+          typeArguments: convert(o.typeArguments),
+        ) as T,
+      front_end.NullableTypeAnnotation o => dart_model.NullableTypeAnnotation(
+          typeAnnotation: convert(o.typeAnnotation),
+        ) as T,
+      front_end.NullAwarePropertyGet o => dart_model.NullAwarePropertyGet(
+          receiver: convertToExpression(o.receiver),
+          name: convert(o.name),
+        ) as T,
+      front_end.NullCheck o => dart_model.NullCheck(
+          expression: convertToExpression(o.expression),
+        ) as T,
+      front_end.NullLiteral o => dart_model.NullLiteral() as T,
+      front_end.ParenthesizedExpression o => dart_model.ParenthesizedExpression(
+          expression: convertToExpression(o.expression),
+        ) as T,
+      front_end.PositionalArgument o => dart_model.PositionalArgument(
+          expression: convertToExpression(o.expression),
+        ) as T,
+      front_end.PropertyGet o => dart_model.PropertyGet(
+          receiver: convertToExpression(o.receiver),
+          name: convert(o.name),
+        ) as T,
+      front_end.RecordLiteral o => dart_model.RecordLiteral(
+          fields: convert(o.fields),
+        ) as T,
+      front_end.RecordNamedField o => dart_model.RecordNamedField(
+          name: convert(o.name),
+          expression: convertToExpression(o.expression),
+        ) as T,
+      front_end.RecordPositionalField o => dart_model.RecordPositionalField(
+          expression: convertToExpression(o.expression),
+        ) as T,
+      front_end.RecordTypeAnnotation o => dart_model.RecordTypeAnnotation(
+          positional: convert(o.positional),
+          named: convert(o.named),
+        ) as T,
+      front_end.RecordTypeEntry o => dart_model.RecordTypeEntry() as T,
+      front_end.References o => dart_model.References() as T,
+      front_end.SetOrMapLiteral o => dart_model.SetOrMapLiteral(
+          typeArguments: convert(o.typeArguments),
+          elements: convert(o.elements),
+        ) as T,
+      front_end.SpreadElement o => dart_model.SpreadElement(
+          expression: convertToExpression(o.expression),
+          isNullAware: convert(o.isNullAware),
+        ) as T,
+      front_end.StaticGet o => dart_model.StaticGet(
+          reference: convert(o.reference),
+        ) as T,
+      front_end.StaticInvocation o => dart_model.StaticInvocation(
+          function: convert(o.function),
+          typeArguments: convert(o.typeArguments),
+          arguments: convert(o.arguments),
+        ) as T,
+      front_end.AdjacentStringLiterals o => dart_model.AdjacentStringLiterals(
+          expressions: convert(o.expressions),
+        ) as T,
+      front_end.StringLiteral o => dart_model.StringLiteral(
+          parts: convert(o.parts),
+        ) as T,
+      front_end.StringPart o => dart_model.StringPart(
+          text: convert(o.text),
+        ) as T,
+      front_end.SymbolLiteral o => dart_model.SymbolLiteral(
+          parts: convert(o.parts),
+        ) as T,
+      front_end.TypedefReference o => dart_model.TypedefReference() as T,
+      front_end.TypeLiteral o => dart_model.TypeLiteral(
+          typeAnnotation: convert(o.typeAnnotation),
+        ) as T,
+      front_end.TypeReference o => dart_model.TypeReference() as T,
+      front_end.UnaryExpression o => dart_model.UnaryExpression(
+          operator: convert(o.operator),
+          expression: convertToExpression(o.expression),
+        ) as T,
+      front_end.UnresolvedExpression o =>
+        dart_model.UnresolvedExpression() as T,
+      front_end.UnresolvedTypeAnnotation o =>
+        dart_model.UnresolvedTypeAnnotation() as T,
+      front_end.VoidTypeAnnotation o => dart_model.VoidTypeAnnotation(
+          reference: convertToReference(o.reference),
+        ) as T,
+      String o => o as T,
+      int o => o as T,
+      bool o => o as T,
+      double o => o as T,
+      List o => o.map((i) => convert<Map<String, Object?>>(i)!).toList() as T,
+      null => null,
+      _ => throw ArgumentError(object),
+    };

--- a/pkgs/_analyzer_cfe_macros/mono_pkg.yaml
+++ b/pkgs/_analyzer_cfe_macros/mono_pkg.yaml
@@ -1,0 +1,16 @@
+sdk:
+# Only "pubspec" for when using SDK via a hash reference for latest
+# `_fe_analyzer_shared`.
+- pubspec
+
+stages:
+- analyze_and_format:
+  - analyze: --fatal-infos .
+  - format:
+    sdk:
+    - dev
+- unit_test:
+  - test: --test-randomize-ordering-seed=random
+    os:
+    - linux
+    - windows

--- a/pkgs/_analyzer_cfe_macros/pubspec.yaml
+++ b/pkgs/_analyzer_cfe_macros/pubspec.yaml
@@ -1,0 +1,15 @@
+name: _analyzer_cfe_macros
+publish-to: none
+description: Macro support for the analyzer and CFE.
+resolution: workspace
+
+environment:
+  sdk: ^3.7.0-39.0.dev
+
+dependencies:
+  _fe_analyzer_shared: any
+  dart_model: any
+
+dev_dependencies:
+  dart_flutter_team_lints: ^3.0.0
+  test: ^1.25.0

--- a/pkgs/_analyzer_cfe_macros/test/metadata_converter_test.dart
+++ b/pkgs/_analyzer_cfe_macros/test/metadata_converter_test.dart
@@ -1,0 +1,62 @@
+// Copyright (c) 2024, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:_analyzer_cfe_macros/metadata_converter.dart';
+import 'package:_fe_analyzer_shared/src/metadata/ast.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('converts with unions', () {
+    final invocation = MethodInvocation(DoubleLiteral('1.23'), 'round', [], []);
+
+    expect(convert<Object>(invocation), <String, Object?>{
+      'receiver': {
+        'type': 'DoubleLiteral',
+        'value': {'text': '1.23'}
+      },
+      'name': 'round',
+      'typeArguments': [],
+      'arguments': [],
+    });
+  });
+
+  test('converts with enums', () {
+    final expression = BinaryExpression(
+        DoubleLiteral('1.23'), BinaryOperator.minus, DoubleLiteral('1.24'));
+
+    expect(convert<Object>(expression), <String, Object?>{
+      'left': {
+        'type': 'DoubleLiteral',
+        'value': {'text': '1.23'}
+      },
+      'operator': 'minus',
+      'right': {
+        'type': 'DoubleLiteral',
+        'value': {'text': '1.24'}
+      }
+    });
+  });
+
+  test('converts with lists', () {
+    final invocation = MethodInvocation(DoubleLiteral('1.23'), 'round', [],
+        [PositionalArgument(IntegerLiteral('4'))]);
+
+    expect(convert<Object>(invocation), <String, Object?>{
+      'receiver': {
+        'type': 'DoubleLiteral',
+        'value': {'text': '1.23'}
+      },
+      'name': 'round',
+      'typeArguments': [],
+      'arguments': [
+        {
+          'expression': {
+            'type': 'IntegerLiteral',
+            'value': {'text': '4'}
+          }
+        }
+      ]
+    });
+  });
+}

--- a/pkgs/dart_model/lib/src/macro_metadata.g.dart
+++ b/pkgs/dart_model/lib/src/macro_metadata.g.dart
@@ -1,0 +1,2067 @@
+// This file is generated. To make changes edit tool/dart_model_generator
+// then run from the repo root: dart tool/dart_model_generator/bin/main.dart
+
+// ignore: implementation_imports,unused_import,prefer_relative_imports
+import 'package:dart_model/src/deep_cast_map.dart';
+// ignore: implementation_imports,unused_import,prefer_relative_imports
+import 'package:dart_model/src/json_buffer/json_buffer_builder.dart';
+// ignore: implementation_imports,unused_import,prefer_relative_imports
+import 'package:dart_model/src/scopes.dart';
+
+enum ArgumentType {
+  // Private so switches must have a default. See `isKnown`.
+  _unknown,
+  positionalArgument,
+  namedArgument;
+
+  bool get isKnown => this != _unknown;
+}
+
+extension type Argument.fromJson(Map<String, Object?> node) implements Object {
+  static Argument positionalArgument(PositionalArgument positionalArgument) =>
+      Argument.fromJson({
+        'type': 'PositionalArgument',
+        'value': positionalArgument,
+      });
+  static Argument namedArgument(NamedArgument namedArgument) =>
+      Argument.fromJson({
+        'type': 'NamedArgument',
+        'value': namedArgument,
+      });
+  ArgumentType get type {
+    switch (node['type'] as String) {
+      case 'PositionalArgument':
+        return ArgumentType.positionalArgument;
+      case 'NamedArgument':
+        return ArgumentType.namedArgument;
+      default:
+        return ArgumentType._unknown;
+    }
+  }
+
+  PositionalArgument get asPositionalArgument {
+    if (node['type'] != 'PositionalArgument') {
+      throw StateError('Not a PositionalArgument.');
+    }
+    return PositionalArgument.fromJson(node['value'] as Map<String, Object?>);
+  }
+
+  NamedArgument get asNamedArgument {
+    if (node['type'] != 'NamedArgument') {
+      throw StateError('Not a NamedArgument.');
+    }
+    return NamedArgument.fromJson(node['value'] as Map<String, Object?>);
+  }
+}
+
+enum ElementType {
+  // Private so switches must have a default. See `isKnown`.
+  _unknown,
+  expressionElement,
+  mapEntryElement,
+  spreadElement,
+  ifElement;
+
+  bool get isKnown => this != _unknown;
+}
+
+extension type Element.fromJson(Map<String, Object?> node) implements Object {
+  static Element expressionElement(ExpressionElement expressionElement) =>
+      Element.fromJson({
+        'type': 'ExpressionElement',
+        'value': expressionElement,
+      });
+  static Element mapEntryElement(MapEntryElement mapEntryElement) =>
+      Element.fromJson({
+        'type': 'MapEntryElement',
+        'value': mapEntryElement,
+      });
+  static Element spreadElement(SpreadElement spreadElement) =>
+      Element.fromJson({
+        'type': 'SpreadElement',
+        'value': spreadElement,
+      });
+  static Element ifElement(IfElement ifElement) => Element.fromJson({
+        'type': 'IfElement',
+        'value': ifElement,
+      });
+  ElementType get type {
+    switch (node['type'] as String) {
+      case 'ExpressionElement':
+        return ElementType.expressionElement;
+      case 'MapEntryElement':
+        return ElementType.mapEntryElement;
+      case 'SpreadElement':
+        return ElementType.spreadElement;
+      case 'IfElement':
+        return ElementType.ifElement;
+      default:
+        return ElementType._unknown;
+    }
+  }
+
+  ExpressionElement get asExpressionElement {
+    if (node['type'] != 'ExpressionElement') {
+      throw StateError('Not a ExpressionElement.');
+    }
+    return ExpressionElement.fromJson(node['value'] as Map<String, Object?>);
+  }
+
+  MapEntryElement get asMapEntryElement {
+    if (node['type'] != 'MapEntryElement') {
+      throw StateError('Not a MapEntryElement.');
+    }
+    return MapEntryElement.fromJson(node['value'] as Map<String, Object?>);
+  }
+
+  SpreadElement get asSpreadElement {
+    if (node['type'] != 'SpreadElement') {
+      throw StateError('Not a SpreadElement.');
+    }
+    return SpreadElement.fromJson(node['value'] as Map<String, Object?>);
+  }
+
+  IfElement get asIfElement {
+    if (node['type'] != 'IfElement') {
+      throw StateError('Not a IfElement.');
+    }
+    return IfElement.fromJson(node['value'] as Map<String, Object?>);
+  }
+}
+
+enum ExpressionType {
+  // Private so switches must have a default. See `isKnown`.
+  _unknown,
+  invalidExpression,
+  staticGet,
+  functionTearOff,
+  constructorTearOff,
+  constructorInvocation,
+  integerLiteral,
+  doubleLiteral,
+  booleanLiteral,
+  nullLiteral,
+  symbolLiteral,
+  stringLiteral,
+  adjacentStringLiterals,
+  implicitInvocation,
+  staticInvocation,
+  instantiation,
+  methodInvocation,
+  propertyGet,
+  nullAwarePropertyGet,
+  typeLiteral,
+  parenthesizedExpression,
+  conditionalExpression,
+  listLiteral,
+  setOrMapLiteral,
+  recordLiteral,
+  ifNull,
+  logicalExpression,
+  equalityExpression,
+  binaryExpression,
+  unaryExpression,
+  isTest,
+  asExpression,
+  nullCheck,
+  unresolvedExpression;
+
+  bool get isKnown => this != _unknown;
+}
+
+extension type Expression.fromJson(Map<String, Object?> node)
+    implements Object {
+  static Expression invalidExpression(InvalidExpression invalidExpression) =>
+      Expression.fromJson({
+        'type': 'InvalidExpression',
+        'value': invalidExpression,
+      });
+  static Expression staticGet(StaticGet staticGet) => Expression.fromJson({
+        'type': 'StaticGet',
+        'value': staticGet,
+      });
+  static Expression functionTearOff(FunctionTearOff functionTearOff) =>
+      Expression.fromJson({
+        'type': 'FunctionTearOff',
+        'value': functionTearOff,
+      });
+  static Expression constructorTearOff(ConstructorTearOff constructorTearOff) =>
+      Expression.fromJson({
+        'type': 'ConstructorTearOff',
+        'value': constructorTearOff,
+      });
+  static Expression constructorInvocation(
+          ConstructorInvocation constructorInvocation) =>
+      Expression.fromJson({
+        'type': 'ConstructorInvocation',
+        'value': constructorInvocation,
+      });
+  static Expression integerLiteral(IntegerLiteral integerLiteral) =>
+      Expression.fromJson({
+        'type': 'IntegerLiteral',
+        'value': integerLiteral,
+      });
+  static Expression doubleLiteral(DoubleLiteral doubleLiteral) =>
+      Expression.fromJson({
+        'type': 'DoubleLiteral',
+        'value': doubleLiteral,
+      });
+  static Expression booleanLiteral(BooleanLiteral booleanLiteral) =>
+      Expression.fromJson({
+        'type': 'BooleanLiteral',
+        'value': booleanLiteral,
+      });
+  static Expression nullLiteral(NullLiteral nullLiteral) =>
+      Expression.fromJson({
+        'type': 'NullLiteral',
+        'value': nullLiteral,
+      });
+  static Expression symbolLiteral(SymbolLiteral symbolLiteral) =>
+      Expression.fromJson({
+        'type': 'SymbolLiteral',
+        'value': symbolLiteral,
+      });
+  static Expression stringLiteral(StringLiteral stringLiteral) =>
+      Expression.fromJson({
+        'type': 'StringLiteral',
+        'value': stringLiteral,
+      });
+  static Expression adjacentStringLiterals(
+          AdjacentStringLiterals adjacentStringLiterals) =>
+      Expression.fromJson({
+        'type': 'AdjacentStringLiterals',
+        'value': adjacentStringLiterals,
+      });
+  static Expression implicitInvocation(ImplicitInvocation implicitInvocation) =>
+      Expression.fromJson({
+        'type': 'ImplicitInvocation',
+        'value': implicitInvocation,
+      });
+  static Expression staticInvocation(StaticInvocation staticInvocation) =>
+      Expression.fromJson({
+        'type': 'StaticInvocation',
+        'value': staticInvocation,
+      });
+  static Expression instantiation(Instantiation instantiation) =>
+      Expression.fromJson({
+        'type': 'Instantiation',
+        'value': instantiation,
+      });
+  static Expression methodInvocation(MethodInvocation methodInvocation) =>
+      Expression.fromJson({
+        'type': 'MethodInvocation',
+        'value': methodInvocation,
+      });
+  static Expression propertyGet(PropertyGet propertyGet) =>
+      Expression.fromJson({
+        'type': 'PropertyGet',
+        'value': propertyGet,
+      });
+  static Expression nullAwarePropertyGet(
+          NullAwarePropertyGet nullAwarePropertyGet) =>
+      Expression.fromJson({
+        'type': 'NullAwarePropertyGet',
+        'value': nullAwarePropertyGet,
+      });
+  static Expression typeLiteral(TypeLiteral typeLiteral) =>
+      Expression.fromJson({
+        'type': 'TypeLiteral',
+        'value': typeLiteral,
+      });
+  static Expression parenthesizedExpression(
+          ParenthesizedExpression parenthesizedExpression) =>
+      Expression.fromJson({
+        'type': 'ParenthesizedExpression',
+        'value': parenthesizedExpression,
+      });
+  static Expression conditionalExpression(
+          ConditionalExpression conditionalExpression) =>
+      Expression.fromJson({
+        'type': 'ConditionalExpression',
+        'value': conditionalExpression,
+      });
+  static Expression listLiteral(ListLiteral listLiteral) =>
+      Expression.fromJson({
+        'type': 'ListLiteral',
+        'value': listLiteral,
+      });
+  static Expression setOrMapLiteral(SetOrMapLiteral setOrMapLiteral) =>
+      Expression.fromJson({
+        'type': 'SetOrMapLiteral',
+        'value': setOrMapLiteral,
+      });
+  static Expression recordLiteral(RecordLiteral recordLiteral) =>
+      Expression.fromJson({
+        'type': 'RecordLiteral',
+        'value': recordLiteral,
+      });
+  static Expression ifNull(IfNull ifNull) => Expression.fromJson({
+        'type': 'IfNull',
+        'value': ifNull,
+      });
+  static Expression logicalExpression(LogicalExpression logicalExpression) =>
+      Expression.fromJson({
+        'type': 'LogicalExpression',
+        'value': logicalExpression,
+      });
+  static Expression equalityExpression(EqualityExpression equalityExpression) =>
+      Expression.fromJson({
+        'type': 'EqualityExpression',
+        'value': equalityExpression,
+      });
+  static Expression binaryExpression(BinaryExpression binaryExpression) =>
+      Expression.fromJson({
+        'type': 'BinaryExpression',
+        'value': binaryExpression,
+      });
+  static Expression unaryExpression(UnaryExpression unaryExpression) =>
+      Expression.fromJson({
+        'type': 'UnaryExpression',
+        'value': unaryExpression,
+      });
+  static Expression isTest(IsTest isTest) => Expression.fromJson({
+        'type': 'IsTest',
+        'value': isTest,
+      });
+  static Expression asExpression(AsExpression asExpression) =>
+      Expression.fromJson({
+        'type': 'AsExpression',
+        'value': asExpression,
+      });
+  static Expression nullCheck(NullCheck nullCheck) => Expression.fromJson({
+        'type': 'NullCheck',
+        'value': nullCheck,
+      });
+  static Expression unresolvedExpression(
+          UnresolvedExpression unresolvedExpression) =>
+      Expression.fromJson({
+        'type': 'UnresolvedExpression',
+        'value': unresolvedExpression,
+      });
+  ExpressionType get type {
+    switch (node['type'] as String) {
+      case 'InvalidExpression':
+        return ExpressionType.invalidExpression;
+      case 'StaticGet':
+        return ExpressionType.staticGet;
+      case 'FunctionTearOff':
+        return ExpressionType.functionTearOff;
+      case 'ConstructorTearOff':
+        return ExpressionType.constructorTearOff;
+      case 'ConstructorInvocation':
+        return ExpressionType.constructorInvocation;
+      case 'IntegerLiteral':
+        return ExpressionType.integerLiteral;
+      case 'DoubleLiteral':
+        return ExpressionType.doubleLiteral;
+      case 'BooleanLiteral':
+        return ExpressionType.booleanLiteral;
+      case 'NullLiteral':
+        return ExpressionType.nullLiteral;
+      case 'SymbolLiteral':
+        return ExpressionType.symbolLiteral;
+      case 'StringLiteral':
+        return ExpressionType.stringLiteral;
+      case 'AdjacentStringLiterals':
+        return ExpressionType.adjacentStringLiterals;
+      case 'ImplicitInvocation':
+        return ExpressionType.implicitInvocation;
+      case 'StaticInvocation':
+        return ExpressionType.staticInvocation;
+      case 'Instantiation':
+        return ExpressionType.instantiation;
+      case 'MethodInvocation':
+        return ExpressionType.methodInvocation;
+      case 'PropertyGet':
+        return ExpressionType.propertyGet;
+      case 'NullAwarePropertyGet':
+        return ExpressionType.nullAwarePropertyGet;
+      case 'TypeLiteral':
+        return ExpressionType.typeLiteral;
+      case 'ParenthesizedExpression':
+        return ExpressionType.parenthesizedExpression;
+      case 'ConditionalExpression':
+        return ExpressionType.conditionalExpression;
+      case 'ListLiteral':
+        return ExpressionType.listLiteral;
+      case 'SetOrMapLiteral':
+        return ExpressionType.setOrMapLiteral;
+      case 'RecordLiteral':
+        return ExpressionType.recordLiteral;
+      case 'IfNull':
+        return ExpressionType.ifNull;
+      case 'LogicalExpression':
+        return ExpressionType.logicalExpression;
+      case 'EqualityExpression':
+        return ExpressionType.equalityExpression;
+      case 'BinaryExpression':
+        return ExpressionType.binaryExpression;
+      case 'UnaryExpression':
+        return ExpressionType.unaryExpression;
+      case 'IsTest':
+        return ExpressionType.isTest;
+      case 'AsExpression':
+        return ExpressionType.asExpression;
+      case 'NullCheck':
+        return ExpressionType.nullCheck;
+      case 'UnresolvedExpression':
+        return ExpressionType.unresolvedExpression;
+      default:
+        return ExpressionType._unknown;
+    }
+  }
+
+  InvalidExpression get asInvalidExpression {
+    if (node['type'] != 'InvalidExpression') {
+      throw StateError('Not a InvalidExpression.');
+    }
+    return InvalidExpression.fromJson(node['value'] as Map<String, Object?>);
+  }
+
+  StaticGet get asStaticGet {
+    if (node['type'] != 'StaticGet') {
+      throw StateError('Not a StaticGet.');
+    }
+    return StaticGet.fromJson(node['value'] as Map<String, Object?>);
+  }
+
+  FunctionTearOff get asFunctionTearOff {
+    if (node['type'] != 'FunctionTearOff') {
+      throw StateError('Not a FunctionTearOff.');
+    }
+    return FunctionTearOff.fromJson(node['value'] as Map<String, Object?>);
+  }
+
+  ConstructorTearOff get asConstructorTearOff {
+    if (node['type'] != 'ConstructorTearOff') {
+      throw StateError('Not a ConstructorTearOff.');
+    }
+    return ConstructorTearOff.fromJson(node['value'] as Map<String, Object?>);
+  }
+
+  ConstructorInvocation get asConstructorInvocation {
+    if (node['type'] != 'ConstructorInvocation') {
+      throw StateError('Not a ConstructorInvocation.');
+    }
+    return ConstructorInvocation.fromJson(
+        node['value'] as Map<String, Object?>);
+  }
+
+  IntegerLiteral get asIntegerLiteral {
+    if (node['type'] != 'IntegerLiteral') {
+      throw StateError('Not a IntegerLiteral.');
+    }
+    return IntegerLiteral.fromJson(node['value'] as Map<String, Object?>);
+  }
+
+  DoubleLiteral get asDoubleLiteral {
+    if (node['type'] != 'DoubleLiteral') {
+      throw StateError('Not a DoubleLiteral.');
+    }
+    return DoubleLiteral.fromJson(node['value'] as Map<String, Object?>);
+  }
+
+  BooleanLiteral get asBooleanLiteral {
+    if (node['type'] != 'BooleanLiteral') {
+      throw StateError('Not a BooleanLiteral.');
+    }
+    return BooleanLiteral.fromJson(node['value'] as Map<String, Object?>);
+  }
+
+  NullLiteral get asNullLiteral {
+    if (node['type'] != 'NullLiteral') {
+      throw StateError('Not a NullLiteral.');
+    }
+    return NullLiteral.fromJson(node['value'] as Map<String, Object?>);
+  }
+
+  SymbolLiteral get asSymbolLiteral {
+    if (node['type'] != 'SymbolLiteral') {
+      throw StateError('Not a SymbolLiteral.');
+    }
+    return SymbolLiteral.fromJson(node['value'] as Map<String, Object?>);
+  }
+
+  StringLiteral get asStringLiteral {
+    if (node['type'] != 'StringLiteral') {
+      throw StateError('Not a StringLiteral.');
+    }
+    return StringLiteral.fromJson(node['value'] as Map<String, Object?>);
+  }
+
+  AdjacentStringLiterals get asAdjacentStringLiterals {
+    if (node['type'] != 'AdjacentStringLiterals') {
+      throw StateError('Not a AdjacentStringLiterals.');
+    }
+    return AdjacentStringLiterals.fromJson(
+        node['value'] as Map<String, Object?>);
+  }
+
+  ImplicitInvocation get asImplicitInvocation {
+    if (node['type'] != 'ImplicitInvocation') {
+      throw StateError('Not a ImplicitInvocation.');
+    }
+    return ImplicitInvocation.fromJson(node['value'] as Map<String, Object?>);
+  }
+
+  StaticInvocation get asStaticInvocation {
+    if (node['type'] != 'StaticInvocation') {
+      throw StateError('Not a StaticInvocation.');
+    }
+    return StaticInvocation.fromJson(node['value'] as Map<String, Object?>);
+  }
+
+  Instantiation get asInstantiation {
+    if (node['type'] != 'Instantiation') {
+      throw StateError('Not a Instantiation.');
+    }
+    return Instantiation.fromJson(node['value'] as Map<String, Object?>);
+  }
+
+  MethodInvocation get asMethodInvocation {
+    if (node['type'] != 'MethodInvocation') {
+      throw StateError('Not a MethodInvocation.');
+    }
+    return MethodInvocation.fromJson(node['value'] as Map<String, Object?>);
+  }
+
+  PropertyGet get asPropertyGet {
+    if (node['type'] != 'PropertyGet') {
+      throw StateError('Not a PropertyGet.');
+    }
+    return PropertyGet.fromJson(node['value'] as Map<String, Object?>);
+  }
+
+  NullAwarePropertyGet get asNullAwarePropertyGet {
+    if (node['type'] != 'NullAwarePropertyGet') {
+      throw StateError('Not a NullAwarePropertyGet.');
+    }
+    return NullAwarePropertyGet.fromJson(node['value'] as Map<String, Object?>);
+  }
+
+  TypeLiteral get asTypeLiteral {
+    if (node['type'] != 'TypeLiteral') {
+      throw StateError('Not a TypeLiteral.');
+    }
+    return TypeLiteral.fromJson(node['value'] as Map<String, Object?>);
+  }
+
+  ParenthesizedExpression get asParenthesizedExpression {
+    if (node['type'] != 'ParenthesizedExpression') {
+      throw StateError('Not a ParenthesizedExpression.');
+    }
+    return ParenthesizedExpression.fromJson(
+        node['value'] as Map<String, Object?>);
+  }
+
+  ConditionalExpression get asConditionalExpression {
+    if (node['type'] != 'ConditionalExpression') {
+      throw StateError('Not a ConditionalExpression.');
+    }
+    return ConditionalExpression.fromJson(
+        node['value'] as Map<String, Object?>);
+  }
+
+  ListLiteral get asListLiteral {
+    if (node['type'] != 'ListLiteral') {
+      throw StateError('Not a ListLiteral.');
+    }
+    return ListLiteral.fromJson(node['value'] as Map<String, Object?>);
+  }
+
+  SetOrMapLiteral get asSetOrMapLiteral {
+    if (node['type'] != 'SetOrMapLiteral') {
+      throw StateError('Not a SetOrMapLiteral.');
+    }
+    return SetOrMapLiteral.fromJson(node['value'] as Map<String, Object?>);
+  }
+
+  RecordLiteral get asRecordLiteral {
+    if (node['type'] != 'RecordLiteral') {
+      throw StateError('Not a RecordLiteral.');
+    }
+    return RecordLiteral.fromJson(node['value'] as Map<String, Object?>);
+  }
+
+  IfNull get asIfNull {
+    if (node['type'] != 'IfNull') {
+      throw StateError('Not a IfNull.');
+    }
+    return IfNull.fromJson(node['value'] as Map<String, Object?>);
+  }
+
+  LogicalExpression get asLogicalExpression {
+    if (node['type'] != 'LogicalExpression') {
+      throw StateError('Not a LogicalExpression.');
+    }
+    return LogicalExpression.fromJson(node['value'] as Map<String, Object?>);
+  }
+
+  EqualityExpression get asEqualityExpression {
+    if (node['type'] != 'EqualityExpression') {
+      throw StateError('Not a EqualityExpression.');
+    }
+    return EqualityExpression.fromJson(node['value'] as Map<String, Object?>);
+  }
+
+  BinaryExpression get asBinaryExpression {
+    if (node['type'] != 'BinaryExpression') {
+      throw StateError('Not a BinaryExpression.');
+    }
+    return BinaryExpression.fromJson(node['value'] as Map<String, Object?>);
+  }
+
+  UnaryExpression get asUnaryExpression {
+    if (node['type'] != 'UnaryExpression') {
+      throw StateError('Not a UnaryExpression.');
+    }
+    return UnaryExpression.fromJson(node['value'] as Map<String, Object?>);
+  }
+
+  IsTest get asIsTest {
+    if (node['type'] != 'IsTest') {
+      throw StateError('Not a IsTest.');
+    }
+    return IsTest.fromJson(node['value'] as Map<String, Object?>);
+  }
+
+  AsExpression get asAsExpression {
+    if (node['type'] != 'AsExpression') {
+      throw StateError('Not a AsExpression.');
+    }
+    return AsExpression.fromJson(node['value'] as Map<String, Object?>);
+  }
+
+  NullCheck get asNullCheck {
+    if (node['type'] != 'NullCheck') {
+      throw StateError('Not a NullCheck.');
+    }
+    return NullCheck.fromJson(node['value'] as Map<String, Object?>);
+  }
+
+  UnresolvedExpression get asUnresolvedExpression {
+    if (node['type'] != 'UnresolvedExpression') {
+      throw StateError('Not a UnresolvedExpression.');
+    }
+    return UnresolvedExpression.fromJson(node['value'] as Map<String, Object?>);
+  }
+}
+
+enum RecordFieldType {
+  // Private so switches must have a default. See `isKnown`.
+  _unknown,
+  recordNamedField,
+  recordPositionalField;
+
+  bool get isKnown => this != _unknown;
+}
+
+extension type RecordField.fromJson(Map<String, Object?> node)
+    implements Object {
+  static RecordField recordNamedField(RecordNamedField recordNamedField) =>
+      RecordField.fromJson({
+        'type': 'RecordNamedField',
+        'value': recordNamedField,
+      });
+  static RecordField recordPositionalField(
+          RecordPositionalField recordPositionalField) =>
+      RecordField.fromJson({
+        'type': 'RecordPositionalField',
+        'value': recordPositionalField,
+      });
+  RecordFieldType get type {
+    switch (node['type'] as String) {
+      case 'RecordNamedField':
+        return RecordFieldType.recordNamedField;
+      case 'RecordPositionalField':
+        return RecordFieldType.recordPositionalField;
+      default:
+        return RecordFieldType._unknown;
+    }
+  }
+
+  RecordNamedField get asRecordNamedField {
+    if (node['type'] != 'RecordNamedField') {
+      throw StateError('Not a RecordNamedField.');
+    }
+    return RecordNamedField.fromJson(node['value'] as Map<String, Object?>);
+  }
+
+  RecordPositionalField get asRecordPositionalField {
+    if (node['type'] != 'RecordPositionalField') {
+      throw StateError('Not a RecordPositionalField.');
+    }
+    return RecordPositionalField.fromJson(
+        node['value'] as Map<String, Object?>);
+  }
+}
+
+enum ReferenceType {
+  // Private so switches must have a default. See `isKnown`.
+  _unknown,
+  fieldReference,
+  functionReference,
+  constructorReference,
+  typeReference,
+  classReference,
+  typedefReference,
+  extensionReference,
+  extensionTypeReference,
+  enumReference,
+  functionTypeParameterReference;
+
+  bool get isKnown => this != _unknown;
+}
+
+extension type Reference.fromJson(Map<String, Object?> node) implements Object {
+  static Reference fieldReference(FieldReference fieldReference) =>
+      Reference.fromJson({
+        'type': 'FieldReference',
+        'value': fieldReference,
+      });
+  static Reference functionReference(FunctionReference functionReference) =>
+      Reference.fromJson({
+        'type': 'FunctionReference',
+        'value': functionReference,
+      });
+  static Reference constructorReference(
+          ConstructorReference constructorReference) =>
+      Reference.fromJson({
+        'type': 'ConstructorReference',
+        'value': constructorReference,
+      });
+  static Reference typeReference(TypeReference typeReference) =>
+      Reference.fromJson({
+        'type': 'TypeReference',
+        'value': typeReference,
+      });
+  static Reference classReference(ClassReference classReference) =>
+      Reference.fromJson({
+        'type': 'ClassReference',
+        'value': classReference,
+      });
+  static Reference typedefReference(TypedefReference typedefReference) =>
+      Reference.fromJson({
+        'type': 'TypedefReference',
+        'value': typedefReference,
+      });
+  static Reference extensionReference(ExtensionReference extensionReference) =>
+      Reference.fromJson({
+        'type': 'ExtensionReference',
+        'value': extensionReference,
+      });
+  static Reference extensionTypeReference(
+          ExtensionTypeReference extensionTypeReference) =>
+      Reference.fromJson({
+        'type': 'ExtensionTypeReference',
+        'value': extensionTypeReference,
+      });
+  static Reference enumReference(EnumReference enumReference) =>
+      Reference.fromJson({
+        'type': 'EnumReference',
+        'value': enumReference,
+      });
+  static Reference functionTypeParameterReference(
+          FunctionTypeParameterReference functionTypeParameterReference) =>
+      Reference.fromJson({
+        'type': 'FunctionTypeParameterReference',
+        'value': functionTypeParameterReference,
+      });
+  ReferenceType get type {
+    switch (node['type'] as String) {
+      case 'FieldReference':
+        return ReferenceType.fieldReference;
+      case 'FunctionReference':
+        return ReferenceType.functionReference;
+      case 'ConstructorReference':
+        return ReferenceType.constructorReference;
+      case 'TypeReference':
+        return ReferenceType.typeReference;
+      case 'ClassReference':
+        return ReferenceType.classReference;
+      case 'TypedefReference':
+        return ReferenceType.typedefReference;
+      case 'ExtensionReference':
+        return ReferenceType.extensionReference;
+      case 'ExtensionTypeReference':
+        return ReferenceType.extensionTypeReference;
+      case 'EnumReference':
+        return ReferenceType.enumReference;
+      case 'FunctionTypeParameterReference':
+        return ReferenceType.functionTypeParameterReference;
+      default:
+        return ReferenceType._unknown;
+    }
+  }
+
+  FieldReference get asFieldReference {
+    if (node['type'] != 'FieldReference') {
+      throw StateError('Not a FieldReference.');
+    }
+    return FieldReference.fromJson(node['value'] as Map<String, Object?>);
+  }
+
+  FunctionReference get asFunctionReference {
+    if (node['type'] != 'FunctionReference') {
+      throw StateError('Not a FunctionReference.');
+    }
+    return FunctionReference.fromJson(node['value'] as Map<String, Object?>);
+  }
+
+  ConstructorReference get asConstructorReference {
+    if (node['type'] != 'ConstructorReference') {
+      throw StateError('Not a ConstructorReference.');
+    }
+    return ConstructorReference.fromJson(node['value'] as Map<String, Object?>);
+  }
+
+  TypeReference get asTypeReference {
+    if (node['type'] != 'TypeReference') {
+      throw StateError('Not a TypeReference.');
+    }
+    return TypeReference.fromJson(node['value'] as Map<String, Object?>);
+  }
+
+  ClassReference get asClassReference {
+    if (node['type'] != 'ClassReference') {
+      throw StateError('Not a ClassReference.');
+    }
+    return ClassReference.fromJson(node['value'] as Map<String, Object?>);
+  }
+
+  TypedefReference get asTypedefReference {
+    if (node['type'] != 'TypedefReference') {
+      throw StateError('Not a TypedefReference.');
+    }
+    return TypedefReference.fromJson(node['value'] as Map<String, Object?>);
+  }
+
+  ExtensionReference get asExtensionReference {
+    if (node['type'] != 'ExtensionReference') {
+      throw StateError('Not a ExtensionReference.');
+    }
+    return ExtensionReference.fromJson(node['value'] as Map<String, Object?>);
+  }
+
+  ExtensionTypeReference get asExtensionTypeReference {
+    if (node['type'] != 'ExtensionTypeReference') {
+      throw StateError('Not a ExtensionTypeReference.');
+    }
+    return ExtensionTypeReference.fromJson(
+        node['value'] as Map<String, Object?>);
+  }
+
+  EnumReference get asEnumReference {
+    if (node['type'] != 'EnumReference') {
+      throw StateError('Not a EnumReference.');
+    }
+    return EnumReference.fromJson(node['value'] as Map<String, Object?>);
+  }
+
+  FunctionTypeParameterReference get asFunctionTypeParameterReference {
+    if (node['type'] != 'FunctionTypeParameterReference') {
+      throw StateError('Not a FunctionTypeParameterReference.');
+    }
+    return FunctionTypeParameterReference.fromJson(
+        node['value'] as Map<String, Object?>);
+  }
+}
+
+enum StringLiteralPartType {
+  // Private so switches must have a default. See `isKnown`.
+  _unknown,
+  stringPart,
+  interpolationPart;
+
+  bool get isKnown => this != _unknown;
+}
+
+extension type StringLiteralPart.fromJson(Map<String, Object?> node)
+    implements Object {
+  static StringLiteralPart stringPart(StringPart stringPart) =>
+      StringLiteralPart.fromJson({
+        'type': 'StringPart',
+        'value': stringPart,
+      });
+  static StringLiteralPart interpolationPart(
+          InterpolationPart interpolationPart) =>
+      StringLiteralPart.fromJson({
+        'type': 'InterpolationPart',
+        'value': interpolationPart,
+      });
+  StringLiteralPartType get type {
+    switch (node['type'] as String) {
+      case 'StringPart':
+        return StringLiteralPartType.stringPart;
+      case 'InterpolationPart':
+        return StringLiteralPartType.interpolationPart;
+      default:
+        return StringLiteralPartType._unknown;
+    }
+  }
+
+  StringPart get asStringPart {
+    if (node['type'] != 'StringPart') {
+      throw StateError('Not a StringPart.');
+    }
+    return StringPart.fromJson(node['value'] as Map<String, Object?>);
+  }
+
+  InterpolationPart get asInterpolationPart {
+    if (node['type'] != 'InterpolationPart') {
+      throw StateError('Not a InterpolationPart.');
+    }
+    return InterpolationPart.fromJson(node['value'] as Map<String, Object?>);
+  }
+}
+
+enum TypeAnnotationType {
+  // Private so switches must have a default. See `isKnown`.
+  _unknown,
+  namedTypeAnnotation,
+  nullableTypeAnnotation,
+  voidTypeAnnotation,
+  dynamicTypeAnnotation,
+  invalidTypeAnnotation,
+  unresolvedTypeAnnotation,
+  functionTypeAnnotation,
+  functionTypeParameterType,
+  recordTypeAnnotation;
+
+  bool get isKnown => this != _unknown;
+}
+
+extension type TypeAnnotation.fromJson(Map<String, Object?> node)
+    implements Object {
+  static TypeAnnotation namedTypeAnnotation(
+          NamedTypeAnnotation namedTypeAnnotation) =>
+      TypeAnnotation.fromJson({
+        'type': 'NamedTypeAnnotation',
+        'value': namedTypeAnnotation,
+      });
+  static TypeAnnotation nullableTypeAnnotation(
+          NullableTypeAnnotation nullableTypeAnnotation) =>
+      TypeAnnotation.fromJson({
+        'type': 'NullableTypeAnnotation',
+        'value': nullableTypeAnnotation,
+      });
+  static TypeAnnotation voidTypeAnnotation(
+          VoidTypeAnnotation voidTypeAnnotation) =>
+      TypeAnnotation.fromJson({
+        'type': 'VoidTypeAnnotation',
+        'value': voidTypeAnnotation,
+      });
+  static TypeAnnotation dynamicTypeAnnotation(
+          DynamicTypeAnnotation dynamicTypeAnnotation) =>
+      TypeAnnotation.fromJson({
+        'type': 'DynamicTypeAnnotation',
+        'value': dynamicTypeAnnotation,
+      });
+  static TypeAnnotation invalidTypeAnnotation(
+          InvalidTypeAnnotation invalidTypeAnnotation) =>
+      TypeAnnotation.fromJson({
+        'type': 'InvalidTypeAnnotation',
+        'value': invalidTypeAnnotation,
+      });
+  static TypeAnnotation unresolvedTypeAnnotation(
+          UnresolvedTypeAnnotation unresolvedTypeAnnotation) =>
+      TypeAnnotation.fromJson({
+        'type': 'UnresolvedTypeAnnotation',
+        'value': unresolvedTypeAnnotation,
+      });
+  static TypeAnnotation functionTypeAnnotation(
+          FunctionTypeAnnotation functionTypeAnnotation) =>
+      TypeAnnotation.fromJson({
+        'type': 'FunctionTypeAnnotation',
+        'value': functionTypeAnnotation,
+      });
+  static TypeAnnotation functionTypeParameterType(
+          FunctionTypeParameterType functionTypeParameterType) =>
+      TypeAnnotation.fromJson({
+        'type': 'FunctionTypeParameterType',
+        'value': functionTypeParameterType,
+      });
+  static TypeAnnotation recordTypeAnnotation(
+          RecordTypeAnnotation recordTypeAnnotation) =>
+      TypeAnnotation.fromJson({
+        'type': 'RecordTypeAnnotation',
+        'value': recordTypeAnnotation,
+      });
+  TypeAnnotationType get type {
+    switch (node['type'] as String) {
+      case 'NamedTypeAnnotation':
+        return TypeAnnotationType.namedTypeAnnotation;
+      case 'NullableTypeAnnotation':
+        return TypeAnnotationType.nullableTypeAnnotation;
+      case 'VoidTypeAnnotation':
+        return TypeAnnotationType.voidTypeAnnotation;
+      case 'DynamicTypeAnnotation':
+        return TypeAnnotationType.dynamicTypeAnnotation;
+      case 'InvalidTypeAnnotation':
+        return TypeAnnotationType.invalidTypeAnnotation;
+      case 'UnresolvedTypeAnnotation':
+        return TypeAnnotationType.unresolvedTypeAnnotation;
+      case 'FunctionTypeAnnotation':
+        return TypeAnnotationType.functionTypeAnnotation;
+      case 'FunctionTypeParameterType':
+        return TypeAnnotationType.functionTypeParameterType;
+      case 'RecordTypeAnnotation':
+        return TypeAnnotationType.recordTypeAnnotation;
+      default:
+        return TypeAnnotationType._unknown;
+    }
+  }
+
+  NamedTypeAnnotation get asNamedTypeAnnotation {
+    if (node['type'] != 'NamedTypeAnnotation') {
+      throw StateError('Not a NamedTypeAnnotation.');
+    }
+    return NamedTypeAnnotation.fromJson(node['value'] as Map<String, Object?>);
+  }
+
+  NullableTypeAnnotation get asNullableTypeAnnotation {
+    if (node['type'] != 'NullableTypeAnnotation') {
+      throw StateError('Not a NullableTypeAnnotation.');
+    }
+    return NullableTypeAnnotation.fromJson(
+        node['value'] as Map<String, Object?>);
+  }
+
+  VoidTypeAnnotation get asVoidTypeAnnotation {
+    if (node['type'] != 'VoidTypeAnnotation') {
+      throw StateError('Not a VoidTypeAnnotation.');
+    }
+    return VoidTypeAnnotation.fromJson(node['value'] as Map<String, Object?>);
+  }
+
+  DynamicTypeAnnotation get asDynamicTypeAnnotation {
+    if (node['type'] != 'DynamicTypeAnnotation') {
+      throw StateError('Not a DynamicTypeAnnotation.');
+    }
+    return DynamicTypeAnnotation.fromJson(
+        node['value'] as Map<String, Object?>);
+  }
+
+  InvalidTypeAnnotation get asInvalidTypeAnnotation {
+    if (node['type'] != 'InvalidTypeAnnotation') {
+      throw StateError('Not a InvalidTypeAnnotation.');
+    }
+    return InvalidTypeAnnotation.fromJson(
+        node['value'] as Map<String, Object?>);
+  }
+
+  UnresolvedTypeAnnotation get asUnresolvedTypeAnnotation {
+    if (node['type'] != 'UnresolvedTypeAnnotation') {
+      throw StateError('Not a UnresolvedTypeAnnotation.');
+    }
+    return UnresolvedTypeAnnotation.fromJson(
+        node['value'] as Map<String, Object?>);
+  }
+
+  FunctionTypeAnnotation get asFunctionTypeAnnotation {
+    if (node['type'] != 'FunctionTypeAnnotation') {
+      throw StateError('Not a FunctionTypeAnnotation.');
+    }
+    return FunctionTypeAnnotation.fromJson(
+        node['value'] as Map<String, Object?>);
+  }
+
+  FunctionTypeParameterType get asFunctionTypeParameterType {
+    if (node['type'] != 'FunctionTypeParameterType') {
+      throw StateError('Not a FunctionTypeParameterType.');
+    }
+    return FunctionTypeParameterType.fromJson(
+        node['value'] as Map<String, Object?>);
+  }
+
+  RecordTypeAnnotation get asRecordTypeAnnotation {
+    if (node['type'] != 'RecordTypeAnnotation') {
+      throw StateError('Not a RecordTypeAnnotation.');
+    }
+    return RecordTypeAnnotation.fromJson(node['value'] as Map<String, Object?>);
+  }
+}
+
+///
+extension type const BinaryOperator.fromJson(String string) implements Object {
+  static const BinaryOperator greaterThan =
+      BinaryOperator.fromJson('greaterThan');
+  static const BinaryOperator greaterThanOrEqual =
+      BinaryOperator.fromJson('greaterThanOrEqual');
+  static const BinaryOperator lessThan = BinaryOperator.fromJson('lessThan');
+  static const BinaryOperator lessThanOrEqual =
+      BinaryOperator.fromJson('lessThanOrEqual');
+  static const BinaryOperator shiftLeft = BinaryOperator.fromJson('shiftLeft');
+  static const BinaryOperator signedShiftRight =
+      BinaryOperator.fromJson('signedShiftRight');
+  static const BinaryOperator unsignedShiftRight =
+      BinaryOperator.fromJson('unsignedShiftRight');
+  static const BinaryOperator plus = BinaryOperator.fromJson('plus');
+  static const BinaryOperator minus = BinaryOperator.fromJson('minus');
+  static const BinaryOperator times = BinaryOperator.fromJson('times');
+  static const BinaryOperator divide = BinaryOperator.fromJson('divide');
+  static const BinaryOperator integerDivide =
+      BinaryOperator.fromJson('integerDivide');
+  static const BinaryOperator modulo = BinaryOperator.fromJson('modulo');
+  static const BinaryOperator bitwiseOr = BinaryOperator.fromJson('bitwiseOr');
+  static const BinaryOperator bitwiseAnd =
+      BinaryOperator.fromJson('bitwiseAnd');
+  static const BinaryOperator bitwiseXor =
+      BinaryOperator.fromJson('bitwiseXor');
+}
+
+///
+extension type const LogicalOperator.fromJson(String string) implements Object {
+  static const LogicalOperator and = LogicalOperator.fromJson('and');
+  static const LogicalOperator or = LogicalOperator.fromJson('or');
+}
+
+///
+extension type const UnaryOperator.fromJson(String string) implements Object {
+  static const UnaryOperator minus = UnaryOperator.fromJson('minus');
+  static const UnaryOperator bang = UnaryOperator.fromJson('bang');
+  static const UnaryOperator tilde = UnaryOperator.fromJson('tilde');
+}
+
+///
+extension type AsExpression.fromJson(Map<String, Object?> node)
+    implements Object {
+  AsExpression({
+    Expression? expression,
+    TypeAnnotation? type,
+  }) : this.fromJson({
+          if (expression != null) 'expression': expression,
+          if (type != null) 'type': type,
+        });
+
+  ///
+  Expression get expression => node['expression'] as Expression;
+
+  ///
+  TypeAnnotation get type => node['type'] as TypeAnnotation;
+}
+
+///
+extension type BinaryExpression.fromJson(Map<String, Object?> node)
+    implements Object {
+  BinaryExpression({
+    Expression? left,
+    BinaryOperator? operator,
+    Expression? right,
+  }) : this.fromJson({
+          if (left != null) 'left': left,
+          if (operator != null) 'operator': operator,
+          if (right != null) 'right': right,
+        });
+
+  ///
+  Expression get left => node['left'] as Expression;
+
+  ///
+  BinaryOperator get operator => node['operator'] as BinaryOperator;
+
+  ///
+  Expression get right => node['right'] as Expression;
+}
+
+///
+extension type BooleanLiteral.fromJson(Map<String, Object?> node)
+    implements Object {
+  BooleanLiteral({
+    String? text,
+  }) : this.fromJson({
+          if (text != null) 'text': text,
+        });
+
+  ///
+  String get text => node['text'] as String;
+}
+
+///
+extension type ClassReference.fromJson(Map<String, Object?> node)
+    implements Object {
+  ClassReference() : this.fromJson({});
+}
+
+///
+extension type ConditionalExpression.fromJson(Map<String, Object?> node)
+    implements Object {
+  ConditionalExpression({
+    Expression? condition,
+    Expression? then,
+    Expression? otherwise,
+  }) : this.fromJson({
+          if (condition != null) 'condition': condition,
+          if (then != null) 'then': then,
+          if (otherwise != null) 'otherwise': otherwise,
+        });
+
+  ///
+  Expression get condition => node['condition'] as Expression;
+
+  ///
+  Expression get then => node['then'] as Expression;
+
+  ///
+  Expression get otherwise => node['otherwise'] as Expression;
+}
+
+///
+extension type ConstructorInvocation.fromJson(Map<String, Object?> node)
+    implements Object {
+  ConstructorInvocation({
+    TypeAnnotation? type,
+    Reference? constructor,
+    List<Argument>? arguments,
+  }) : this.fromJson({
+          if (type != null) 'type': type,
+          if (constructor != null) 'constructor': constructor,
+          if (arguments != null) 'arguments': arguments,
+        });
+
+  ///
+  TypeAnnotation get type => node['type'] as TypeAnnotation;
+
+  ///
+  Reference get constructor => node['constructor'] as Reference;
+
+  ///
+  List<Argument> get arguments => (node['arguments'] as List).cast();
+}
+
+///
+extension type ConstructorReference.fromJson(Map<String, Object?> node)
+    implements Object {
+  ConstructorReference() : this.fromJson({});
+}
+
+///
+extension type ConstructorTearOff.fromJson(Map<String, Object?> node)
+    implements Object {
+  ConstructorTearOff({
+    TypeAnnotation? type,
+    ConstructorReference? reference,
+  }) : this.fromJson({
+          if (type != null) 'type': type,
+          if (reference != null) 'reference': reference,
+        });
+
+  ///
+  TypeAnnotation get type => node['type'] as TypeAnnotation;
+
+  ///
+  ConstructorReference get reference =>
+      node['reference'] as ConstructorReference;
+}
+
+///
+extension type DoubleLiteral.fromJson(Map<String, Object?> node)
+    implements Object {
+  DoubleLiteral({
+    String? text,
+  }) : this.fromJson({
+          if (text != null) 'text': text,
+        });
+
+  ///
+  String get text => node['text'] as String;
+}
+
+///
+extension type DynamicTypeAnnotation.fromJson(Map<String, Object?> node)
+    implements Object {
+  DynamicTypeAnnotation({
+    Reference? reference,
+  }) : this.fromJson({
+          if (reference != null) 'reference': reference,
+        });
+
+  ///
+  Reference get reference => node['reference'] as Reference;
+}
+
+///
+extension type EnumReference.fromJson(Map<String, Object?> node)
+    implements Object {
+  EnumReference() : this.fromJson({});
+}
+
+///
+extension type EqualityExpression.fromJson(Map<String, Object?> node)
+    implements Object {
+  EqualityExpression({
+    Expression? left,
+    Expression? right,
+    bool? isNotEquals,
+  }) : this.fromJson({
+          if (left != null) 'left': left,
+          if (right != null) 'right': right,
+          if (isNotEquals != null) 'isNotEquals': isNotEquals,
+        });
+
+  ///
+  Expression get left => node['left'] as Expression;
+
+  ///
+  Expression get right => node['right'] as Expression;
+
+  ///
+  bool get isNotEquals => node['isNotEquals'] as bool;
+}
+
+///
+extension type ExpressionElement.fromJson(Map<String, Object?> node)
+    implements Object {
+  ExpressionElement({
+    Expression? expression,
+    bool? isNullAware,
+  }) : this.fromJson({
+          if (expression != null) 'expression': expression,
+          if (isNullAware != null) 'isNullAware': isNullAware,
+        });
+
+  ///
+  Expression get expression => node['expression'] as Expression;
+
+  ///
+  bool get isNullAware => node['isNullAware'] as bool;
+}
+
+///
+extension type ExtensionReference.fromJson(Map<String, Object?> node)
+    implements Object {
+  ExtensionReference() : this.fromJson({});
+}
+
+///
+extension type ExtensionTypeReference.fromJson(Map<String, Object?> node)
+    implements Object {
+  ExtensionTypeReference() : this.fromJson({});
+}
+
+///
+extension type FieldReference.fromJson(Map<String, Object?> node)
+    implements Object {
+  FieldReference() : this.fromJson({});
+}
+
+///
+extension type FormalParameter.fromJson(Map<String, Object?> node)
+    implements Object {
+  FormalParameter() : this.fromJson({});
+}
+
+///
+extension type FormalParameterGroup.fromJson(Map<String, Object?> node)
+    implements Object {
+  FormalParameterGroup() : this.fromJson({});
+}
+
+///
+extension type FunctionReference.fromJson(Map<String, Object?> node)
+    implements Object {
+  FunctionReference() : this.fromJson({});
+}
+
+///
+extension type FunctionTearOff.fromJson(Map<String, Object?> node)
+    implements Object {
+  FunctionTearOff({
+    FunctionReference? reference,
+  }) : this.fromJson({
+          if (reference != null) 'reference': reference,
+        });
+
+  ///
+  FunctionReference get reference => node['reference'] as FunctionReference;
+}
+
+///
+extension type FunctionTypeAnnotation.fromJson(Map<String, Object?> node)
+    implements Object {
+  FunctionTypeAnnotation({
+    TypeAnnotation? returnType,
+    List<FunctionTypeParameter>? typeParameters,
+    List<FormalParameter>? formalParameters,
+  }) : this.fromJson({
+          if (returnType != null) 'returnType': returnType,
+          if (typeParameters != null) 'typeParameters': typeParameters,
+          if (formalParameters != null) 'formalParameters': formalParameters,
+        });
+
+  ///
+  TypeAnnotation? get returnType => node['returnType'] as TypeAnnotation?;
+
+  ///
+  List<FunctionTypeParameter> get typeParameters =>
+      (node['typeParameters'] as List).cast();
+
+  ///
+  List<FormalParameter> get formalParameters =>
+      (node['formalParameters'] as List).cast();
+}
+
+///
+extension type FunctionTypeParameter.fromJson(Map<String, Object?> node)
+    implements Object {
+  FunctionTypeParameter() : this.fromJson({});
+}
+
+///
+extension type FunctionTypeParameterReference.fromJson(
+    Map<String, Object?> node) implements Object {
+  FunctionTypeParameterReference() : this.fromJson({});
+}
+
+///
+extension type FunctionTypeParameterType.fromJson(Map<String, Object?> node)
+    implements Object {
+  FunctionTypeParameterType({
+    FunctionTypeParameter? functionTypeParameter,
+  }) : this.fromJson({
+          if (functionTypeParameter != null)
+            'functionTypeParameter': functionTypeParameter,
+        });
+
+  ///
+  FunctionTypeParameter get functionTypeParameter =>
+      node['functionTypeParameter'] as FunctionTypeParameter;
+}
+
+///
+extension type IfElement.fromJson(Map<String, Object?> node) implements Object {
+  IfElement({
+    Expression? condition,
+    Element? then,
+    Element? otherwise,
+  }) : this.fromJson({
+          if (condition != null) 'condition': condition,
+          if (then != null) 'then': then,
+          if (otherwise != null) 'otherwise': otherwise,
+        });
+
+  ///
+  Expression get condition => node['condition'] as Expression;
+
+  ///
+  Element get then => node['then'] as Element;
+
+  ///
+  Element? get otherwise => node['otherwise'] as Element?;
+}
+
+///
+extension type IfNull.fromJson(Map<String, Object?> node) implements Object {
+  IfNull({
+    Expression? left,
+    Expression? right,
+  }) : this.fromJson({
+          if (left != null) 'left': left,
+          if (right != null) 'right': right,
+        });
+
+  ///
+  Expression get left => node['left'] as Expression;
+
+  ///
+  Expression get right => node['right'] as Expression;
+}
+
+///
+extension type ImplicitInvocation.fromJson(Map<String, Object?> node)
+    implements Object {
+  ImplicitInvocation({
+    Expression? receiver,
+    List<TypeAnnotation>? typeArguments,
+    List<Argument>? arguments,
+  }) : this.fromJson({
+          if (receiver != null) 'receiver': receiver,
+          if (typeArguments != null) 'typeArguments': typeArguments,
+          if (arguments != null) 'arguments': arguments,
+        });
+
+  ///
+  Expression get receiver => node['receiver'] as Expression;
+
+  ///
+  List<TypeAnnotation> get typeArguments =>
+      (node['typeArguments'] as List).cast();
+
+  ///
+  List<Argument> get arguments => (node['arguments'] as List).cast();
+}
+
+///
+extension type Instantiation.fromJson(Map<String, Object?> node)
+    implements Object {
+  Instantiation({
+    Expression? receiver,
+    List<TypeAnnotation>? typeArguments,
+  }) : this.fromJson({
+          if (receiver != null) 'receiver': receiver,
+          if (typeArguments != null) 'typeArguments': typeArguments,
+        });
+
+  ///
+  Expression get receiver => node['receiver'] as Expression;
+
+  ///
+  List<TypeAnnotation> get typeArguments =>
+      (node['typeArguments'] as List).cast();
+}
+
+///
+extension type IntegerLiteral.fromJson(Map<String, Object?> node)
+    implements Object {
+  IntegerLiteral({
+    String? text,
+  }) : this.fromJson({
+          if (text != null) 'text': text,
+        });
+
+  ///
+  String get text => node['text'] as String;
+}
+
+///
+extension type InterpolationPart.fromJson(Map<String, Object?> node)
+    implements Object {
+  InterpolationPart({
+    Expression? expression,
+  }) : this.fromJson({
+          if (expression != null) 'expression': expression,
+        });
+
+  ///
+  Expression get expression => node['expression'] as Expression;
+}
+
+///
+extension type InvalidExpression.fromJson(Map<String, Object?> node)
+    implements Object {
+  InvalidExpression() : this.fromJson({});
+}
+
+///
+extension type InvalidTypeAnnotation.fromJson(Map<String, Object?> node)
+    implements Object {
+  InvalidTypeAnnotation() : this.fromJson({});
+}
+
+///
+extension type IsTest.fromJson(Map<String, Object?> node) implements Object {
+  IsTest({
+    Expression? expression,
+    TypeAnnotation? type,
+    bool? isNot,
+  }) : this.fromJson({
+          if (expression != null) 'expression': expression,
+          if (type != null) 'type': type,
+          if (isNot != null) 'isNot': isNot,
+        });
+
+  ///
+  Expression get expression => node['expression'] as Expression;
+
+  ///
+  TypeAnnotation get type => node['type'] as TypeAnnotation;
+
+  ///
+  bool get isNot => node['isNot'] as bool;
+}
+
+///
+extension type ListLiteral.fromJson(Map<String, Object?> node)
+    implements Object {
+  ListLiteral({
+    List<TypeAnnotation>? typeArguments,
+    List<Element>? elements,
+  }) : this.fromJson({
+          if (typeArguments != null) 'typeArguments': typeArguments,
+          if (elements != null) 'elements': elements,
+        });
+
+  ///
+  List<TypeAnnotation> get typeArguments =>
+      (node['typeArguments'] as List).cast();
+
+  ///
+  List<Element> get elements => (node['elements'] as List).cast();
+}
+
+///
+extension type LogicalExpression.fromJson(Map<String, Object?> node)
+    implements Object {
+  LogicalExpression({
+    Expression? left,
+    LogicalOperator? operator,
+    Expression? right,
+  }) : this.fromJson({
+          if (left != null) 'left': left,
+          if (operator != null) 'operator': operator,
+          if (right != null) 'right': right,
+        });
+
+  ///
+  Expression get left => node['left'] as Expression;
+
+  ///
+  LogicalOperator get operator => node['operator'] as LogicalOperator;
+
+  ///
+  Expression get right => node['right'] as Expression;
+}
+
+///
+extension type MapEntryElement.fromJson(Map<String, Object?> node)
+    implements Object {
+  MapEntryElement({
+    Expression? key,
+    Expression? value,
+    bool? isNullAwareKey,
+    bool? isNullAwareValue,
+  }) : this.fromJson({
+          if (key != null) 'key': key,
+          if (value != null) 'value': value,
+          if (isNullAwareKey != null) 'isNullAwareKey': isNullAwareKey,
+          if (isNullAwareValue != null) 'isNullAwareValue': isNullAwareValue,
+        });
+
+  ///
+  Expression get key => node['key'] as Expression;
+
+  ///
+  Expression get value => node['value'] as Expression;
+
+  ///
+  bool get isNullAwareKey => node['isNullAwareKey'] as bool;
+
+  ///
+  bool get isNullAwareValue => node['isNullAwareValue'] as bool;
+}
+
+///
+extension type MethodInvocation.fromJson(Map<String, Object?> node)
+    implements Object {
+  MethodInvocation({
+    Expression? receiver,
+    String? name,
+    List<TypeAnnotation>? typeArguments,
+    List<Argument>? arguments,
+  }) : this.fromJson({
+          if (receiver != null) 'receiver': receiver,
+          if (name != null) 'name': name,
+          if (typeArguments != null) 'typeArguments': typeArguments,
+          if (arguments != null) 'arguments': arguments,
+        });
+
+  ///
+  Expression get receiver => node['receiver'] as Expression;
+
+  ///
+  String get name => node['name'] as String;
+
+  ///
+  List<TypeAnnotation> get typeArguments =>
+      (node['typeArguments'] as List).cast();
+
+  ///
+  List<Argument> get arguments => (node['arguments'] as List).cast();
+}
+
+///
+extension type NamedArgument.fromJson(Map<String, Object?> node)
+    implements Object {
+  NamedArgument({
+    String? name,
+    Expression? expression,
+  }) : this.fromJson({
+          if (name != null) 'name': name,
+          if (expression != null) 'expression': expression,
+        });
+
+  ///
+  String get name => node['name'] as String;
+
+  ///
+  Expression get expression => node['expression'] as Expression;
+}
+
+///
+extension type NamedTypeAnnotation.fromJson(Map<String, Object?> node)
+    implements Object {
+  NamedTypeAnnotation({
+    Reference? reference,
+    List<TypeAnnotation>? typeArguments,
+  }) : this.fromJson({
+          if (reference != null) 'reference': reference,
+          if (typeArguments != null) 'typeArguments': typeArguments,
+        });
+
+  ///
+  Reference get reference => node['reference'] as Reference;
+
+  ///
+  List<TypeAnnotation> get typeArguments =>
+      (node['typeArguments'] as List).cast();
+}
+
+///
+extension type NullableTypeAnnotation.fromJson(Map<String, Object?> node)
+    implements Object {
+  NullableTypeAnnotation({
+    TypeAnnotation? typeAnnotation,
+  }) : this.fromJson({
+          if (typeAnnotation != null) 'typeAnnotation': typeAnnotation,
+        });
+
+  ///
+  TypeAnnotation get typeAnnotation => node['typeAnnotation'] as TypeAnnotation;
+}
+
+///
+extension type NullAwarePropertyGet.fromJson(Map<String, Object?> node)
+    implements Object {
+  NullAwarePropertyGet({
+    Expression? receiver,
+    String? name,
+  }) : this.fromJson({
+          if (receiver != null) 'receiver': receiver,
+          if (name != null) 'name': name,
+        });
+
+  ///
+  Expression get receiver => node['receiver'] as Expression;
+
+  ///
+  String get name => node['name'] as String;
+}
+
+///
+extension type NullCheck.fromJson(Map<String, Object?> node) implements Object {
+  NullCheck({
+    Expression? expression,
+  }) : this.fromJson({
+          if (expression != null) 'expression': expression,
+        });
+
+  ///
+  Expression get expression => node['expression'] as Expression;
+}
+
+///
+extension type NullLiteral.fromJson(Map<String, Object?> node)
+    implements Object {
+  NullLiteral() : this.fromJson({});
+}
+
+///
+extension type ParenthesizedExpression.fromJson(Map<String, Object?> node)
+    implements Object {
+  ParenthesizedExpression({
+    Expression? expression,
+  }) : this.fromJson({
+          if (expression != null) 'expression': expression,
+        });
+
+  ///
+  Expression get expression => node['expression'] as Expression;
+}
+
+///
+extension type PositionalArgument.fromJson(Map<String, Object?> node)
+    implements Object {
+  PositionalArgument({
+    Expression? expression,
+  }) : this.fromJson({
+          if (expression != null) 'expression': expression,
+        });
+
+  ///
+  Expression get expression => node['expression'] as Expression;
+}
+
+///
+extension type PropertyGet.fromJson(Map<String, Object?> node)
+    implements Object {
+  PropertyGet({
+    Expression? receiver,
+    String? name,
+  }) : this.fromJson({
+          if (receiver != null) 'receiver': receiver,
+          if (name != null) 'name': name,
+        });
+
+  ///
+  Expression get receiver => node['receiver'] as Expression;
+
+  ///
+  String get name => node['name'] as String;
+}
+
+///
+extension type RecordLiteral.fromJson(Map<String, Object?> node)
+    implements Object {
+  RecordLiteral({
+    List<RecordField>? fields,
+  }) : this.fromJson({
+          if (fields != null) 'fields': fields,
+        });
+
+  ///
+  List<RecordField> get fields => (node['fields'] as List).cast();
+}
+
+///
+extension type RecordNamedField.fromJson(Map<String, Object?> node)
+    implements Object {
+  RecordNamedField({
+    String? name,
+    Expression? expression,
+  }) : this.fromJson({
+          if (name != null) 'name': name,
+          if (expression != null) 'expression': expression,
+        });
+
+  ///
+  String get name => node['name'] as String;
+
+  ///
+  Expression get expression => node['expression'] as Expression;
+}
+
+///
+extension type RecordPositionalField.fromJson(Map<String, Object?> node)
+    implements Object {
+  RecordPositionalField({
+    Expression? expression,
+  }) : this.fromJson({
+          if (expression != null) 'expression': expression,
+        });
+
+  ///
+  Expression get expression => node['expression'] as Expression;
+}
+
+///
+extension type RecordTypeAnnotation.fromJson(Map<String, Object?> node)
+    implements Object {
+  RecordTypeAnnotation({
+    List<RecordTypeEntry>? positional,
+    List<RecordTypeEntry>? named,
+  }) : this.fromJson({
+          if (positional != null) 'positional': positional,
+          if (named != null) 'named': named,
+        });
+
+  ///
+  List<RecordTypeEntry> get positional => (node['positional'] as List).cast();
+
+  ///
+  List<RecordTypeEntry> get named => (node['named'] as List).cast();
+}
+
+///
+extension type RecordTypeEntry.fromJson(Map<String, Object?> node)
+    implements Object {
+  RecordTypeEntry() : this.fromJson({});
+}
+
+///
+extension type References.fromJson(Map<String, Object?> node)
+    implements Object {
+  References() : this.fromJson({});
+}
+
+///
+extension type SetOrMapLiteral.fromJson(Map<String, Object?> node)
+    implements Object {
+  SetOrMapLiteral({
+    List<TypeAnnotation>? typeArguments,
+    List<Element>? elements,
+  }) : this.fromJson({
+          if (typeArguments != null) 'typeArguments': typeArguments,
+          if (elements != null) 'elements': elements,
+        });
+
+  ///
+  List<TypeAnnotation> get typeArguments =>
+      (node['typeArguments'] as List).cast();
+
+  ///
+  List<Element> get elements => (node['elements'] as List).cast();
+}
+
+///
+extension type SpreadElement.fromJson(Map<String, Object?> node)
+    implements Object {
+  SpreadElement({
+    Expression? expression,
+    bool? isNullAware,
+  }) : this.fromJson({
+          if (expression != null) 'expression': expression,
+          if (isNullAware != null) 'isNullAware': isNullAware,
+        });
+
+  ///
+  Expression get expression => node['expression'] as Expression;
+
+  ///
+  bool get isNullAware => node['isNullAware'] as bool;
+}
+
+///
+extension type StaticGet.fromJson(Map<String, Object?> node) implements Object {
+  StaticGet({
+    FieldReference? reference,
+  }) : this.fromJson({
+          if (reference != null) 'reference': reference,
+        });
+
+  ///
+  FieldReference get reference => node['reference'] as FieldReference;
+}
+
+///
+extension type StaticInvocation.fromJson(Map<String, Object?> node)
+    implements Object {
+  StaticInvocation({
+    FunctionReference? function,
+    List<TypeAnnotation>? typeArguments,
+    List<Argument>? arguments,
+  }) : this.fromJson({
+          if (function != null) 'function': function,
+          if (typeArguments != null) 'typeArguments': typeArguments,
+          if (arguments != null) 'arguments': arguments,
+        });
+
+  ///
+  FunctionReference get function => node['function'] as FunctionReference;
+
+  ///
+  List<TypeAnnotation> get typeArguments =>
+      (node['typeArguments'] as List).cast();
+
+  ///
+  List<Argument> get arguments => (node['arguments'] as List).cast();
+}
+
+///
+extension type AdjacentStringLiterals.fromJson(Map<String, Object?> node)
+    implements Object {
+  AdjacentStringLiterals({
+    List<Expression>? expressions,
+  }) : this.fromJson({
+          if (expressions != null) 'expressions': expressions,
+        });
+
+  ///
+  List<Expression> get expressions => (node['expressions'] as List).cast();
+}
+
+///
+extension type StringLiteral.fromJson(Map<String, Object?> node)
+    implements Object {
+  StringLiteral({
+    List<StringLiteralPart>? parts,
+  }) : this.fromJson({
+          if (parts != null) 'parts': parts,
+        });
+
+  ///
+  List<StringLiteralPart> get parts => (node['parts'] as List).cast();
+}
+
+///
+extension type StringPart.fromJson(Map<String, Object?> node)
+    implements Object {
+  StringPart({
+    String? text,
+  }) : this.fromJson({
+          if (text != null) 'text': text,
+        });
+
+  ///
+  String get text => node['text'] as String;
+}
+
+///
+extension type SymbolLiteral.fromJson(Map<String, Object?> node)
+    implements Object {
+  SymbolLiteral({
+    List<String>? parts,
+  }) : this.fromJson({
+          if (parts != null) 'parts': parts,
+        });
+
+  ///
+  List<String> get parts => (node['parts'] as List).cast();
+}
+
+///
+extension type TypedefReference.fromJson(Map<String, Object?> node)
+    implements Object {
+  TypedefReference() : this.fromJson({});
+}
+
+///
+extension type TypeLiteral.fromJson(Map<String, Object?> node)
+    implements Object {
+  TypeLiteral({
+    TypeAnnotation? typeAnnotation,
+  }) : this.fromJson({
+          if (typeAnnotation != null) 'typeAnnotation': typeAnnotation,
+        });
+
+  ///
+  TypeAnnotation get typeAnnotation => node['typeAnnotation'] as TypeAnnotation;
+}
+
+///
+extension type TypeReference.fromJson(Map<String, Object?> node)
+    implements Object {
+  TypeReference() : this.fromJson({});
+}
+
+///
+extension type UnaryExpression.fromJson(Map<String, Object?> node)
+    implements Object {
+  UnaryExpression({
+    UnaryOperator? operator,
+    Expression? expression,
+  }) : this.fromJson({
+          if (operator != null) 'operator': operator,
+          if (expression != null) 'expression': expression,
+        });
+
+  ///
+  UnaryOperator get operator => node['operator'] as UnaryOperator;
+
+  ///
+  Expression get expression => node['expression'] as Expression;
+}
+
+///
+extension type UnresolvedExpression.fromJson(Map<String, Object?> node)
+    implements Object {
+  UnresolvedExpression() : this.fromJson({});
+}
+
+///
+extension type UnresolvedTypeAnnotation.fromJson(Map<String, Object?> node)
+    implements Object {
+  UnresolvedTypeAnnotation() : this.fromJson({});
+}
+
+///
+extension type VoidTypeAnnotation.fromJson(Map<String, Object?> node)
+    implements Object {
+  VoidTypeAnnotation({
+    Reference? reference,
+  }) : this.fromJson({
+          if (reference != null) 'reference': reference,
+        });
+
+  ///
+  Reference get reference => node['reference'] as Reference;
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,6 +6,7 @@ dev_dependencies:
 publish_to: none
 workspace:
   - goldens/foo
+  - pkgs/_analyzer_cfe_macros
   - pkgs/_analyzer_macros
   - pkgs/_analyzer_macros/test/package_under_test
   - pkgs/_cfe_macros

--- a/schemas/macro_metadata.schema.json
+++ b/schemas/macro_metadata.schema.json
@@ -1,0 +1,1120 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "oneOf": [],
+  "$defs": {
+    "Argument": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "value": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/PositionalArgument"
+            },
+            {
+              "$ref": "#/$defs/NamedArgument"
+            }
+          ]
+        },
+        "required": [
+          "type",
+          "value"
+        ]
+      }
+    },
+    "Element": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "value": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/ExpressionElement"
+            },
+            {
+              "$ref": "#/$defs/MapEntryElement"
+            },
+            {
+              "$ref": "#/$defs/SpreadElement"
+            },
+            {
+              "$ref": "#/$defs/IfElement"
+            }
+          ]
+        },
+        "required": [
+          "type",
+          "value"
+        ]
+      }
+    },
+    "Expression": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "value": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/InvalidExpression"
+            },
+            {
+              "$ref": "#/$defs/StaticGet"
+            },
+            {
+              "$ref": "#/$defs/FunctionTearOff"
+            },
+            {
+              "$ref": "#/$defs/ConstructorTearOff"
+            },
+            {
+              "$ref": "#/$defs/ConstructorInvocation"
+            },
+            {
+              "$ref": "#/$defs/IntegerLiteral"
+            },
+            {
+              "$ref": "#/$defs/DoubleLiteral"
+            },
+            {
+              "$ref": "#/$defs/BooleanLiteral"
+            },
+            {
+              "$ref": "#/$defs/NullLiteral"
+            },
+            {
+              "$ref": "#/$defs/SymbolLiteral"
+            },
+            {
+              "$ref": "#/$defs/StringLiteral"
+            },
+            {
+              "$ref": "#/$defs/AdjacentStringLiterals"
+            },
+            {
+              "$ref": "#/$defs/ImplicitInvocation"
+            },
+            {
+              "$ref": "#/$defs/StaticInvocation"
+            },
+            {
+              "$ref": "#/$defs/Instantiation"
+            },
+            {
+              "$ref": "#/$defs/MethodInvocation"
+            },
+            {
+              "$ref": "#/$defs/PropertyGet"
+            },
+            {
+              "$ref": "#/$defs/NullAwarePropertyGet"
+            },
+            {
+              "$ref": "#/$defs/TypeLiteral"
+            },
+            {
+              "$ref": "#/$defs/ParenthesizedExpression"
+            },
+            {
+              "$ref": "#/$defs/ConditionalExpression"
+            },
+            {
+              "$ref": "#/$defs/ListLiteral"
+            },
+            {
+              "$ref": "#/$defs/SetOrMapLiteral"
+            },
+            {
+              "$ref": "#/$defs/RecordLiteral"
+            },
+            {
+              "$ref": "#/$defs/IfNull"
+            },
+            {
+              "$ref": "#/$defs/LogicalExpression"
+            },
+            {
+              "$ref": "#/$defs/EqualityExpression"
+            },
+            {
+              "$ref": "#/$defs/BinaryExpression"
+            },
+            {
+              "$ref": "#/$defs/UnaryExpression"
+            },
+            {
+              "$ref": "#/$defs/IsTest"
+            },
+            {
+              "$ref": "#/$defs/AsExpression"
+            },
+            {
+              "$ref": "#/$defs/NullCheck"
+            },
+            {
+              "$ref": "#/$defs/UnresolvedExpression"
+            }
+          ]
+        },
+        "required": [
+          "type",
+          "value"
+        ]
+      }
+    },
+    "RecordField": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "value": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/RecordNamedField"
+            },
+            {
+              "$ref": "#/$defs/RecordPositionalField"
+            }
+          ]
+        },
+        "required": [
+          "type",
+          "value"
+        ]
+      }
+    },
+    "Reference": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "value": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/FieldReference"
+            },
+            {
+              "$ref": "#/$defs/FunctionReference"
+            },
+            {
+              "$ref": "#/$defs/ConstructorReference"
+            },
+            {
+              "$ref": "#/$defs/TypeReference"
+            },
+            {
+              "$ref": "#/$defs/ClassReference"
+            },
+            {
+              "$ref": "#/$defs/TypedefReference"
+            },
+            {
+              "$ref": "#/$defs/ExtensionReference"
+            },
+            {
+              "$ref": "#/$defs/ExtensionTypeReference"
+            },
+            {
+              "$ref": "#/$defs/EnumReference"
+            },
+            {
+              "$ref": "#/$defs/FunctionTypeParameterReference"
+            }
+          ]
+        },
+        "required": [
+          "type",
+          "value"
+        ]
+      }
+    },
+    "StringLiteralPart": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "value": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/StringPart"
+            },
+            {
+              "$ref": "#/$defs/InterpolationPart"
+            }
+          ]
+        },
+        "required": [
+          "type",
+          "value"
+        ]
+      }
+    },
+    "TypeAnnotation": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "value": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/NamedTypeAnnotation"
+            },
+            {
+              "$ref": "#/$defs/NullableTypeAnnotation"
+            },
+            {
+              "$ref": "#/$defs/VoidTypeAnnotation"
+            },
+            {
+              "$ref": "#/$defs/DynamicTypeAnnotation"
+            },
+            {
+              "$ref": "#/$defs/InvalidTypeAnnotation"
+            },
+            {
+              "$ref": "#/$defs/UnresolvedTypeAnnotation"
+            },
+            {
+              "$ref": "#/$defs/FunctionTypeAnnotation"
+            },
+            {
+              "$ref": "#/$defs/FunctionTypeParameterType"
+            },
+            {
+              "$ref": "#/$defs/RecordTypeAnnotation"
+            }
+          ]
+        },
+        "required": [
+          "type",
+          "value"
+        ]
+      }
+    },
+    "BinaryOperator": {
+      "type": "string",
+      "description": ""
+    },
+    "LogicalOperator": {
+      "type": "string",
+      "description": ""
+    },
+    "UnaryOperator": {
+      "type": "string",
+      "description": ""
+    },
+    "AsExpression": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "expression": {
+          "$comment": "",
+          "$ref": "#/$defs/Expression"
+        },
+        "type": {
+          "$comment": "",
+          "$ref": "#/$defs/TypeAnnotation"
+        }
+      }
+    },
+    "BinaryExpression": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "left": {
+          "$comment": "",
+          "$ref": "#/$defs/Expression"
+        },
+        "operator": {
+          "$comment": "",
+          "$ref": "#/$defs/BinaryOperator"
+        },
+        "right": {
+          "$comment": "",
+          "$ref": "#/$defs/Expression"
+        }
+      }
+    },
+    "BooleanLiteral": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "text": {
+          "type": "string",
+          "description": ""
+        }
+      }
+    },
+    "ClassReference": {
+      "type": "object",
+      "description": "",
+      "properties": {}
+    },
+    "ConditionalExpression": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "condition": {
+          "$comment": "",
+          "$ref": "#/$defs/Expression"
+        },
+        "then": {
+          "$comment": "",
+          "$ref": "#/$defs/Expression"
+        },
+        "otherwise": {
+          "$comment": "",
+          "$ref": "#/$defs/Expression"
+        }
+      }
+    },
+    "ConstructorInvocation": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "type": {
+          "$comment": "",
+          "$ref": "#/$defs/TypeAnnotation"
+        },
+        "constructor": {
+          "$comment": "",
+          "$ref": "#/$defs/Reference"
+        },
+        "arguments": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/$defs/Argument"
+          }
+        }
+      }
+    },
+    "ConstructorReference": {
+      "type": "object",
+      "description": "",
+      "properties": {}
+    },
+    "ConstructorTearOff": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "type": {
+          "$comment": "",
+          "$ref": "#/$defs/TypeAnnotation"
+        },
+        "reference": {
+          "$comment": "",
+          "$ref": "#/$defs/ConstructorReference"
+        }
+      }
+    },
+    "DoubleLiteral": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "text": {
+          "type": "string",
+          "description": ""
+        }
+      }
+    },
+    "DynamicTypeAnnotation": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "reference": {
+          "$comment": "",
+          "$ref": "#/$defs/Reference"
+        }
+      }
+    },
+    "EnumReference": {
+      "type": "object",
+      "description": "",
+      "properties": {}
+    },
+    "EqualityExpression": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "left": {
+          "$comment": "",
+          "$ref": "#/$defs/Expression"
+        },
+        "right": {
+          "$comment": "",
+          "$ref": "#/$defs/Expression"
+        },
+        "isNotEquals": {
+          "type": "boolean",
+          "description": ""
+        }
+      }
+    },
+    "ExpressionElement": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "expression": {
+          "$comment": "",
+          "$ref": "#/$defs/Expression"
+        },
+        "isNullAware": {
+          "type": "boolean",
+          "description": ""
+        }
+      }
+    },
+    "ExtensionReference": {
+      "type": "object",
+      "description": "",
+      "properties": {}
+    },
+    "ExtensionTypeReference": {
+      "type": "object",
+      "description": "",
+      "properties": {}
+    },
+    "FieldReference": {
+      "type": "object",
+      "description": "",
+      "properties": {}
+    },
+    "FormalParameter": {
+      "type": "object",
+      "description": "",
+      "properties": {}
+    },
+    "FormalParameterGroup": {
+      "type": "object",
+      "description": "",
+      "properties": {}
+    },
+    "FunctionReference": {
+      "type": "object",
+      "description": "",
+      "properties": {}
+    },
+    "FunctionTearOff": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "reference": {
+          "$comment": "",
+          "$ref": "#/$defs/FunctionReference"
+        }
+      }
+    },
+    "FunctionTypeAnnotation": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "returnType": {
+          "$comment": "",
+          "$ref": "#/$defs/TypeAnnotation"
+        },
+        "typeParameters": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/$defs/FunctionTypeParameter"
+          }
+        },
+        "formalParameters": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/$defs/FormalParameter"
+          }
+        }
+      }
+    },
+    "FunctionTypeParameter": {
+      "type": "object",
+      "description": "",
+      "properties": {}
+    },
+    "FunctionTypeParameterReference": {
+      "type": "object",
+      "description": "",
+      "properties": {}
+    },
+    "FunctionTypeParameterType": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "functionTypeParameter": {
+          "$comment": "",
+          "$ref": "#/$defs/FunctionTypeParameter"
+        }
+      }
+    },
+    "IfElement": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "condition": {
+          "$comment": "",
+          "$ref": "#/$defs/Expression"
+        },
+        "then": {
+          "$comment": "",
+          "$ref": "#/$defs/Element"
+        },
+        "otherwise": {
+          "$comment": "",
+          "$ref": "#/$defs/Element"
+        }
+      }
+    },
+    "IfNull": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "left": {
+          "$comment": "",
+          "$ref": "#/$defs/Expression"
+        },
+        "right": {
+          "$comment": "",
+          "$ref": "#/$defs/Expression"
+        }
+      }
+    },
+    "ImplicitInvocation": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "receiver": {
+          "$comment": "",
+          "$ref": "#/$defs/Expression"
+        },
+        "typeArguments": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/$defs/TypeAnnotation"
+          }
+        },
+        "arguments": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/$defs/Argument"
+          }
+        }
+      }
+    },
+    "Instantiation": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "receiver": {
+          "$comment": "",
+          "$ref": "#/$defs/Expression"
+        },
+        "typeArguments": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/$defs/TypeAnnotation"
+          }
+        }
+      }
+    },
+    "IntegerLiteral": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "text": {
+          "type": "string",
+          "description": ""
+        }
+      }
+    },
+    "InterpolationPart": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "expression": {
+          "$comment": "",
+          "$ref": "#/$defs/Expression"
+        }
+      }
+    },
+    "InvalidExpression": {
+      "type": "object",
+      "description": "",
+      "properties": {}
+    },
+    "InvalidTypeAnnotation": {
+      "type": "object",
+      "description": "",
+      "properties": {}
+    },
+    "IsTest": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "expression": {
+          "$comment": "",
+          "$ref": "#/$defs/Expression"
+        },
+        "type": {
+          "$comment": "",
+          "$ref": "#/$defs/TypeAnnotation"
+        },
+        "isNot": {
+          "type": "boolean",
+          "description": ""
+        }
+      }
+    },
+    "ListLiteral": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "typeArguments": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/$defs/TypeAnnotation"
+          }
+        },
+        "elements": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/$defs/Element"
+          }
+        }
+      }
+    },
+    "LogicalExpression": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "left": {
+          "$comment": "",
+          "$ref": "#/$defs/Expression"
+        },
+        "operator": {
+          "$comment": "",
+          "$ref": "#/$defs/LogicalOperator"
+        },
+        "right": {
+          "$comment": "",
+          "$ref": "#/$defs/Expression"
+        }
+      }
+    },
+    "MapEntryElement": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "key": {
+          "$comment": "",
+          "$ref": "#/$defs/Expression"
+        },
+        "value": {
+          "$comment": "",
+          "$ref": "#/$defs/Expression"
+        },
+        "isNullAwareKey": {
+          "type": "boolean",
+          "description": ""
+        },
+        "isNullAwareValue": {
+          "type": "boolean",
+          "description": ""
+        }
+      }
+    },
+    "MethodInvocation": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "receiver": {
+          "$comment": "",
+          "$ref": "#/$defs/Expression"
+        },
+        "name": {
+          "type": "string",
+          "description": ""
+        },
+        "typeArguments": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/$defs/TypeAnnotation"
+          }
+        },
+        "arguments": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/$defs/Argument"
+          }
+        }
+      }
+    },
+    "NamedArgument": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": ""
+        },
+        "expression": {
+          "$comment": "",
+          "$ref": "#/$defs/Expression"
+        }
+      }
+    },
+    "NamedTypeAnnotation": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "reference": {
+          "$comment": "",
+          "$ref": "#/$defs/Reference"
+        },
+        "typeArguments": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/$defs/TypeAnnotation"
+          }
+        }
+      }
+    },
+    "NullableTypeAnnotation": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "typeAnnotation": {
+          "$comment": "",
+          "$ref": "#/$defs/TypeAnnotation"
+        }
+      }
+    },
+    "NullAwarePropertyGet": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "receiver": {
+          "$comment": "",
+          "$ref": "#/$defs/Expression"
+        },
+        "name": {
+          "type": "string",
+          "description": ""
+        }
+      }
+    },
+    "NullCheck": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "expression": {
+          "$comment": "",
+          "$ref": "#/$defs/Expression"
+        }
+      }
+    },
+    "NullLiteral": {
+      "type": "object",
+      "description": "",
+      "properties": {}
+    },
+    "ParenthesizedExpression": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "expression": {
+          "$comment": "",
+          "$ref": "#/$defs/Expression"
+        }
+      }
+    },
+    "PositionalArgument": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "expression": {
+          "$comment": "",
+          "$ref": "#/$defs/Expression"
+        }
+      }
+    },
+    "PropertyGet": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "receiver": {
+          "$comment": "",
+          "$ref": "#/$defs/Expression"
+        },
+        "name": {
+          "type": "string",
+          "description": ""
+        }
+      }
+    },
+    "RecordLiteral": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "fields": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/$defs/RecordField"
+          }
+        }
+      }
+    },
+    "RecordNamedField": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": ""
+        },
+        "expression": {
+          "$comment": "",
+          "$ref": "#/$defs/Expression"
+        }
+      }
+    },
+    "RecordPositionalField": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "expression": {
+          "$comment": "",
+          "$ref": "#/$defs/Expression"
+        }
+      }
+    },
+    "RecordTypeAnnotation": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "positional": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/$defs/RecordTypeEntry"
+          }
+        },
+        "named": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/$defs/RecordTypeEntry"
+          }
+        }
+      }
+    },
+    "RecordTypeEntry": {
+      "type": "object",
+      "description": "",
+      "properties": {}
+    },
+    "References": {
+      "type": "object",
+      "description": "",
+      "properties": {}
+    },
+    "SetOrMapLiteral": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "typeArguments": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/$defs/TypeAnnotation"
+          }
+        },
+        "elements": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/$defs/Element"
+          }
+        }
+      }
+    },
+    "SpreadElement": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "expression": {
+          "$comment": "",
+          "$ref": "#/$defs/Expression"
+        },
+        "isNullAware": {
+          "type": "boolean",
+          "description": ""
+        }
+      }
+    },
+    "StaticGet": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "reference": {
+          "$comment": "",
+          "$ref": "#/$defs/FieldReference"
+        }
+      }
+    },
+    "StaticInvocation": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "function": {
+          "$comment": "",
+          "$ref": "#/$defs/FunctionReference"
+        },
+        "typeArguments": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/$defs/TypeAnnotation"
+          }
+        },
+        "arguments": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/$defs/Argument"
+          }
+        }
+      }
+    },
+    "AdjacentStringLiterals": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "expressions": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/$defs/Expression"
+          }
+        }
+      }
+    },
+    "StringLiteral": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "parts": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "$ref": "#/$defs/StringLiteralPart"
+          }
+        }
+      }
+    },
+    "StringPart": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "text": {
+          "type": "string",
+          "description": ""
+        }
+      }
+    },
+    "SymbolLiteral": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "parts": {
+          "type": "array",
+          "description": "",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "TypedefReference": {
+      "type": "object",
+      "description": "",
+      "properties": {}
+    },
+    "TypeLiteral": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "typeAnnotation": {
+          "$comment": "",
+          "$ref": "#/$defs/TypeAnnotation"
+        }
+      }
+    },
+    "TypeReference": {
+      "type": "object",
+      "description": "",
+      "properties": {}
+    },
+    "UnaryExpression": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "operator": {
+          "$comment": "",
+          "$ref": "#/$defs/UnaryOperator"
+        },
+        "expression": {
+          "$comment": "",
+          "$ref": "#/$defs/Expression"
+        }
+      }
+    },
+    "UnresolvedExpression": {
+      "type": "object",
+      "description": "",
+      "properties": {}
+    },
+    "UnresolvedTypeAnnotation": {
+      "type": "object",
+      "description": "",
+      "properties": {}
+    },
+    "VoidTypeAnnotation": {
+      "type": "object",
+      "description": "",
+      "properties": {
+        "reference": {
+          "$comment": "",
+          "$ref": "#/$defs/Reference"
+        }
+      }
+    }
+  }
+}

--- a/tool/dart_model_generator/lib/definitions.dart
+++ b/tool/dart_model_generator/lib/definitions.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'generate_dart_model.dart';
+import 'macro_metadata_definitions.dart' as macro_metadata;
 
 final schemas = Schemas([
   Schema(
@@ -54,6 +55,13 @@ static Protocol handshakeProtocol = Protocol(
           description: 'The protocol version.',
           values: ['handshake', 'macros1']),
     ],
+  ),
+  Schema(
+    schemaPath: 'macro_metadata.schema.json',
+    codePackage: 'dart_model',
+    codePath: 'src/macro_metadata.g.dart',
+    rootTypes: [],
+    declarations: macro_metadata.definitions,
   ),
   Schema(
       schemaPath: 'dart_model.schema.json',

--- a/tool/dart_model_generator/lib/macro_metadata_definitions.dart
+++ b/tool/dart_model_generator/lib/macro_metadata_definitions.dart
@@ -1,0 +1,636 @@
+// Copyright (c) 2024, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'generate_dart_model.dart';
+
+// These definitions are generated and experimental, talk to davidmorgan@
+// before making any manual changes.
+// TODO(davidmorgan): determine how this will be maintained.
+
+final definitions = [
+  Definition.union(
+    'Argument',
+    description: '',
+    types: [
+      'PositionalArgument',
+      'NamedArgument',
+    ],
+    properties: [],
+  ),
+  Definition.union(
+    'Element',
+    description: '',
+    types: [
+      'ExpressionElement',
+      'MapEntryElement',
+      'SpreadElement',
+      'IfElement',
+    ],
+    properties: [],
+  ),
+  Definition.union(
+    'Expression',
+    description: '',
+    types: [
+      'InvalidExpression',
+      'StaticGet',
+      'FunctionTearOff',
+      'ConstructorTearOff',
+      'ConstructorInvocation',
+      'IntegerLiteral',
+      'DoubleLiteral',
+      'BooleanLiteral',
+      'NullLiteral',
+      'SymbolLiteral',
+      'StringLiteral',
+      'AdjacentStringLiterals',
+      'ImplicitInvocation',
+      'StaticInvocation',
+      'Instantiation',
+      'MethodInvocation',
+      'PropertyGet',
+      'NullAwarePropertyGet',
+      'TypeLiteral',
+      'ParenthesizedExpression',
+      'ConditionalExpression',
+      'ListLiteral',
+      'SetOrMapLiteral',
+      'RecordLiteral',
+      'IfNull',
+      'LogicalExpression',
+      'EqualityExpression',
+      'BinaryExpression',
+      'UnaryExpression',
+      'IsTest',
+      'AsExpression',
+      'NullCheck',
+      'UnresolvedExpression',
+    ],
+    properties: [],
+  ),
+  Definition.union(
+    'RecordField',
+    description: '',
+    types: [
+      'RecordNamedField',
+      'RecordPositionalField',
+    ],
+    properties: [],
+  ),
+  Definition.union(
+    'Reference',
+    description: '',
+    types: [
+      'FieldReference',
+      'FunctionReference',
+      'ConstructorReference',
+      'TypeReference',
+      'ClassReference',
+      'TypedefReference',
+      'ExtensionReference',
+      'ExtensionTypeReference',
+      'EnumReference',
+      'FunctionTypeParameterReference',
+    ],
+    properties: [],
+  ),
+  Definition.union(
+    'StringLiteralPart',
+    description: '',
+    types: [
+      'StringPart',
+      'InterpolationPart',
+    ],
+    properties: [],
+  ),
+  Definition.union(
+    'TypeAnnotation',
+    description: '',
+    types: [
+      'NamedTypeAnnotation',
+      'NullableTypeAnnotation',
+      'VoidTypeAnnotation',
+      'DynamicTypeAnnotation',
+      'InvalidTypeAnnotation',
+      'UnresolvedTypeAnnotation',
+      'FunctionTypeAnnotation',
+      'FunctionTypeParameterType',
+      'RecordTypeAnnotation',
+    ],
+    properties: [],
+  ),
+  Definition.$enum(
+    'BinaryOperator',
+    description: '',
+    values: [
+      'greaterThan',
+      'greaterThanOrEqual',
+      'lessThan',
+      'lessThanOrEqual',
+      'shiftLeft',
+      'signedShiftRight',
+      'unsignedShiftRight',
+      'plus',
+      'minus',
+      'times',
+      'divide',
+      'integerDivide',
+      'modulo',
+      'bitwiseOr',
+      'bitwiseAnd',
+      'bitwiseXor',
+    ],
+  ),
+  Definition.$enum(
+    'LogicalOperator',
+    description: '',
+    values: [
+      'and',
+      'or',
+    ],
+  ),
+  Definition.$enum(
+    'UnaryOperator',
+    description: '',
+    values: [
+      'minus',
+      'bang',
+      'tilde',
+    ],
+  ),
+  Definition.clazz(
+    'AsExpression',
+    description: '',
+    properties: [
+      Property('expression', type: 'Expression', description: ''),
+      Property('type', type: 'TypeAnnotation', description: ''),
+    ],
+  ),
+  Definition.clazz(
+    'BinaryExpression',
+    description: '',
+    properties: [
+      Property('left', type: 'Expression', description: ''),
+      Property('operator', type: 'BinaryOperator', description: ''),
+      Property('right', type: 'Expression', description: ''),
+    ],
+  ),
+  Definition.clazz(
+    'BooleanLiteral',
+    description: '',
+    properties: [
+      Property('text', type: 'String', description: ''),
+    ],
+  ),
+  Definition.clazz(
+    'ClassReference',
+    description: '',
+    properties: [],
+  ),
+  Definition.clazz(
+    'ConditionalExpression',
+    description: '',
+    properties: [
+      Property('condition', type: 'Expression', description: ''),
+      Property('then', type: 'Expression', description: ''),
+      Property('otherwise', type: 'Expression', description: ''),
+    ],
+  ),
+  Definition.clazz(
+    'ConstructorInvocation',
+    description: '',
+    properties: [
+      Property('type', type: 'TypeAnnotation', description: ''),
+      Property('constructor', type: 'Reference', description: ''),
+      Property('arguments', type: 'List<Argument>', description: ''),
+    ],
+  ),
+  Definition.clazz(
+    'ConstructorReference',
+    description: '',
+    properties: [],
+  ),
+  Definition.clazz(
+    'ConstructorTearOff',
+    description: '',
+    properties: [
+      Property('type', type: 'TypeAnnotation', description: ''),
+      Property('reference', type: 'ConstructorReference', description: ''),
+    ],
+  ),
+  Definition.clazz(
+    'DoubleLiteral',
+    description: '',
+    properties: [
+      Property('text', type: 'String', description: ''),
+    ],
+  ),
+  Definition.clazz(
+    'DynamicTypeAnnotation',
+    description: '',
+    properties: [
+      Property('reference', type: 'Reference', description: ''),
+    ],
+  ),
+  Definition.clazz(
+    'EnumReference',
+    description: '',
+    properties: [],
+  ),
+  Definition.clazz(
+    'EqualityExpression',
+    description: '',
+    properties: [
+      Property('left', type: 'Expression', description: ''),
+      Property('right', type: 'Expression', description: ''),
+      Property('isNotEquals', type: 'bool', description: ''),
+    ],
+  ),
+  Definition.clazz(
+    'ExpressionElement',
+    description: '',
+    properties: [
+      Property('expression', type: 'Expression', description: ''),
+      Property('isNullAware', type: 'bool', description: ''),
+    ],
+  ),
+  Definition.clazz(
+    'ExtensionReference',
+    description: '',
+    properties: [],
+  ),
+  Definition.clazz(
+    'ExtensionTypeReference',
+    description: '',
+    properties: [],
+  ),
+  Definition.clazz(
+    'FieldReference',
+    description: '',
+    properties: [],
+  ),
+  Definition.clazz(
+    'FormalParameter',
+    description: '',
+    properties: [],
+  ),
+  Definition.clazz(
+    'FormalParameterGroup',
+    description: '',
+    properties: [],
+  ),
+  Definition.clazz(
+    'FunctionReference',
+    description: '',
+    properties: [],
+  ),
+  Definition.clazz(
+    'FunctionTearOff',
+    description: '',
+    properties: [
+      Property('reference', type: 'FunctionReference', description: ''),
+    ],
+  ),
+  Definition.clazz(
+    'FunctionTypeAnnotation',
+    description: '',
+    properties: [
+      Property('returnType',
+          type: 'TypeAnnotation', description: '', nullable: true),
+      Property('typeParameters',
+          type: 'List<FunctionTypeParameter>', description: ''),
+      Property('formalParameters',
+          type: 'List<FormalParameter>', description: ''),
+    ],
+  ),
+  Definition.clazz(
+    'FunctionTypeParameter',
+    description: '',
+    properties: [],
+  ),
+  Definition.clazz(
+    'FunctionTypeParameterReference',
+    description: '',
+    properties: [],
+  ),
+  Definition.clazz(
+    'FunctionTypeParameterType',
+    description: '',
+    properties: [
+      Property('functionTypeParameter',
+          type: 'FunctionTypeParameter', description: ''),
+    ],
+  ),
+  Definition.clazz(
+    'IfElement',
+    description: '',
+    properties: [
+      Property('condition', type: 'Expression', description: ''),
+      Property('then', type: 'Element', description: ''),
+      Property('otherwise', type: 'Element', description: '', nullable: true),
+    ],
+  ),
+  Definition.clazz(
+    'IfNull',
+    description: '',
+    properties: [
+      Property('left', type: 'Expression', description: ''),
+      Property('right', type: 'Expression', description: ''),
+    ],
+  ),
+  Definition.clazz(
+    'ImplicitInvocation',
+    description: '',
+    properties: [
+      Property('receiver', type: 'Expression', description: ''),
+      Property('typeArguments', type: 'List<TypeAnnotation>', description: ''),
+      Property('arguments', type: 'List<Argument>', description: ''),
+    ],
+  ),
+  Definition.clazz(
+    'Instantiation',
+    description: '',
+    properties: [
+      Property('receiver', type: 'Expression', description: ''),
+      Property('typeArguments', type: 'List<TypeAnnotation>', description: ''),
+    ],
+  ),
+  Definition.clazz(
+    'IntegerLiteral',
+    description: '',
+    properties: [
+      Property('text', type: 'String', description: ''),
+    ],
+  ),
+  Definition.clazz(
+    'InterpolationPart',
+    description: '',
+    properties: [
+      Property('expression', type: 'Expression', description: ''),
+    ],
+  ),
+  Definition.clazz(
+    'InvalidExpression',
+    description: '',
+    properties: [],
+  ),
+  Definition.clazz(
+    'InvalidTypeAnnotation',
+    description: '',
+    properties: [],
+  ),
+  Definition.clazz(
+    'IsTest',
+    description: '',
+    properties: [
+      Property('expression', type: 'Expression', description: ''),
+      Property('type', type: 'TypeAnnotation', description: ''),
+      Property('isNot', type: 'bool', description: ''),
+    ],
+  ),
+  Definition.clazz(
+    'ListLiteral',
+    description: '',
+    properties: [
+      Property('typeArguments', type: 'List<TypeAnnotation>', description: ''),
+      Property('elements', type: 'List<Element>', description: ''),
+    ],
+  ),
+  Definition.clazz(
+    'LogicalExpression',
+    description: '',
+    properties: [
+      Property('left', type: 'Expression', description: ''),
+      Property('operator', type: 'LogicalOperator', description: ''),
+      Property('right', type: 'Expression', description: ''),
+    ],
+  ),
+  Definition.clazz(
+    'MapEntryElement',
+    description: '',
+    properties: [
+      Property('key', type: 'Expression', description: ''),
+      Property('value', type: 'Expression', description: ''),
+      Property('isNullAwareKey', type: 'bool', description: ''),
+      Property('isNullAwareValue', type: 'bool', description: ''),
+    ],
+  ),
+  Definition.clazz(
+    'MethodInvocation',
+    description: '',
+    properties: [
+      Property('receiver', type: 'Expression', description: ''),
+      Property('name', type: 'String', description: ''),
+      Property('typeArguments', type: 'List<TypeAnnotation>', description: ''),
+      Property('arguments', type: 'List<Argument>', description: ''),
+    ],
+  ),
+  Definition.clazz(
+    'NamedArgument',
+    description: '',
+    properties: [
+      Property('name', type: 'String', description: ''),
+      Property('expression', type: 'Expression', description: ''),
+    ],
+  ),
+  Definition.clazz(
+    'NamedTypeAnnotation',
+    description: '',
+    properties: [
+      Property('reference', type: 'Reference', description: ''),
+      Property('typeArguments', type: 'List<TypeAnnotation>', description: ''),
+    ],
+  ),
+  Definition.clazz(
+    'NullableTypeAnnotation',
+    description: '',
+    properties: [
+      Property('typeAnnotation', type: 'TypeAnnotation', description: ''),
+    ],
+  ),
+  Definition.clazz(
+    'NullAwarePropertyGet',
+    description: '',
+    properties: [
+      Property('receiver', type: 'Expression', description: ''),
+      Property('name', type: 'String', description: ''),
+    ],
+  ),
+  Definition.clazz(
+    'NullCheck',
+    description: '',
+    properties: [
+      Property('expression', type: 'Expression', description: ''),
+    ],
+  ),
+  Definition.clazz(
+    'NullLiteral',
+    description: '',
+    properties: [],
+  ),
+  Definition.clazz(
+    'ParenthesizedExpression',
+    description: '',
+    properties: [
+      Property('expression', type: 'Expression', description: ''),
+    ],
+  ),
+  Definition.clazz(
+    'PositionalArgument',
+    description: '',
+    properties: [
+      Property('expression', type: 'Expression', description: ''),
+    ],
+  ),
+  Definition.clazz(
+    'PropertyGet',
+    description: '',
+    properties: [
+      Property('receiver', type: 'Expression', description: ''),
+      Property('name', type: 'String', description: ''),
+    ],
+  ),
+  Definition.clazz(
+    'RecordLiteral',
+    description: '',
+    properties: [
+      Property('fields', type: 'List<RecordField>', description: ''),
+    ],
+  ),
+  Definition.clazz(
+    'RecordNamedField',
+    description: '',
+    properties: [
+      Property('name', type: 'String', description: ''),
+      Property('expression', type: 'Expression', description: ''),
+    ],
+  ),
+  Definition.clazz(
+    'RecordPositionalField',
+    description: '',
+    properties: [
+      Property('expression', type: 'Expression', description: ''),
+    ],
+  ),
+  Definition.clazz(
+    'RecordTypeAnnotation',
+    description: '',
+    properties: [
+      Property('positional', type: 'List<RecordTypeEntry>', description: ''),
+      Property('named', type: 'List<RecordTypeEntry>', description: ''),
+    ],
+  ),
+  Definition.clazz(
+    'RecordTypeEntry',
+    description: '',
+    properties: [],
+  ),
+  Definition.clazz(
+    'References',
+    description: '',
+    properties: [],
+  ),
+  Definition.clazz(
+    'SetOrMapLiteral',
+    description: '',
+    properties: [
+      Property('typeArguments', type: 'List<TypeAnnotation>', description: ''),
+      Property('elements', type: 'List<Element>', description: ''),
+    ],
+  ),
+  Definition.clazz(
+    'SpreadElement',
+    description: '',
+    properties: [
+      Property('expression', type: 'Expression', description: ''),
+      Property('isNullAware', type: 'bool', description: ''),
+    ],
+  ),
+  Definition.clazz(
+    'StaticGet',
+    description: '',
+    properties: [
+      Property('reference', type: 'FieldReference', description: ''),
+    ],
+  ),
+  Definition.clazz(
+    'StaticInvocation',
+    description: '',
+    properties: [
+      Property('function', type: 'FunctionReference', description: ''),
+      Property('typeArguments', type: 'List<TypeAnnotation>', description: ''),
+      Property('arguments', type: 'List<Argument>', description: ''),
+    ],
+  ),
+  Definition.clazz(
+    'AdjacentStringLiterals',
+    description: '',
+    properties: [
+      Property('expressions', type: 'List<Expression>', description: ''),
+    ],
+  ),
+  Definition.clazz(
+    'StringLiteral',
+    description: '',
+    properties: [
+      Property('parts', type: 'List<StringLiteralPart>', description: ''),
+    ],
+  ),
+  Definition.clazz(
+    'StringPart',
+    description: '',
+    properties: [
+      Property('text', type: 'String', description: ''),
+    ],
+  ),
+  Definition.clazz(
+    'SymbolLiteral',
+    description: '',
+    properties: [
+      Property('parts', type: 'List<String>', description: ''),
+    ],
+  ),
+  Definition.clazz(
+    'TypedefReference',
+    description: '',
+    properties: [],
+  ),
+  Definition.clazz(
+    'TypeLiteral',
+    description: '',
+    properties: [
+      Property('typeAnnotation', type: 'TypeAnnotation', description: ''),
+    ],
+  ),
+  Definition.clazz(
+    'TypeReference',
+    description: '',
+    properties: [],
+  ),
+  Definition.clazz(
+    'UnaryExpression',
+    description: '',
+    properties: [
+      Property('operator', type: 'UnaryOperator', description: ''),
+      Property('expression', type: 'Expression', description: ''),
+    ],
+  ),
+  Definition.clazz(
+    'UnresolvedExpression',
+    description: '',
+    properties: [],
+  ),
+  Definition.clazz(
+    'UnresolvedTypeAnnotation',
+    description: '',
+    properties: [],
+  ),
+  Definition.clazz(
+    'VoidTypeAnnotation',
+    description: '',
+    properties: [
+      Property('reference', type: 'Reference', description: ''),
+    ],
+  ),
+];

--- a/tool/generate_converter
+++ b/tool/generate_converter
@@ -1,0 +1,86 @@
+#!/bin/bash --
+#
+# Generates converter -->dart_model from `_fe_analyzer_shared` code.
+#
+# TODO(davidmorgan): this is intended to be single use code: delete if we don't
+# need it again, convert to Dart if we do.
+#
+# mkdir /tmp/inputs
+# cp ~/git/dart-sdk/sdk/pkg/_fe_analyzer_shared/lib/src/metadata/* /tmp/inputs
+# rm /tmp/inputs/proto.dart /tmp/inputs/parser.dart /tmp/inputs/scope.dart
+# tool/generate_converter /tmp/inputs
+
+path="$1"
+source=$(find $path -name \*.dart | xargs cat)
+IFS=$'\n'
+
+# Unions.
+for union in $(
+  echo "$source" \
+  | grep 'sealed class' \
+  | sed -e s'#sealed class ##' \
+  | sed -e 's# {##' \
+  | sort); do
+  echo "dart_model.$union? convertTo$union(Object? object) => switch (object) {"
+  for type in $(echo "$source" \
+    | grep "extends $union" \
+    | sed -e 's#abstract ##' \
+    | sed -e 's#class ##' \
+    | sed -e 's# extends .*##'); do
+    lower_first_type=${type,}
+    echo "    front_end.$type o => dart_model.$union.$lower_first_type(convert<dart_model.$type>(o)!),"
+  done
+  echo "null => null,"
+  echo "_ => throw ArgumentError(object),"
+  echo "};";
+done
+
+echo "T? convert<T>(Object? object) => switch (object) {"
+
+# Enums.
+for type in $(echo "$source" \
+  | egrep '^enum [A-Z]' \
+  | sed -e 's#enum ##' \
+  | sed -e 's# .*##' \
+  | sort); do
+  echo "front_end.$type o => o.name as T,"
+done
+
+# Classes.
+for type in $(echo "$source" \
+  | egrep '^[a-z ]*class ' \
+  | grep -v 'sealed' \
+  | sed -e 's#abstract ##' \
+  | sed -e 's#class ##' \
+  | sed -e 's# extends .*##' \
+  | sed -e 's# {##' \
+  | sort); do
+  echo "front_end.$type o => dart_model.$type("
+  for line in $(echo "$source" \
+    | grep -A1000000 "class $type extends" \
+    | tail -n +2); do
+    if echo "$line" | grep -q '  final'; then
+      field_name=$(echo $line | sed -e 's#  final ##' | sed -e 's#.* ##' | sed -e 's#;##')
+      if test "$field_name" == "unresolved"; then
+        continue
+      fi
+      field_type=$(echo $line | sed -e 's#  final ##' | sed -e 's# .*##')
+      if echo "$field_type" | egrep -q '^(Argument|Element|Expression|RecordField|Reference|StringLiteralPart)$'; then
+        echo "    $field_name: convertTo$field_type(o.$field_name),"
+      else
+        echo "    $field_name: convert(o.$field_name),"
+      fi
+    else
+      break
+    fi
+  done
+  echo ") as T,"
+done
+echo "String o => o as T,"
+echo "int o => o as T,"
+echo "bool o => o as T,"
+echo "double o => o as T,"
+echo "List o => o.map((i) => convert<Map<String, Object?>>(i)!).toList() as T,"
+echo "null => null,"
+echo "_ => throw ArgumentError(object),"
+echo "};"

--- a/tool/generate_definitions
+++ b/tool/generate_definitions
@@ -1,0 +1,98 @@
+#!/bin/bash --
+#
+# Generates dart_model definitions from `_fe_analyzer_shared` code.
+#
+# TODO(davidmorgan): this is intended to be single use code: delete if we don't
+# need it again, convert to Dart if we do.
+#
+# mkdir /tmp/inputs
+# cp ~/git/dart-sdk/sdk/pkg/_fe_analyzer_shared/lib/src/metadata/* /tmp/inputs
+# rm /tmp/inputs/proto.dart /tmp/inputs/parser.dart /tmp/inputs/scope.dart
+# tool/generate_definitions /tmp/inputs
+
+path="$1"
+source=$(find $path -name \*.dart | xargs cat)
+IFS=$'\n'
+
+echo "final definitions = ["
+
+# Unions.
+for union in $(
+  echo "$source" \
+  | grep 'sealed class' \
+  | sed -e s'#sealed class ##' \
+  | sed -e 's# {##' \
+  | sort); do
+  echo "Definition.union('$union',"
+  echo "  description: '',"
+  echo "  types: ["
+  for type in $(echo "$source" \
+    | grep "extends $union" \
+    | sed -e 's#abstract ##' \
+    | sed -e 's#class ##' \
+    | sed -e 's# extends .*##'); do
+    echo "    '$type',"
+  done
+  echo "  ],"
+  echo "  properties: [],"
+  echo "),";
+done
+
+# Enums.
+for type in $(echo "$source" \
+  | egrep '^enum [A-Z]' \
+  | sed -e 's#enum ##' \
+  | sed -e 's# .*##' \
+  | sort); do
+  echo "Definition.\$enum('$type',"
+  echo "  description: '',"
+  echo "  values: ["
+  for line in $(echo "$source" \
+    | grep -A1000000 "enum $type " \
+    | tail -n +2); do
+    if echo "$line" | grep -q ';'; then
+      break
+    else
+      value=$(echo $line | sed -e 's#  ##' | sed -e 's#(.*##')
+      echo "    '$value',"
+    fi
+  done
+  echo "  ],"
+  echo "),"
+done
+
+# Classes.
+for type in $(echo "$source" \
+  | egrep '^[a-z ]*class ' \
+  | grep -v 'sealed' \
+  | sed -e 's#abstract ##' \
+  | sed -e 's#class ##' \
+  | sed -e 's# extends .*##' \
+  | sed -e 's# {##' \
+  | sort); do
+  echo "Definition.clazz('$type',"
+  echo "  description: '',"
+  echo "  properties: ["
+  for line in $(echo "$source" \
+    | grep -A1000000 "class $type extends" \
+    | tail -n +2); do
+    if echo "$line" | grep -q '  final'; then
+      field_name=$(echo $line | sed -e 's#  final ##' | sed -e 's#.* ##' | sed -e 's#;##')
+      if test "$field_name" == "unresolved"; then
+        continue
+      fi
+      field_type=$(echo $line | sed -e 's#  final ##' | sed -e 's# .*##')
+      if echo "$field_type" | fgrep -q '?'; then
+        field_type=$(echo "$field_type" | sed -e 's#?##')
+        echo "    Property('$field_name', type: '$field_type', description: '', nullable: true),"
+      else
+        echo "    Property('$field_name', type: '$field_type', description: ''),"
+      fi
+    else
+      break
+    fi
+  done
+  echo "  ],"
+  echo "),"
+done
+echo "];"


### PR DESCRIPTION
- Two generate scripts: `generate_definitions` which generates `dart_model` definitions from `_fe_analyzer_shared` code, and `generate_converter` which generates code to convert from `_fe_analyzer_shared` code to the new `dart_model` types.
   - Neither is intended to be maintained, I'll delete if we don't need them again or rewrite if we need to iterate / use them more than once.
- Add definitions from `generate_definitions` to `macro_metadata_definitions.dart`.
- Add package `_analyzer_cfe_macros` for common code between `_analyzer_macros` and `_cfe_macros`, this code will likely end up in `_fe_analyzer_shared`.
- Add converter from `generate_converter` to `_analyzer_cfe_macros` and simple unit test.

