### PR TITLE
Add an `analysis_server` binary with `dart_model` implementation injected

### DIFF
--- a/goldens/foo/lib/json_codable_test.dart
+++ b/goldens/foo/lib/json_codable_test.dart
@@ -223,7 +223,7 @@ class A {
 
   final double doubleField;
 
-  final num numField;
+  final num numFieldXfzAbcdefgabc;
 
   final List<C> listOfSerializableField;
 

--- a/goldens/foo/lib/json_codable_test.dart
+++ b/goldens/foo/lib/json_codable_test.dart
@@ -223,7 +223,7 @@ class A {
 
   final double doubleField;
 
-  final num numFieldXfzAbcdefgabc;
+  final num numField;
 
   final List<C> listOfSerializableField;
 

--- a/pkgs/_analyzer_macros/bin/server.dart
+++ b/pkgs/_analyzer_macros/bin/server.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:io';
-
 import 'package:_analyzer_macros/macro_implementation.dart';
 import 'package:analysis_server/starter.dart';
 import 'package:analyzer/src/summary2/macro_injected_impl.dart' as injected;
@@ -14,21 +12,21 @@ import 'package:macro_service/macro_service.dart';
 /// Run with your IDE by compiling and placing in the SDK your IDE is using,
 /// for example:
 ///
-/// dart compile kernel bin/server.dart
+/// dart compile kernel -DPACKAGE_CONFIG_PATH=$HOME/git/macros/.dart_tool/package_config.json bin/server.dart
 /// cp bin/server.dill ~/opt/dart-sdk-be/bin/snapshots/analysis_server.dart.snapshot
 ///
 /// Then restart, VSCode: Ctrl+Shift+P, Restart Analysis Server.
 ///
-/// Only works for one path, see `packageConfig` path hardcoded below.
+/// Only works for one project, the one specified in the command line with
+/// `PACKAGE_CONFIG_PATH`.
 void main(List<String> args) async {
-  final home = Platform.environment['HOME']!;
   injected.macroImplementation = await AnalyzerMacroImplementation.start(
       protocol: Protocol(
           encoding: ProtocolEncoding.binary, version: ProtocolVersion.macros1),
       // TODO(davidmorgan): this needs to come from the analyzer, not be
       // hardcoded.
       packageConfig:
-          Uri.file('$home/git/macros/.dart_tool/package_config.json'));
+          Uri.file(const String.fromEnvironment('PACKAGE_CONFIG_PATH')));
 
   var starter = ServerStarter();
   starter.start(args);

--- a/pkgs/_analyzer_macros/bin/server.dart
+++ b/pkgs/_analyzer_macros/bin/server.dart
@@ -1,0 +1,35 @@
+// Copyright (c) 2024, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:_analyzer_macros/macro_implementation.dart';
+import 'package:analysis_server/starter.dart';
+import 'package:analyzer/src/summary2/macro_injected_impl.dart' as injected;
+import 'package:macro_service/macro_service.dart';
+
+/// Analysis server with `dart_model` implementation injected.
+///
+/// Run with your IDE by compiling and placing in the SDK your IDE is using,
+/// for example:
+///
+/// dart compile kernel bin/server.dart
+/// cp bin/server.dill ~/opt/dart-sdk-be/bin/snapshots/analysis_server.dart.snapshot
+///
+/// Then restart, VSCode: Ctrl+Shift+P, Restart Analysis Server.
+///
+/// Only works for one path, see `packageConfig` path hardcoded below.
+void main(List<String> args) async {
+  final home = Platform.environment['HOME']!;
+  injected.macroImplementation = await AnalyzerMacroImplementation.start(
+      protocol: Protocol(
+          encoding: ProtocolEncoding.binary, version: ProtocolVersion.macros1),
+      // TODO(davidmorgan): this needs to come from the analyzer, not be
+      // hardcoded.
+      packageConfig:
+          Uri.file('$home/git/macros/.dart_tool/package_config.json'));
+
+  var starter = ServerStarter();
+  starter.start(args);
+}

--- a/pkgs/_analyzer_macros/pubspec.yaml
+++ b/pkgs/_analyzer_macros/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 dependencies:
   _macro_host: any
   analyzer: any
+  analysis_server: any
   dart_model: any
   macro_service: any
   macros: any

--- a/pkgs/_analyzer_macros/pubspec.yaml
+++ b/pkgs/_analyzer_macros/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 
 dependencies:
   _macro_host: any
-  analyzer: any
   analysis_server: any
+  analyzer: any
   dart_model: any
   macro_service: any
   macros: any

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,10 +39,20 @@ dependency_overrides:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/_macros
       ref: a8bee55e94979730890500026884afcf33e68f2f
+  analysis_server:
+    git:
+      url: https://github.com/dart-lang/sdk.git
+      path: pkg/analysis_server
+      ref: a8bee55e94979730890500026884afcf33e68f2f
   analyzer:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/analyzer
+      ref: a8bee55e94979730890500026884afcf33e68f2f
+  analyzer_plugin:
+    git:
+      url: https://github.com/dart-lang/sdk.git
+      path: pkg/analyzer_plugin
       ref: a8bee55e94979730890500026884afcf33e68f2f
   analyzer_utilities:
     git:
@@ -109,6 +119,16 @@ dependency_overrides:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/kernel
       ref: a8bee55e94979730890500026884afcf33e68f2f
+  analysis_server_plugin:
+    git:
+      url: https://github.com/dart-lang/sdk.git
+      path: pkg/analysis_server_plugin
+      ref: a8bee55e94979730890500026884afcf33e68f2f
+  language_server_protocol:
+    git:
+      url: https://github.com/dart-lang/sdk.git
+      path: third_party/pkg/language_server_protocol
+      ref: a8bee55e94979730890500026884afcf33e68f2f
   linter:
     git:
       url: https://github.com/dart-lang/sdk.git
@@ -118,6 +138,11 @@ dependency_overrides:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/mmap
+      ref: a8bee55e94979730890500026884afcf33e68f2f
+  telemetry:
+    git:
+      url: https://github.com/dart-lang/sdk.git
+      path: pkg/telemetry
       ref: a8bee55e94979730890500026884afcf33e68f2f
   vm:
     git:


### PR DESCRIPTION
There are definitely some correctness issues, in particular it looks like the cached results from with no macro impl injected prevent macros running, so I had to add some change to trigger macros.

But it does work interactively on e.g. `json_codable_test.dart`.