### PR TITLE
Add support for definitions implementing other definitions

### DIFF
--- a/pkgs/dart_model/lib/src/dart_model.g.dart
+++ b/pkgs/dart_model/lib/src/dart_model.g.dart
@@ -137,29 +137,50 @@ extension type MetadataAnnotation.fromJson(Map<String, Object?> node)
   QualifiedName get type => node['type'] as QualifiedName;
 }
 
-/// An interface.
-extension type Interface.fromJson(Map<String, Object?> node) implements Object {
+/// Base type for all declarations
+extension type Declaration.fromJson(Map<String, Object?> node)
+    implements Object {
   static final TypedMapSchema _schema = TypedMapSchema({
     'metadataAnnotations': Type.closedListPointer,
-    'members': Type.growableMapPointer,
-    'thisType': Type.typedMapPointer,
     'properties': Type.typedMapPointer,
   });
-  Interface({
+  Declaration({
     List<MetadataAnnotation>? metadataAnnotations,
-    NamedTypeDesc? thisType,
     Properties? properties,
   }) : this.fromJson(Scope.createMap(
           _schema,
           metadataAnnotations,
-          Scope.createGrowableMap(),
-          thisType,
           properties,
         ));
 
-  /// The metadata annotations attached to this interface.
+  /// The metadata annotations attached to this declaration.
   List<MetadataAnnotation> get metadataAnnotations =>
       (node['metadataAnnotations'] as List).cast();
+
+  /// The properties of this declaration.
+  Properties get properties => node['properties'] as Properties;
+}
+
+/// An interface.
+extension type Interface.fromJson(Map<String, Object?> node)
+    implements Declaration {
+  static final TypedMapSchema _schema = TypedMapSchema({
+    'members': Type.growableMapPointer,
+    'thisType': Type.typedMapPointer,
+    'metadataAnnotations': Type.closedListPointer,
+    'properties': Type.typedMapPointer,
+  });
+  Interface({
+    NamedTypeDesc? thisType,
+    List<MetadataAnnotation>? metadataAnnotations,
+    Properties? properties,
+  }) : this.fromJson(Scope.createMap(
+          _schema,
+          Scope.createGrowableMap(),
+          thisType,
+          metadataAnnotations,
+          properties,
+        ));
 
   /// Map of members by name.
   Map<String, Member> get members =>
@@ -167,9 +188,6 @@ extension type Interface.fromJson(Map<String, Object?> node) implements Object {
 
   /// The type of the expression `this` when used in this interface.
   NamedTypeDesc get thisType => node['thisType'] as NamedTypeDesc;
-
-  /// The properties of this interface.
-  Properties get properties => node['properties'] as Properties;
 }
 
 /// Library.
@@ -189,31 +207,32 @@ extension type Library.fromJson(Map<String, Object?> node) implements Object {
 }
 
 /// Member of a scope.
-extension type Member.fromJson(Map<String, Object?> node) implements Object {
+extension type Member.fromJson(Map<String, Object?> node)
+    implements Declaration {
   static final TypedMapSchema _schema = TypedMapSchema({
-    'properties': Type.typedMapPointer,
     'returnType': Type.typedMapPointer,
     'requiredPositionalParameters': Type.closedListPointer,
     'optionalPositionalParameters': Type.closedListPointer,
     'namedParameters': Type.closedListPointer,
+    'metadataAnnotations': Type.closedListPointer,
+    'properties': Type.typedMapPointer,
   });
   Member({
-    Properties? properties,
     StaticTypeDesc? returnType,
     List<StaticTypeDesc>? requiredPositionalParameters,
     List<StaticTypeDesc>? optionalPositionalParameters,
     List<NamedFunctionTypeParameter>? namedParameters,
+    List<MetadataAnnotation>? metadataAnnotations,
+    Properties? properties,
   }) : this.fromJson(Scope.createMap(
           _schema,
-          properties,
           returnType,
           requiredPositionalParameters,
           optionalPositionalParameters,
           namedParameters,
+          metadataAnnotations,
+          properties,
         ));
-
-  /// The properties of this member.
-  Properties get properties => node['properties'] as Properties;
 
   /// The return type of this member, if it has one.
   StaticTypeDesc get returnType => node['returnType'] as StaticTypeDesc;

--- a/pkgs/dart_model/lib/src/dart_model.g.dart
+++ b/pkgs/dart_model/lib/src/dart_model.g.dart
@@ -137,22 +137,8 @@ extension type MetadataAnnotation.fromJson(Map<String, Object?> node)
   QualifiedName get type => node['type'] as QualifiedName;
 }
 
-/// Base type for all declarations
-extension type Declaration.fromJson(Map<String, Object?> node)
-    implements Object {
-  static final TypedMapSchema _schema = TypedMapSchema({
-    'metadataAnnotations': Type.closedListPointer,
-    'properties': Type.typedMapPointer,
-  });
-  Declaration({
-    List<MetadataAnnotation>? metadataAnnotations,
-    Properties? properties,
-  }) : this.fromJson(Scope.createMap(
-          _schema,
-          metadataAnnotations,
-          properties,
-        ));
-
+/// Interface type for all declarations
+extension type Declaration._(Map<String, Object?> node) implements Object {
   /// The metadata annotations attached to this declaration.
   List<MetadataAnnotation> get metadataAnnotations =>
       (node['metadataAnnotations'] as List).cast();

--- a/schemas/dart_model.schema.json
+++ b/schemas/dart_model.schema.json
@@ -91,23 +91,6 @@
         }
       }
     },
-    "Declaration": {
-      "type": "object",
-      "description": "Base type for all declarations",
-      "properties": {
-        "metadataAnnotations": {
-          "type": "array",
-          "description": "The metadata annotations attached to this declaration.",
-          "items": {
-            "$ref": "#/$defs/MetadataAnnotation"
-          }
-        },
-        "properties": {
-          "$comment": "The properties of this declaration.",
-          "$ref": "#/$defs/Properties"
-        }
-      }
-    },
     "Interface": {
       "type": "object",
       "description": "An interface.",

--- a/schemas/dart_model.schema.json
+++ b/schemas/dart_model.schema.json
@@ -91,17 +91,27 @@
         }
       }
     },
-    "Interface": {
+    "Declaration": {
       "type": "object",
-      "description": "An interface.",
+      "description": "Base type for all declarations",
       "properties": {
         "metadataAnnotations": {
           "type": "array",
-          "description": "The metadata annotations attached to this interface.",
+          "description": "The metadata annotations attached to this declaration.",
           "items": {
             "$ref": "#/$defs/MetadataAnnotation"
           }
         },
+        "properties": {
+          "$comment": "The properties of this declaration.",
+          "$ref": "#/$defs/Properties"
+        }
+      }
+    },
+    "Interface": {
+      "type": "object",
+      "description": "An interface.",
+      "properties": {
         "members": {
           "type": "object",
           "description": "Map of members by name.",
@@ -113,8 +123,15 @@
           "$comment": "The type of the expression `this` when used in this interface.",
           "$ref": "#/$defs/NamedTypeDesc"
         },
+        "metadataAnnotations": {
+          "type": "array",
+          "description": "The metadata annotations attached to this declaration.",
+          "items": {
+            "$ref": "#/$defs/MetadataAnnotation"
+          }
+        },
         "properties": {
-          "$comment": "The properties of this interface.",
+          "$comment": "The properties of this declaration.",
           "$ref": "#/$defs/Properties"
         }
       }
@@ -136,10 +153,6 @@
       "type": "object",
       "description": "Member of a scope.",
       "properties": {
-        "properties": {
-          "$comment": "The properties of this member.",
-          "$ref": "#/$defs/Properties"
-        },
         "returnType": {
           "$comment": "The return type of this member, if it has one.",
           "$ref": "#/$defs/StaticTypeDesc"
@@ -164,6 +177,17 @@
           "items": {
             "$ref": "#/$defs/NamedFunctionTypeParameter"
           }
+        },
+        "metadataAnnotations": {
+          "type": "array",
+          "description": "The metadata annotations attached to this declaration.",
+          "items": {
+            "$ref": "#/$defs/MetadataAnnotation"
+          }
+        },
+        "properties": {
+          "$comment": "The properties of this declaration.",
+          "$ref": "#/$defs/Properties"
         }
       }
     },

--- a/tool/dart_model_generator/lib/definitions.dart
+++ b/tool/dart_model_generator/lib/definitions.dart
@@ -109,15 +109,26 @@ static Protocol handshakeProtocol = Protocol(
                   type: 'QualifiedName',
                   description: 'The type of the annotation.'),
             ]),
+        Definition.clazz('Declaration',
+            description: 'Base type for all declarations',
+            createInBuffer: true,
+            properties: [
+              Property('metadataAnnotations',
+                  type: 'List<MetadataAnnotation>',
+                  description:
+                      'The metadata annotations attached to this declaration.'),
+              Property('properties',
+                  type: 'Properties',
+                  description: 'The properties of this declaration.'),
+            ]),
         Definition.clazz(
           'Interface',
           description: 'An interface.',
           createInBuffer: true,
+          implements: [
+            'Declaration',
+          ],
           properties: [
-            Property('metadataAnnotations',
-                type: 'List<MetadataAnnotation>',
-                description:
-                    'The metadata annotations attached to this interface.'),
             Property('members',
                 type: 'Map<Member>', description: 'Map of members by name.'),
             Property('thisType',
@@ -125,9 +136,6 @@ static Protocol handshakeProtocol = Protocol(
                 description:
                     'The type of the expression `this` when used in this '
                     'interface.'),
-            Property('properties',
-                type: 'Properties',
-                description: 'The properties of this interface.'),
           ],
         ),
         Definition.clazz('Library',
@@ -141,10 +149,10 @@ static Protocol handshakeProtocol = Protocol(
         Definition.clazz('Member',
             description: 'Member of a scope.',
             createInBuffer: true,
+            implements: [
+              'Declaration',
+            ],
             properties: [
-              Property('properties',
-                  type: 'Properties',
-                  description: 'The properties of this member.'),
               Property(
                 'returnType',
                 type: 'StaticTypeDesc',

--- a/tool/dart_model_generator/lib/definitions.dart
+++ b/tool/dart_model_generator/lib/definitions.dart
@@ -110,8 +110,8 @@ static Protocol handshakeProtocol = Protocol(
                   description: 'The type of the annotation.'),
             ]),
         Definition.clazz('Declaration',
-            description: 'Base type for all declarations',
-            createInBuffer: true,
+            description: 'Interface type for all declarations',
+            interfaceOnly: true,
             properties: [
               Property('metadataAnnotations',
                   type: 'List<MetadataAnnotation>',


### PR DESCRIPTION
Towards https://github.com/dart-lang/macros/issues/103

Adds an `implements` list to `Definition.clazz`, which:

- Replaces the default `implements Object` and instead lists all the implemented types (which transitively gives `Object`).
- Adds all inherited properties and associated code to the constructors and schemas
- Does not re-generate getters, these are inherited via `Implements`

I also added a base type `Declaration` because it is both useful and also serves as an example usage.

I think one good follow-up would be to add `is<Type>` and `as<Type>` getters to anything which is implemented by another type, for each of the types which implement it. We at least need some mechanism for down casting extension types to their known subtypes. One tricky part with that though is ideally we don't want to inherit those methods in the subtypes, because they won't all make sense?