### PR TITLE
Add benchmark_generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 **/.dart_tool
 **/pubspec.lock
+goldens/foo/lib/generated/**

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ workspace:
   - pkgs/dart_model
   - pkgs/macro
   - pkgs/macro_service
+  - tool/benchmark_generator
   - tool/dart_model_generator
 
 # Update by running: tool/set_sdk_version <git ref>

--- a/tool/benchmark_generator/README.md
+++ b/tool/benchmark_generator/README.md
@@ -1,0 +1,16 @@
+# Benchmark Generator
+
+Generates code that uses macros, for benchmarking.
+
+Example use:
+
+```
+dart bin/main.dart large macro 64
+dart ~/git/macros/pkgs/_macro_tool/bin/main.dart \
+    --workspace=$HOME/git/macros/goldens/foo \
+    --packageConfig=$HOME/git/macros/.dart_tool/package_config.json \
+    --script=$HOME/git/macros/goldens/foo/lib/generated/large/a0.dart \
+    --host=analyzer --watch
+```
+
+then change `goldens/foo/lib/generated/large/a0.dart` to see the refresh time.

--- a/tool/benchmark_generator/bin/main.dart
+++ b/tool/benchmark_generator/bin/main.dart
@@ -1,0 +1,32 @@
+// Copyright (c) 2024, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:benchmark_generator/json_encodable/input_generator.dart';
+import 'package:benchmark_generator/workspace.dart';
+
+Future<void> main(List<String> arguments) async {
+  if (arguments.length != 3) {
+    print('''
+Creates packages to benchmark macro performance. Usage:
+
+  dart bin/main_json.dart <workspace name> <macro|manual|none> <# libraries>
+''');
+    exit(1);
+  }
+
+  final workspaceName = arguments[0];
+  final strategy = Strategy.values.where((e) => e.name == arguments[1]).single;
+  final libraryCount = int.parse(arguments[2]);
+
+  final workspace = Workspace(workspaceName);
+  print('Creating under: ${workspace.directory.path}');
+  final inputGenerator = JsonEncodableInputGenerator(
+      fieldsPerClass: 100,
+      classesPerLibrary: 10,
+      librariesPerCycle: libraryCount,
+      strategy: strategy);
+  inputGenerator.generate(workspace);
+}

--- a/tool/benchmark_generator/lib/json_encodable/input_generator.dart
+++ b/tool/benchmark_generator/lib/json_encodable/input_generator.dart
@@ -1,0 +1,127 @@
+// Copyright (c) 2024, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:benchmark_generator/random.dart';
+import 'package:benchmark_generator/workspace.dart';
+
+enum Strategy {
+  manual,
+  macro,
+  none;
+
+  String annotation(String name) {
+    switch (this) {
+      case Strategy.manual:
+      case Strategy.none:
+        return '';
+      case Strategy.macro:
+        return '@m.$name()';
+    }
+  }
+}
+
+class JsonEncodableInputGenerator {
+  final int fieldsPerClass;
+  final int classesPerLibrary;
+  final int librariesPerCycle;
+  final Strategy strategy;
+
+  JsonEncodableInputGenerator(
+      {required this.fieldsPerClass,
+      required this.classesPerLibrary,
+      required this.librariesPerCycle,
+      required this.strategy});
+
+  void generate(Workspace workspace) {
+    for (var i = 0; i != librariesPerCycle; ++i) {
+      workspace.write('a$i.dart', source: _generateLibrary(i));
+    }
+  }
+
+  String _generateLibrary(int index,
+      {bool topLevelCacheBuster = false, bool fieldCacheBuster = false}) {
+    final buffer = StringBuffer();
+
+    if (strategy == Strategy.macro) {
+      buffer.writeln("import 'package:_test_macros/json_codable.dart';");
+    }
+
+    if (librariesPerCycle != 1) {
+      final nextLibrary = (index + 1) % librariesPerCycle;
+      buffer.writeln('import "a$nextLibrary.dart" as next_in_cycle;');
+      buffer.writeln('next_in_cycle.A0? referenceOther;');
+    }
+
+    if (topLevelCacheBuster) {
+      buffer.writeln('int? cacheBuster$largeRandom;');
+    }
+
+    for (var j = 0; j != classesPerLibrary; ++j) {
+      buffer.write(_generateClass(j, fieldCacheBuster: fieldCacheBuster));
+    }
+
+    return buffer.toString();
+  }
+
+  String _generateClass(int index, {required bool fieldCacheBuster}) {
+    final className = 'A$index';
+    String fieldName(int index) => 'a$index';
+
+    final result =
+        StringBuffer(strategy == Strategy.macro ? '@JsonCodable()' : '');
+
+    result.writeln('class $className {');
+    result.writeln('''
+  // TODO(davidmorgan): see https://github.com/dart-lang/macros/issues/80.
+  external $className.fromJson(Map<String, Object?> json);
+  external Map<String, Object?> toJson();''');
+
+    if (fieldCacheBuster) {
+      result.writeln('int? b$largeRandom;');
+    }
+    for (var i = 0; i != fieldsPerClass; ++i) {
+      result.writeln('int? ${fieldName(i)};');
+    }
+
+    if (strategy == Strategy.manual) {
+      result.writeln('$className._({');
+      for (var i = 0; i != fieldsPerClass; ++i) {
+        result.writeln('required this.${fieldName(i)},');
+      }
+      result.writeln('});');
+
+      result.writeln('Map<String, Object?> toJson() {');
+      result.writeln('  final result = <String, Object?>{};');
+      for (var i = 0; i != fieldsPerClass; ++i) {
+        result.writeln(
+            "if (${fieldName(i)} != null) result['${fieldName(i)}'] = ${fieldName(i)};");
+      }
+      result.writeln('return result;');
+      result.writeln('}');
+      result
+          .writeln('factory $className.fromJson(Map<String, Object?> json) {');
+      result.writeln('return $className._(');
+      for (var i = 0; i != fieldsPerClass; ++i) {
+        result.writeln("${fieldName(i)}: json['${fieldName(i)}'] as int,");
+      }
+      result.writeln(');');
+      result.writeln('}');
+    }
+
+    result.writeln('}');
+    return result.toString();
+  }
+
+  void changeIrrelevantInput(Workspace workspace) {
+    workspace.write('a0.dart',
+        source: _generateLibrary(0, topLevelCacheBuster: true));
+  }
+
+  void changeRevelantInput(Workspace workspace) {
+    workspace.write('a0.dart',
+        source: _generateLibrary(0, fieldCacheBuster: true));
+  }
+}

--- a/tool/benchmark_generator/lib/random.dart
+++ b/tool/benchmark_generator/lib/random.dart
@@ -1,0 +1,9 @@
+// Copyright (c) 2024, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:math';
+
+final _random = Random.secure();
+int get largeRandom =>
+    _random.nextInt(0xFFFFFFFF) + (_random.nextInt(0x7FFFFFFF) << 32);

--- a/tool/benchmark_generator/lib/workspace.dart
+++ b/tool/benchmark_generator/lib/workspace.dart
@@ -1,0 +1,23 @@
+// Copyright (c) 2024, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+class Workspace {
+  final String name;
+
+  Directory get directory => Directory.fromUri(
+      Platform.script.resolve('../../../goldens/foo/lib/generated/$name'));
+
+  Workspace(this.name) {
+    if (directory.existsSync()) directory.deleteSync(recursive: true);
+    directory.createSync(recursive: true);
+  }
+
+  void write(String path, {required String source}) {
+    final file = File.fromUri(directory.uri.resolve('$path'));
+    file.parent.createSync(recursive: true);
+    file.writeAsStringSync(source);
+  }
+}

--- a/tool/benchmark_generator/pubspec.yaml
+++ b/tool/benchmark_generator/pubspec.yaml
@@ -1,0 +1,9 @@
+name: benchmark_generator
+publish-to: none
+resolution: workspace
+environment:
+  sdk: ^3.7.0-39.0.dev
+
+dev_dependencies:
+  dart_flutter_team_lints: ^3.0.0
+  test: ^1.25.7


### PR DESCRIPTION
This is mostly old code, there is a bit of unused code around adding random "cache busters" which will be needed for any kind of actual benchmark.

Running like this:

```
dart bin/main.dart large macro 64
```

Generates source under `goldens/foo/lib/generated/large` which can be run with

```
dart ~/git/macros/pkgs/_macro_tool/bin/main.dart \
    --workspace=$HOME/git/macros/goldens/foo \
    --packageConfig=$HOME/git/macros/.dart_tool/package_config.json \
    --script=$HOME/git/macros/goldens/foo/lib/generated/large/a0.dart \
    --host=analyzer --watch
```

which on changing `a0.dart` shows a refresh time of ~9s. Digging through my old spreadsheets I found "9.289s" as the entry for this benchmark with the v1 macro, so it looks like we are equal or even slightly faster :) ... the v2 macro still needs a bit more error checking though.