### PR TITLE
Return macro metadata from analyzer.

### DIFF
--- a/goldens/foo/lib/foo.analyzer.json
+++ b/goldens/foo/lib/foo.analyzer.json
@@ -5,14 +5,6 @@
         "Foo": {
           "members": {
             "construct": {
-              "properties": {
-                "isAbstract": false,
-                "isConstructor": true,
-                "isGetter": false,
-                "isField": false,
-                "isMethod": false,
-                "isStatic": false
-              },
               "requiredPositionalParameters": [
                 {
                   "type": "NamedTypeDesc",
@@ -37,9 +29,7 @@
                     "instantiation": []
                   }
                 }
-              ]
-            },
-            "construct2": {
+              ],
               "properties": {
                 "isAbstract": false,
                 "isConstructor": true,
@@ -47,7 +37,9 @@
                 "isField": false,
                 "isMethod": false,
                 "isStatic": false
-              },
+              }
+            },
+            "construct2": {
               "requiredPositionalParameters": [
                 {
                   "type": "NamedTypeDesc",
@@ -77,17 +69,17 @@
                   }
                 }
               ],
-              "namedParameters": []
-            },
-            "bar": {
+              "namedParameters": [],
               "properties": {
                 "isAbstract": false,
-                "isConstructor": false,
+                "isConstructor": true,
                 "isGetter": false,
-                "isField": true,
+                "isField": false,
                 "isMethod": false,
                 "isStatic": false
-              },
+              }
+            },
+            "bar": {
               "returnType": {
                 "type": "NamedTypeDesc",
                 "value": {
@@ -97,17 +89,17 @@
                   },
                   "instantiation": []
                 }
-              }
-            },
-            "method": {
+              },
               "properties": {
                 "isAbstract": false,
                 "isConstructor": false,
                 "isGetter": false,
-                "isField": false,
-                "isMethod": true,
+                "isField": true,
+                "isMethod": false,
                 "isStatic": false
-              },
+              }
+            },
+            "method": {
               "returnType": {
                 "type": "VoidTypeDesc"
               },
@@ -140,9 +132,7 @@
                     }
                   }
                 }
-              ]
-            },
-            "method2": {
+              ],
               "properties": {
                 "isAbstract": false,
                 "isConstructor": false,
@@ -150,7 +140,9 @@
                 "isField": false,
                 "isMethod": true,
                 "isStatic": false
-              },
+              }
+            },
+            "method2": {
               "returnType": {
                 "type": "NullableTypeDesc",
                 "value": {
@@ -195,9 +187,35 @@
                   }
                 }
               ],
-              "namedParameters": []
+              "namedParameters": [],
+              "properties": {
+                "isAbstract": false,
+                "isConstructor": false,
+                "isGetter": false,
+                "isField": false,
+                "isMethod": true,
+                "isStatic": false
+              }
             }
           },
+          "metadataAnnotations": [
+            {
+              "expression": {
+                "type": {
+                  "reference": {
+                    "type": "ClassReference",
+                    "value": {}
+                  },
+                  "typeArguments": []
+                },
+                "constructor": {
+                  "type": "ConstructorReference",
+                  "value": {}
+                },
+                "arguments": []
+              }
+            }
+          ],
           "properties": {
             "isClass": true
           }
@@ -205,6 +223,9 @@
         "Bar": {
           "members": {
             "": {
+              "requiredPositionalParameters": [],
+              "optionalPositionalParameters": [],
+              "namedParameters": [],
               "properties": {
                 "isAbstract": false,
                 "isConstructor": true,
@@ -212,20 +233,9 @@
                 "isField": false,
                 "isMethod": false,
                 "isStatic": false
-              },
-              "requiredPositionalParameters": [],
-              "optionalPositionalParameters": [],
-              "namedParameters": []
+              }
             },
             "bar": {
-              "properties": {
-                "isAbstract": false,
-                "isConstructor": false,
-                "isGetter": false,
-                "isField": true,
-                "isMethod": false,
-                "isStatic": false
-              },
               "returnType": {
                 "type": "NamedTypeDesc",
                 "value": {
@@ -235,9 +245,35 @@
                   },
                   "instantiation": []
                 }
+              },
+              "properties": {
+                "isAbstract": false,
+                "isConstructor": false,
+                "isGetter": false,
+                "isField": true,
+                "isMethod": false,
+                "isStatic": false
               }
             }
           },
+          "metadataAnnotations": [
+            {
+              "expression": {
+                "type": {
+                  "reference": {
+                    "type": "ClassReference",
+                    "value": {}
+                  },
+                  "typeArguments": []
+                },
+                "constructor": {
+                  "type": "ConstructorReference",
+                  "value": {}
+                },
+                "arguments": []
+              }
+            }
+          ],
           "properties": {
             "isClass": true
           }

--- a/goldens/foo/lib/foo.analyzer.json
+++ b/goldens/foo/lib/foo.analyzer.json
@@ -201,18 +201,21 @@
           "metadataAnnotations": [
             {
               "expression": {
-                "type": {
-                  "reference": {
-                    "type": "ClassReference",
+                "type": "ConstructorInvocation",
+                "value": {
+                  "type": {
+                    "reference": {
+                      "type": "ClassReference",
+                      "value": {}
+                    },
+                    "typeArguments": []
+                  },
+                  "constructor": {
+                    "type": "ConstructorReference",
                     "value": {}
                   },
-                  "typeArguments": []
-                },
-                "constructor": {
-                  "type": "ConstructorReference",
-                  "value": {}
-                },
-                "arguments": []
+                  "arguments": []
+                }
               }
             }
           ],
@@ -259,18 +262,21 @@
           "metadataAnnotations": [
             {
               "expression": {
-                "type": {
-                  "reference": {
-                    "type": "ClassReference",
+                "type": "ConstructorInvocation",
+                "value": {
+                  "type": {
+                    "reference": {
+                      "type": "ClassReference",
+                      "value": {}
+                    },
+                    "typeArguments": []
+                  },
+                  "constructor": {
+                    "type": "ConstructorReference",
                     "value": {}
                   },
-                  "typeArguments": []
-                },
-                "constructor": {
-                  "type": "ConstructorReference",
-                  "value": {}
-                },
-                "arguments": []
+                  "arguments": []
+                }
               }
             }
           ],

--- a/goldens/foo/lib/metadata.analyzer.json
+++ b/goldens/foo/lib/metadata.analyzer.json
@@ -1,0 +1,164 @@
+{
+  "uris": {
+    "package:foo/metadata.dart": {
+      "scopes": {
+        "Foo": {
+          "members": {
+            "": {
+              "requiredPositionalParameters": [],
+              "optionalPositionalParameters": [],
+              "namedParameters": [],
+              "properties": {
+                "isAbstract": false,
+                "isConstructor": true,
+                "isGetter": false,
+                "isField": false,
+                "isMethod": false,
+                "isStatic": false
+              }
+            }
+          },
+          "metadataAnnotations": [
+            {
+              "expression": {
+                "type": {
+                  "reference": {
+                    "type": "ClassReference",
+                    "value": {}
+                  },
+                  "typeArguments": []
+                },
+                "constructor": {
+                  "type": "ConstructorReference",
+                  "value": {}
+                },
+                "arguments": []
+              }
+            },
+            {
+              "expression": {
+                "type": {
+                  "reference": {
+                    "type": "ClassReference",
+                    "value": {}
+                  },
+                  "typeArguments": []
+                },
+                "constructor": {
+                  "type": "ConstructorReference",
+                  "value": {}
+                },
+                "arguments": [
+                  {
+                    "name": "aBool",
+                    "expression": {
+                      "type": "BooleanLiteral",
+                      "value": {
+                        "text": "true"
+                      }
+                    }
+                  },
+                  {
+                    "name": "anInt",
+                    "expression": {
+                      "type": "IntegerLiteral",
+                      "value": {
+                        "text": "23"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "properties": {
+            "isClass": true
+          }
+        }
+      }
+    }
+  },
+  "types": {
+    "named": {
+      "dart:core#Object": {
+        "typeParameters": [],
+        "self": {
+          "name": {
+            "uri": "dart:core",
+            "name": "Object"
+          },
+          "instantiation": []
+        },
+        "supertypes": []
+      },
+      "dart:core#Null": {
+        "typeParameters": [],
+        "self": {
+          "name": {
+            "uri": "dart:core",
+            "name": "Null"
+          },
+          "instantiation": []
+        },
+        "supertypes": [
+          {
+            "name": {
+              "uri": "dart:core",
+              "name": "Object"
+            },
+            "instantiation": []
+          }
+        ]
+      },
+      "dart:async#Future": {
+        "typeParameters": [
+          {
+            "identifier": 0
+          }
+        ],
+        "self": {
+          "name": {
+            "uri": "dart:async",
+            "name": "Future"
+          },
+          "instantiation": [
+            {
+              "type": "TypeParameterTypeDesc",
+              "value": {
+                "parameterId": 0
+              }
+            }
+          ]
+        },
+        "supertypes": [
+          {
+            "name": {
+              "uri": "dart:core",
+              "name": "Object"
+            },
+            "instantiation": []
+          }
+        ]
+      },
+      "package:foo/metadata.dart#Foo": {
+        "typeParameters": [],
+        "self": {
+          "name": {
+            "uri": "package:foo/metadata.dart",
+            "name": "Foo"
+          },
+          "instantiation": []
+        },
+        "supertypes": [
+          {
+            "name": {
+              "uri": "dart:core",
+              "name": "Object"
+            },
+            "instantiation": []
+          }
+        ]
+      }
+    }
+  }
+}

--- a/goldens/foo/lib/metadata.analyzer.json
+++ b/goldens/foo/lib/metadata.analyzer.json
@@ -21,53 +21,59 @@
           "metadataAnnotations": [
             {
               "expression": {
-                "type": {
-                  "reference": {
-                    "type": "ClassReference",
+                "type": "ConstructorInvocation",
+                "value": {
+                  "type": {
+                    "reference": {
+                      "type": "ClassReference",
+                      "value": {}
+                    },
+                    "typeArguments": []
+                  },
+                  "constructor": {
+                    "type": "ConstructorReference",
                     "value": {}
                   },
-                  "typeArguments": []
-                },
-                "constructor": {
-                  "type": "ConstructorReference",
-                  "value": {}
-                },
-                "arguments": []
+                  "arguments": []
+                }
               }
             },
             {
               "expression": {
-                "type": {
-                  "reference": {
-                    "type": "ClassReference",
+                "type": "ConstructorInvocation",
+                "value": {
+                  "type": {
+                    "reference": {
+                      "type": "ClassReference",
+                      "value": {}
+                    },
+                    "typeArguments": []
+                  },
+                  "constructor": {
+                    "type": "ConstructorReference",
                     "value": {}
                   },
-                  "typeArguments": []
-                },
-                "constructor": {
-                  "type": "ConstructorReference",
-                  "value": {}
-                },
-                "arguments": [
-                  {
-                    "name": "aBool",
-                    "expression": {
-                      "type": "BooleanLiteral",
-                      "value": {
-                        "text": "true"
+                  "arguments": [
+                    {
+                      "name": "aBool",
+                      "expression": {
+                        "type": "BooleanLiteral",
+                        "value": {
+                          "text": "true"
+                        }
+                      }
+                    },
+                    {
+                      "name": "anInt",
+                      "expression": {
+                        "type": "IntegerLiteral",
+                        "value": {
+                          "text": "23"
+                        }
                       }
                     }
-                  },
-                  {
-                    "name": "anInt",
-                    "expression": {
-                      "type": "IntegerLiteral",
-                      "value": {
-                        "text": "23"
-                      }
-                    }
-                  }
-                ]
+                  ]
+                }
               }
             }
           ],

--- a/goldens/foo/lib/metadata.dart
+++ b/goldens/foo/lib/metadata.dart
@@ -1,0 +1,16 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:_test_macros/query_class.dart';
+
+@QueryClass()
+@Annotation(aBool: true, anInt: 23)
+class Foo {}
+
+class Annotation {
+  final bool aBool;
+  final int anInt;
+
+  const Annotation({required this.aBool, required this.anInt});
+}

--- a/pkgs/_analyzer_cfe_macros/test/metadata_converter_test.dart
+++ b/pkgs/_analyzer_cfe_macros/test/metadata_converter_test.dart
@@ -4,20 +4,23 @@
 
 import 'package:_analyzer_cfe_macros/metadata_converter.dart';
 import 'package:_fe_analyzer_shared/src/metadata/ast.dart';
+import 'package:dart_model/dart_model.dart';
 import 'package:test/test.dart';
 
 void main() {
   test('converts with unions', () {
     final invocation = MethodInvocation(DoubleLiteral('1.23'), 'round', [], []);
 
-    expect(convert<Object>(invocation), <String, Object?>{
-      'receiver': {
-        'type': 'DoubleLiteral',
-        'value': {'text': '1.23'}
-      },
-      'name': 'round',
-      'typeArguments': [],
-      'arguments': [],
+    Scope.query.run(() {
+      expect(convert<Object>(invocation), <String, Object?>{
+        'receiver': {
+          'type': 'DoubleLiteral',
+          'value': {'text': '1.23'}
+        },
+        'name': 'round',
+        'typeArguments': [],
+        'arguments': [],
+      });
     });
   });
 
@@ -25,16 +28,18 @@ void main() {
     final expression = BinaryExpression(
         DoubleLiteral('1.23'), BinaryOperator.minus, DoubleLiteral('1.24'));
 
-    expect(convert<Object>(expression), <String, Object?>{
-      'left': {
-        'type': 'DoubleLiteral',
-        'value': {'text': '1.23'}
-      },
-      'operator': 'minus',
-      'right': {
-        'type': 'DoubleLiteral',
-        'value': {'text': '1.24'}
-      }
+    Scope.query.run(() {
+      expect(convert<Object>(expression), <String, Object?>{
+        'left': {
+          'type': 'DoubleLiteral',
+          'value': {'text': '1.23'}
+        },
+        'operator': 'minus',
+        'right': {
+          'type': 'DoubleLiteral',
+          'value': {'text': '1.24'}
+        }
+      });
     });
   });
 
@@ -42,21 +47,23 @@ void main() {
     final invocation = MethodInvocation(DoubleLiteral('1.23'), 'round', [],
         [PositionalArgument(IntegerLiteral('4'))]);
 
-    expect(convert<Object>(invocation), <String, Object?>{
-      'receiver': {
-        'type': 'DoubleLiteral',
-        'value': {'text': '1.23'}
-      },
-      'name': 'round',
-      'typeArguments': [],
-      'arguments': [
-        {
-          'expression': {
-            'type': 'IntegerLiteral',
-            'value': {'text': '4'}
+    Scope.query.run(() {
+      expect(convert<Object>(invocation), <String, Object?>{
+        'receiver': {
+          'type': 'DoubleLiteral',
+          'value': {'text': '1.23'}
+        },
+        'name': 'round',
+        'typeArguments': [],
+        'arguments': [
+          {
+            'expression': {
+              'type': 'IntegerLiteral',
+              'value': {'text': '4'}
+            }
           }
-        }
-      ]
+        ]
+      });
     });
   });
 }

--- a/pkgs/_analyzer_macros/lib/query_service.dart
+++ b/pkgs/_analyzer_macros/lib/query_service.dart
@@ -2,12 +2,16 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// ignore_for_file: implementation_imports
+import 'package:_analyzer_cfe_macros/metadata_converter.dart'
+    as metadata_converter;
 import 'package:_macro_host/macro_host.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:analyzer/dart/element/type_provider.dart';
-// ignore: implementation_imports
+import 'package:analyzer/src/dart/element/element.dart' as analyzer;
 import 'package:analyzer/src/summary2/linked_element_factory.dart' as analyzer;
+import 'package:analyzer/src/summary2/macro_metadata.dart' as analyzer;
 import 'package:dart_model/dart_model.dart' hide InterfaceType;
 import 'package:macro_service/macro_service.dart';
 
@@ -34,8 +38,19 @@ class AnalyzerQueryService implements QueryService {
     final clazz = library.getClass(target.name)!;
     final types = AnalyzerTypeHierarchy(library.typeProvider)
       ..addInterfaceElement(clazz);
+    final metadataAnnotations = <MetadataAnnotation>[];
 
-    final interface = Interface(properties: Properties(isClass: true));
+    for (final annotation in clazz.metadata) {
+      metadataAnnotations.add(
+        MetadataAnnotation(
+            expression: metadata_converter.convert(analyzer.parseAnnotation(
+                annotation as analyzer.ElementAnnotationImpl))),
+      );
+    }
+
+    final interface = Interface(
+        properties: Properties(isClass: true),
+        metadataAnnotations: metadataAnnotations);
     try {
       for (final constructor in clazz.constructors) {
         interface.members[constructor.name] = Member(

--- a/pkgs/_analyzer_macros/lib/query_service.dart
+++ b/pkgs/_analyzer_macros/lib/query_service.dart
@@ -43,8 +43,9 @@ class AnalyzerQueryService implements QueryService {
     for (final annotation in clazz.metadata) {
       metadataAnnotations.add(
         MetadataAnnotation(
-            expression: metadata_converter.convert(analyzer.parseAnnotation(
-                annotation as analyzer.ElementAnnotationImpl))),
+            expression: metadata_converter.convertToExpression(
+                analyzer.parseAnnotation(
+                    annotation as analyzer.ElementAnnotationImpl))),
       );
     }
 

--- a/pkgs/_analyzer_macros/pubspec.yaml
+++ b/pkgs/_analyzer_macros/pubspec.yaml
@@ -7,6 +7,7 @@ environment:
   sdk: ^3.7.0-39.0.dev
 
 dependencies:
+  _analyzer_cfe_macros: any
   _macro_host: any
   analysis_server: any
   analyzer: any

--- a/pkgs/dart_model/lib/src/dart_model.g.dart
+++ b/pkgs/dart_model/lib/src/dart_model.g.dart
@@ -6,6 +6,8 @@ import 'package:dart_model/src/deep_cast_map.dart';
 // ignore: implementation_imports,unused_import,prefer_relative_imports
 import 'package:dart_model/src/json_buffer/json_buffer_builder.dart';
 // ignore: implementation_imports,unused_import,prefer_relative_imports
+import 'package:dart_model/src/macro_metadata.g.dart';
+// ignore: implementation_imports,unused_import,prefer_relative_imports
 import 'package:dart_model/src/scopes.dart';
 
 /// An augmentation to Dart code.
@@ -124,17 +126,17 @@ extension type FunctionTypeDesc.fromJson(Map<String, Object?> node)
 extension type MetadataAnnotation.fromJson(Map<String, Object?> node)
     implements Object {
   static final TypedMapSchema _schema = TypedMapSchema({
-    'type': Type.typedMapPointer,
+    'expression': Type.typedMapPointer,
   });
   MetadataAnnotation({
-    QualifiedName? type,
+    Expression? expression,
   }) : this.fromJson(Scope.createMap(
           _schema,
-          type,
+          expression,
         ));
 
-  /// The type of the annotation.
-  QualifiedName get type => node['type'] as QualifiedName;
+  /// The expression of the annotation.
+  Expression get expression => node['expression'] as Expression;
 }
 
 /// Interface type for all declarations

--- a/pkgs/dart_model/lib/src/macro_metadata.g.dart
+++ b/pkgs/dart_model/lib/src/macro_metadata.g.dart
@@ -18,16 +18,22 @@ enum ArgumentType {
 }
 
 extension type Argument.fromJson(Map<String, Object?> node) implements Object {
+  static final TypedMapSchema _schema = TypedMapSchema({
+    'type': Type.stringPointer,
+    'value': Type.anyPointer,
+  });
   static Argument positionalArgument(PositionalArgument positionalArgument) =>
-      Argument.fromJson({
-        'type': 'PositionalArgument',
-        'value': positionalArgument,
-      });
+      Argument.fromJson(Scope.createMap(
+        _schema,
+        'PositionalArgument',
+        positionalArgument,
+      ));
   static Argument namedArgument(NamedArgument namedArgument) =>
-      Argument.fromJson({
-        'type': 'NamedArgument',
-        'value': namedArgument,
-      });
+      Argument.fromJson(Scope.createMap(
+        _schema,
+        'NamedArgument',
+        namedArgument,
+      ));
   ArgumentType get type {
     switch (node['type'] as String) {
       case 'PositionalArgument':
@@ -66,25 +72,34 @@ enum ElementType {
 }
 
 extension type Element.fromJson(Map<String, Object?> node) implements Object {
+  static final TypedMapSchema _schema = TypedMapSchema({
+    'type': Type.stringPointer,
+    'value': Type.anyPointer,
+  });
   static Element expressionElement(ExpressionElement expressionElement) =>
-      Element.fromJson({
-        'type': 'ExpressionElement',
-        'value': expressionElement,
-      });
+      Element.fromJson(Scope.createMap(
+        _schema,
+        'ExpressionElement',
+        expressionElement,
+      ));
   static Element mapEntryElement(MapEntryElement mapEntryElement) =>
-      Element.fromJson({
-        'type': 'MapEntryElement',
-        'value': mapEntryElement,
-      });
+      Element.fromJson(Scope.createMap(
+        _schema,
+        'MapEntryElement',
+        mapEntryElement,
+      ));
   static Element spreadElement(SpreadElement spreadElement) =>
-      Element.fromJson({
-        'type': 'SpreadElement',
-        'value': spreadElement,
-      });
-  static Element ifElement(IfElement ifElement) => Element.fromJson({
-        'type': 'IfElement',
-        'value': ifElement,
-      });
+      Element.fromJson(Scope.createMap(
+        _schema,
+        'SpreadElement',
+        spreadElement,
+      ));
+  static Element ifElement(IfElement ifElement) =>
+      Element.fromJson(Scope.createMap(
+        _schema,
+        'IfElement',
+        ifElement,
+      ));
   ElementType get type {
     switch (node['type'] as String) {
       case 'ExpressionElement':
@@ -171,173 +186,214 @@ enum ExpressionType {
 
 extension type Expression.fromJson(Map<String, Object?> node)
     implements Object {
+  static final TypedMapSchema _schema = TypedMapSchema({
+    'type': Type.stringPointer,
+    'value': Type.anyPointer,
+  });
   static Expression invalidExpression(InvalidExpression invalidExpression) =>
-      Expression.fromJson({
-        'type': 'InvalidExpression',
-        'value': invalidExpression,
-      });
-  static Expression staticGet(StaticGet staticGet) => Expression.fromJson({
-        'type': 'StaticGet',
-        'value': staticGet,
-      });
+      Expression.fromJson(Scope.createMap(
+        _schema,
+        'InvalidExpression',
+        invalidExpression,
+      ));
+  static Expression staticGet(StaticGet staticGet) =>
+      Expression.fromJson(Scope.createMap(
+        _schema,
+        'StaticGet',
+        staticGet,
+      ));
   static Expression functionTearOff(FunctionTearOff functionTearOff) =>
-      Expression.fromJson({
-        'type': 'FunctionTearOff',
-        'value': functionTearOff,
-      });
+      Expression.fromJson(Scope.createMap(
+        _schema,
+        'FunctionTearOff',
+        functionTearOff,
+      ));
   static Expression constructorTearOff(ConstructorTearOff constructorTearOff) =>
-      Expression.fromJson({
-        'type': 'ConstructorTearOff',
-        'value': constructorTearOff,
-      });
+      Expression.fromJson(Scope.createMap(
+        _schema,
+        'ConstructorTearOff',
+        constructorTearOff,
+      ));
   static Expression constructorInvocation(
           ConstructorInvocation constructorInvocation) =>
-      Expression.fromJson({
-        'type': 'ConstructorInvocation',
-        'value': constructorInvocation,
-      });
+      Expression.fromJson(Scope.createMap(
+        _schema,
+        'ConstructorInvocation',
+        constructorInvocation,
+      ));
   static Expression integerLiteral(IntegerLiteral integerLiteral) =>
-      Expression.fromJson({
-        'type': 'IntegerLiteral',
-        'value': integerLiteral,
-      });
+      Expression.fromJson(Scope.createMap(
+        _schema,
+        'IntegerLiteral',
+        integerLiteral,
+      ));
   static Expression doubleLiteral(DoubleLiteral doubleLiteral) =>
-      Expression.fromJson({
-        'type': 'DoubleLiteral',
-        'value': doubleLiteral,
-      });
+      Expression.fromJson(Scope.createMap(
+        _schema,
+        'DoubleLiteral',
+        doubleLiteral,
+      ));
   static Expression booleanLiteral(BooleanLiteral booleanLiteral) =>
-      Expression.fromJson({
-        'type': 'BooleanLiteral',
-        'value': booleanLiteral,
-      });
+      Expression.fromJson(Scope.createMap(
+        _schema,
+        'BooleanLiteral',
+        booleanLiteral,
+      ));
   static Expression nullLiteral(NullLiteral nullLiteral) =>
-      Expression.fromJson({
-        'type': 'NullLiteral',
-        'value': nullLiteral,
-      });
+      Expression.fromJson(Scope.createMap(
+        _schema,
+        'NullLiteral',
+        nullLiteral,
+      ));
   static Expression symbolLiteral(SymbolLiteral symbolLiteral) =>
-      Expression.fromJson({
-        'type': 'SymbolLiteral',
-        'value': symbolLiteral,
-      });
+      Expression.fromJson(Scope.createMap(
+        _schema,
+        'SymbolLiteral',
+        symbolLiteral,
+      ));
   static Expression stringLiteral(StringLiteral stringLiteral) =>
-      Expression.fromJson({
-        'type': 'StringLiteral',
-        'value': stringLiteral,
-      });
+      Expression.fromJson(Scope.createMap(
+        _schema,
+        'StringLiteral',
+        stringLiteral,
+      ));
   static Expression adjacentStringLiterals(
           AdjacentStringLiterals adjacentStringLiterals) =>
-      Expression.fromJson({
-        'type': 'AdjacentStringLiterals',
-        'value': adjacentStringLiterals,
-      });
+      Expression.fromJson(Scope.createMap(
+        _schema,
+        'AdjacentStringLiterals',
+        adjacentStringLiterals,
+      ));
   static Expression implicitInvocation(ImplicitInvocation implicitInvocation) =>
-      Expression.fromJson({
-        'type': 'ImplicitInvocation',
-        'value': implicitInvocation,
-      });
+      Expression.fromJson(Scope.createMap(
+        _schema,
+        'ImplicitInvocation',
+        implicitInvocation,
+      ));
   static Expression staticInvocation(StaticInvocation staticInvocation) =>
-      Expression.fromJson({
-        'type': 'StaticInvocation',
-        'value': staticInvocation,
-      });
+      Expression.fromJson(Scope.createMap(
+        _schema,
+        'StaticInvocation',
+        staticInvocation,
+      ));
   static Expression instantiation(Instantiation instantiation) =>
-      Expression.fromJson({
-        'type': 'Instantiation',
-        'value': instantiation,
-      });
+      Expression.fromJson(Scope.createMap(
+        _schema,
+        'Instantiation',
+        instantiation,
+      ));
   static Expression methodInvocation(MethodInvocation methodInvocation) =>
-      Expression.fromJson({
-        'type': 'MethodInvocation',
-        'value': methodInvocation,
-      });
+      Expression.fromJson(Scope.createMap(
+        _schema,
+        'MethodInvocation',
+        methodInvocation,
+      ));
   static Expression propertyGet(PropertyGet propertyGet) =>
-      Expression.fromJson({
-        'type': 'PropertyGet',
-        'value': propertyGet,
-      });
+      Expression.fromJson(Scope.createMap(
+        _schema,
+        'PropertyGet',
+        propertyGet,
+      ));
   static Expression nullAwarePropertyGet(
           NullAwarePropertyGet nullAwarePropertyGet) =>
-      Expression.fromJson({
-        'type': 'NullAwarePropertyGet',
-        'value': nullAwarePropertyGet,
-      });
+      Expression.fromJson(Scope.createMap(
+        _schema,
+        'NullAwarePropertyGet',
+        nullAwarePropertyGet,
+      ));
   static Expression typeLiteral(TypeLiteral typeLiteral) =>
-      Expression.fromJson({
-        'type': 'TypeLiteral',
-        'value': typeLiteral,
-      });
+      Expression.fromJson(Scope.createMap(
+        _schema,
+        'TypeLiteral',
+        typeLiteral,
+      ));
   static Expression parenthesizedExpression(
           ParenthesizedExpression parenthesizedExpression) =>
-      Expression.fromJson({
-        'type': 'ParenthesizedExpression',
-        'value': parenthesizedExpression,
-      });
+      Expression.fromJson(Scope.createMap(
+        _schema,
+        'ParenthesizedExpression',
+        parenthesizedExpression,
+      ));
   static Expression conditionalExpression(
           ConditionalExpression conditionalExpression) =>
-      Expression.fromJson({
-        'type': 'ConditionalExpression',
-        'value': conditionalExpression,
-      });
+      Expression.fromJson(Scope.createMap(
+        _schema,
+        'ConditionalExpression',
+        conditionalExpression,
+      ));
   static Expression listLiteral(ListLiteral listLiteral) =>
-      Expression.fromJson({
-        'type': 'ListLiteral',
-        'value': listLiteral,
-      });
+      Expression.fromJson(Scope.createMap(
+        _schema,
+        'ListLiteral',
+        listLiteral,
+      ));
   static Expression setOrMapLiteral(SetOrMapLiteral setOrMapLiteral) =>
-      Expression.fromJson({
-        'type': 'SetOrMapLiteral',
-        'value': setOrMapLiteral,
-      });
+      Expression.fromJson(Scope.createMap(
+        _schema,
+        'SetOrMapLiteral',
+        setOrMapLiteral,
+      ));
   static Expression recordLiteral(RecordLiteral recordLiteral) =>
-      Expression.fromJson({
-        'type': 'RecordLiteral',
-        'value': recordLiteral,
-      });
-  static Expression ifNull(IfNull ifNull) => Expression.fromJson({
-        'type': 'IfNull',
-        'value': ifNull,
-      });
+      Expression.fromJson(Scope.createMap(
+        _schema,
+        'RecordLiteral',
+        recordLiteral,
+      ));
+  static Expression ifNull(IfNull ifNull) =>
+      Expression.fromJson(Scope.createMap(
+        _schema,
+        'IfNull',
+        ifNull,
+      ));
   static Expression logicalExpression(LogicalExpression logicalExpression) =>
-      Expression.fromJson({
-        'type': 'LogicalExpression',
-        'value': logicalExpression,
-      });
+      Expression.fromJson(Scope.createMap(
+        _schema,
+        'LogicalExpression',
+        logicalExpression,
+      ));
   static Expression equalityExpression(EqualityExpression equalityExpression) =>
-      Expression.fromJson({
-        'type': 'EqualityExpression',
-        'value': equalityExpression,
-      });
+      Expression.fromJson(Scope.createMap(
+        _schema,
+        'EqualityExpression',
+        equalityExpression,
+      ));
   static Expression binaryExpression(BinaryExpression binaryExpression) =>
-      Expression.fromJson({
-        'type': 'BinaryExpression',
-        'value': binaryExpression,
-      });
+      Expression.fromJson(Scope.createMap(
+        _schema,
+        'BinaryExpression',
+        binaryExpression,
+      ));
   static Expression unaryExpression(UnaryExpression unaryExpression) =>
-      Expression.fromJson({
-        'type': 'UnaryExpression',
-        'value': unaryExpression,
-      });
-  static Expression isTest(IsTest isTest) => Expression.fromJson({
-        'type': 'IsTest',
-        'value': isTest,
-      });
+      Expression.fromJson(Scope.createMap(
+        _schema,
+        'UnaryExpression',
+        unaryExpression,
+      ));
+  static Expression isTest(IsTest isTest) =>
+      Expression.fromJson(Scope.createMap(
+        _schema,
+        'IsTest',
+        isTest,
+      ));
   static Expression asExpression(AsExpression asExpression) =>
-      Expression.fromJson({
-        'type': 'AsExpression',
-        'value': asExpression,
-      });
-  static Expression nullCheck(NullCheck nullCheck) => Expression.fromJson({
-        'type': 'NullCheck',
-        'value': nullCheck,
-      });
+      Expression.fromJson(Scope.createMap(
+        _schema,
+        'AsExpression',
+        asExpression,
+      ));
+  static Expression nullCheck(NullCheck nullCheck) =>
+      Expression.fromJson(Scope.createMap(
+        _schema,
+        'NullCheck',
+        nullCheck,
+      ));
   static Expression unresolvedExpression(
           UnresolvedExpression unresolvedExpression) =>
-      Expression.fromJson({
-        'type': 'UnresolvedExpression',
-        'value': unresolvedExpression,
-      });
+      Expression.fromJson(Scope.createMap(
+        _schema,
+        'UnresolvedExpression',
+        unresolvedExpression,
+      ));
   ExpressionType get type {
     switch (node['type'] as String) {
       case 'InvalidExpression':
@@ -658,17 +714,23 @@ enum RecordFieldType {
 
 extension type RecordField.fromJson(Map<String, Object?> node)
     implements Object {
+  static final TypedMapSchema _schema = TypedMapSchema({
+    'type': Type.stringPointer,
+    'value': Type.anyPointer,
+  });
   static RecordField recordNamedField(RecordNamedField recordNamedField) =>
-      RecordField.fromJson({
-        'type': 'RecordNamedField',
-        'value': recordNamedField,
-      });
+      RecordField.fromJson(Scope.createMap(
+        _schema,
+        'RecordNamedField',
+        recordNamedField,
+      ));
   static RecordField recordPositionalField(
           RecordPositionalField recordPositionalField) =>
-      RecordField.fromJson({
-        'type': 'RecordPositionalField',
-        'value': recordPositionalField,
-      });
+      RecordField.fromJson(Scope.createMap(
+        _schema,
+        'RecordPositionalField',
+        recordPositionalField,
+      ));
   RecordFieldType get type {
     switch (node['type'] as String) {
       case 'RecordNamedField':
@@ -714,59 +776,73 @@ enum ReferenceType {
 }
 
 extension type Reference.fromJson(Map<String, Object?> node) implements Object {
+  static final TypedMapSchema _schema = TypedMapSchema({
+    'type': Type.stringPointer,
+    'value': Type.anyPointer,
+  });
   static Reference fieldReference(FieldReference fieldReference) =>
-      Reference.fromJson({
-        'type': 'FieldReference',
-        'value': fieldReference,
-      });
+      Reference.fromJson(Scope.createMap(
+        _schema,
+        'FieldReference',
+        fieldReference,
+      ));
   static Reference functionReference(FunctionReference functionReference) =>
-      Reference.fromJson({
-        'type': 'FunctionReference',
-        'value': functionReference,
-      });
+      Reference.fromJson(Scope.createMap(
+        _schema,
+        'FunctionReference',
+        functionReference,
+      ));
   static Reference constructorReference(
           ConstructorReference constructorReference) =>
-      Reference.fromJson({
-        'type': 'ConstructorReference',
-        'value': constructorReference,
-      });
+      Reference.fromJson(Scope.createMap(
+        _schema,
+        'ConstructorReference',
+        constructorReference,
+      ));
   static Reference typeReference(TypeReference typeReference) =>
-      Reference.fromJson({
-        'type': 'TypeReference',
-        'value': typeReference,
-      });
+      Reference.fromJson(Scope.createMap(
+        _schema,
+        'TypeReference',
+        typeReference,
+      ));
   static Reference classReference(ClassReference classReference) =>
-      Reference.fromJson({
-        'type': 'ClassReference',
-        'value': classReference,
-      });
+      Reference.fromJson(Scope.createMap(
+        _schema,
+        'ClassReference',
+        classReference,
+      ));
   static Reference typedefReference(TypedefReference typedefReference) =>
-      Reference.fromJson({
-        'type': 'TypedefReference',
-        'value': typedefReference,
-      });
+      Reference.fromJson(Scope.createMap(
+        _schema,
+        'TypedefReference',
+        typedefReference,
+      ));
   static Reference extensionReference(ExtensionReference extensionReference) =>
-      Reference.fromJson({
-        'type': 'ExtensionReference',
-        'value': extensionReference,
-      });
+      Reference.fromJson(Scope.createMap(
+        _schema,
+        'ExtensionReference',
+        extensionReference,
+      ));
   static Reference extensionTypeReference(
           ExtensionTypeReference extensionTypeReference) =>
-      Reference.fromJson({
-        'type': 'ExtensionTypeReference',
-        'value': extensionTypeReference,
-      });
+      Reference.fromJson(Scope.createMap(
+        _schema,
+        'ExtensionTypeReference',
+        extensionTypeReference,
+      ));
   static Reference enumReference(EnumReference enumReference) =>
-      Reference.fromJson({
-        'type': 'EnumReference',
-        'value': enumReference,
-      });
+      Reference.fromJson(Scope.createMap(
+        _schema,
+        'EnumReference',
+        enumReference,
+      ));
   static Reference functionTypeParameterReference(
           FunctionTypeParameterReference functionTypeParameterReference) =>
-      Reference.fromJson({
-        'type': 'FunctionTypeParameterReference',
-        'value': functionTypeParameterReference,
-      });
+      Reference.fromJson(Scope.createMap(
+        _schema,
+        'FunctionTypeParameterReference',
+        functionTypeParameterReference,
+      ));
   ReferenceType get type {
     switch (node['type'] as String) {
       case 'FieldReference':
@@ -878,17 +954,23 @@ enum StringLiteralPartType {
 
 extension type StringLiteralPart.fromJson(Map<String, Object?> node)
     implements Object {
+  static final TypedMapSchema _schema = TypedMapSchema({
+    'type': Type.stringPointer,
+    'value': Type.anyPointer,
+  });
   static StringLiteralPart stringPart(StringPart stringPart) =>
-      StringLiteralPart.fromJson({
-        'type': 'StringPart',
-        'value': stringPart,
-      });
+      StringLiteralPart.fromJson(Scope.createMap(
+        _schema,
+        'StringPart',
+        stringPart,
+      ));
   static StringLiteralPart interpolationPart(
           InterpolationPart interpolationPart) =>
-      StringLiteralPart.fromJson({
-        'type': 'InterpolationPart',
-        'value': interpolationPart,
-      });
+      StringLiteralPart.fromJson(Scope.createMap(
+        _schema,
+        'InterpolationPart',
+        interpolationPart,
+      ));
   StringLiteralPartType get type {
     switch (node['type'] as String) {
       case 'StringPart':
@@ -933,60 +1015,73 @@ enum TypeAnnotationType {
 
 extension type TypeAnnotation.fromJson(Map<String, Object?> node)
     implements Object {
+  static final TypedMapSchema _schema = TypedMapSchema({
+    'type': Type.stringPointer,
+    'value': Type.anyPointer,
+  });
   static TypeAnnotation namedTypeAnnotation(
           NamedTypeAnnotation namedTypeAnnotation) =>
-      TypeAnnotation.fromJson({
-        'type': 'NamedTypeAnnotation',
-        'value': namedTypeAnnotation,
-      });
+      TypeAnnotation.fromJson(Scope.createMap(
+        _schema,
+        'NamedTypeAnnotation',
+        namedTypeAnnotation,
+      ));
   static TypeAnnotation nullableTypeAnnotation(
           NullableTypeAnnotation nullableTypeAnnotation) =>
-      TypeAnnotation.fromJson({
-        'type': 'NullableTypeAnnotation',
-        'value': nullableTypeAnnotation,
-      });
+      TypeAnnotation.fromJson(Scope.createMap(
+        _schema,
+        'NullableTypeAnnotation',
+        nullableTypeAnnotation,
+      ));
   static TypeAnnotation voidTypeAnnotation(
           VoidTypeAnnotation voidTypeAnnotation) =>
-      TypeAnnotation.fromJson({
-        'type': 'VoidTypeAnnotation',
-        'value': voidTypeAnnotation,
-      });
+      TypeAnnotation.fromJson(Scope.createMap(
+        _schema,
+        'VoidTypeAnnotation',
+        voidTypeAnnotation,
+      ));
   static TypeAnnotation dynamicTypeAnnotation(
           DynamicTypeAnnotation dynamicTypeAnnotation) =>
-      TypeAnnotation.fromJson({
-        'type': 'DynamicTypeAnnotation',
-        'value': dynamicTypeAnnotation,
-      });
+      TypeAnnotation.fromJson(Scope.createMap(
+        _schema,
+        'DynamicTypeAnnotation',
+        dynamicTypeAnnotation,
+      ));
   static TypeAnnotation invalidTypeAnnotation(
           InvalidTypeAnnotation invalidTypeAnnotation) =>
-      TypeAnnotation.fromJson({
-        'type': 'InvalidTypeAnnotation',
-        'value': invalidTypeAnnotation,
-      });
+      TypeAnnotation.fromJson(Scope.createMap(
+        _schema,
+        'InvalidTypeAnnotation',
+        invalidTypeAnnotation,
+      ));
   static TypeAnnotation unresolvedTypeAnnotation(
           UnresolvedTypeAnnotation unresolvedTypeAnnotation) =>
-      TypeAnnotation.fromJson({
-        'type': 'UnresolvedTypeAnnotation',
-        'value': unresolvedTypeAnnotation,
-      });
+      TypeAnnotation.fromJson(Scope.createMap(
+        _schema,
+        'UnresolvedTypeAnnotation',
+        unresolvedTypeAnnotation,
+      ));
   static TypeAnnotation functionTypeAnnotation(
           FunctionTypeAnnotation functionTypeAnnotation) =>
-      TypeAnnotation.fromJson({
-        'type': 'FunctionTypeAnnotation',
-        'value': functionTypeAnnotation,
-      });
+      TypeAnnotation.fromJson(Scope.createMap(
+        _schema,
+        'FunctionTypeAnnotation',
+        functionTypeAnnotation,
+      ));
   static TypeAnnotation functionTypeParameterType(
           FunctionTypeParameterType functionTypeParameterType) =>
-      TypeAnnotation.fromJson({
-        'type': 'FunctionTypeParameterType',
-        'value': functionTypeParameterType,
-      });
+      TypeAnnotation.fromJson(Scope.createMap(
+        _schema,
+        'FunctionTypeParameterType',
+        functionTypeParameterType,
+      ));
   static TypeAnnotation recordTypeAnnotation(
           RecordTypeAnnotation recordTypeAnnotation) =>
-      TypeAnnotation.fromJson({
-        'type': 'RecordTypeAnnotation',
-        'value': recordTypeAnnotation,
-      });
+      TypeAnnotation.fromJson(Scope.createMap(
+        _schema,
+        'RecordTypeAnnotation',
+        recordTypeAnnotation,
+      ));
   TypeAnnotationType get type {
     switch (node['type'] as String) {
       case 'NamedTypeAnnotation':
@@ -1126,13 +1221,18 @@ extension type const UnaryOperator.fromJson(String string) implements Object {
 ///
 extension type AsExpression.fromJson(Map<String, Object?> node)
     implements Object {
+  static final TypedMapSchema _schema = TypedMapSchema({
+    'expression': Type.typedMapPointer,
+    'type': Type.typedMapPointer,
+  });
   AsExpression({
     Expression? expression,
     TypeAnnotation? type,
-  }) : this.fromJson({
-          if (expression != null) 'expression': expression,
-          if (type != null) 'type': type,
-        });
+  }) : this.fromJson(Scope.createMap(
+          _schema,
+          expression,
+          type,
+        ));
 
   ///
   Expression get expression => node['expression'] as Expression;
@@ -1144,15 +1244,21 @@ extension type AsExpression.fromJson(Map<String, Object?> node)
 ///
 extension type BinaryExpression.fromJson(Map<String, Object?> node)
     implements Object {
+  static final TypedMapSchema _schema = TypedMapSchema({
+    'left': Type.typedMapPointer,
+    'operator': Type.stringPointer,
+    'right': Type.typedMapPointer,
+  });
   BinaryExpression({
     Expression? left,
     BinaryOperator? operator,
     Expression? right,
-  }) : this.fromJson({
-          if (left != null) 'left': left,
-          if (operator != null) 'operator': operator,
-          if (right != null) 'right': right,
-        });
+  }) : this.fromJson(Scope.createMap(
+          _schema,
+          left,
+          operator,
+          right,
+        ));
 
   ///
   Expression get left => node['left'] as Expression;
@@ -1167,11 +1273,15 @@ extension type BinaryExpression.fromJson(Map<String, Object?> node)
 ///
 extension type BooleanLiteral.fromJson(Map<String, Object?> node)
     implements Object {
+  static final TypedMapSchema _schema = TypedMapSchema({
+    'text': Type.stringPointer,
+  });
   BooleanLiteral({
     String? text,
-  }) : this.fromJson({
-          if (text != null) 'text': text,
-        });
+  }) : this.fromJson(Scope.createMap(
+          _schema,
+          text,
+        ));
 
   ///
   String get text => node['text'] as String;
@@ -1180,21 +1290,31 @@ extension type BooleanLiteral.fromJson(Map<String, Object?> node)
 ///
 extension type ClassReference.fromJson(Map<String, Object?> node)
     implements Object {
-  ClassReference() : this.fromJson({});
+  static final TypedMapSchema _schema = TypedMapSchema({});
+  ClassReference()
+      : this.fromJson(Scope.createMap(
+          _schema,
+        ));
 }
 
 ///
 extension type ConditionalExpression.fromJson(Map<String, Object?> node)
     implements Object {
+  static final TypedMapSchema _schema = TypedMapSchema({
+    'condition': Type.typedMapPointer,
+    'then': Type.typedMapPointer,
+    'otherwise': Type.typedMapPointer,
+  });
   ConditionalExpression({
     Expression? condition,
     Expression? then,
     Expression? otherwise,
-  }) : this.fromJson({
-          if (condition != null) 'condition': condition,
-          if (then != null) 'then': then,
-          if (otherwise != null) 'otherwise': otherwise,
-        });
+  }) : this.fromJson(Scope.createMap(
+          _schema,
+          condition,
+          then,
+          otherwise,
+        ));
 
   ///
   Expression get condition => node['condition'] as Expression;
@@ -1209,15 +1329,21 @@ extension type ConditionalExpression.fromJson(Map<String, Object?> node)
 ///
 extension type ConstructorInvocation.fromJson(Map<String, Object?> node)
     implements Object {
+  static final TypedMapSchema _schema = TypedMapSchema({
+    'type': Type.typedMapPointer,
+    'constructor': Type.typedMapPointer,
+    'arguments': Type.closedListPointer,
+  });
   ConstructorInvocation({
     TypeAnnotation? type,
     Reference? constructor,
     List<Argument>? arguments,
-  }) : this.fromJson({
-          if (type != null) 'type': type,
-          if (constructor != null) 'constructor': constructor,
-          if (arguments != null) 'arguments': arguments,
-        });
+  }) : this.fromJson(Scope.createMap(
+          _schema,
+          type,
+          constructor,
+          arguments,
+        ));
 
   ///
   TypeAnnotation get type => node['type'] as TypeAnnotation;
@@ -1232,19 +1358,28 @@ extension type ConstructorInvocation.fromJson(Map<String, Object?> node)
 ///
 extension type ConstructorReference.fromJson(Map<String, Object?> node)
     implements Object {
-  ConstructorReference() : this.fromJson({});
+  static final TypedMapSchema _schema = TypedMapSchema({});
+  ConstructorReference()
+      : this.fromJson(Scope.createMap(
+          _schema,
+        ));
 }
 
 ///
 extension type ConstructorTearOff.fromJson(Map<String, Object?> node)
     implements Object {
+  static final TypedMapSchema _schema = TypedMapSchema({
+    'type': Type.typedMapPointer,
+    'reference': Type.typedMapPointer,
+  });
   ConstructorTearOff({
     TypeAnnotation? type,
     ConstructorReference? reference,
-  }) : this.fromJson({
-          if (type != null) 'type': type,
-          if (reference != null) 'reference': reference,
-        });
+  }) : this.fromJson(Scope.createMap(
+          _schema,
+          type,
+          reference,
+        ));
 
   ///
   TypeAnnotation get type => node['type'] as TypeAnnotation;
@@ -1257,11 +1392,15 @@ extension type ConstructorTearOff.fromJson(Map<String, Object?> node)
 ///
 extension type DoubleLiteral.fromJson(Map<String, Object?> node)
     implements Object {
+  static final TypedMapSchema _schema = TypedMapSchema({
+    'text': Type.stringPointer,
+  });
   DoubleLiteral({
     String? text,
-  }) : this.fromJson({
-          if (text != null) 'text': text,
-        });
+  }) : this.fromJson(Scope.createMap(
+          _schema,
+          text,
+        ));
 
   ///
   String get text => node['text'] as String;
@@ -1270,11 +1409,15 @@ extension type DoubleLiteral.fromJson(Map<String, Object?> node)
 ///
 extension type DynamicTypeAnnotation.fromJson(Map<String, Object?> node)
     implements Object {
+  static final TypedMapSchema _schema = TypedMapSchema({
+    'reference': Type.typedMapPointer,
+  });
   DynamicTypeAnnotation({
     Reference? reference,
-  }) : this.fromJson({
-          if (reference != null) 'reference': reference,
-        });
+  }) : this.fromJson(Scope.createMap(
+          _schema,
+          reference,
+        ));
 
   ///
   Reference get reference => node['reference'] as Reference;
@@ -1283,21 +1426,31 @@ extension type DynamicTypeAnnotation.fromJson(Map<String, Object?> node)
 ///
 extension type EnumReference.fromJson(Map<String, Object?> node)
     implements Object {
-  EnumReference() : this.fromJson({});
+  static final TypedMapSchema _schema = TypedMapSchema({});
+  EnumReference()
+      : this.fromJson(Scope.createMap(
+          _schema,
+        ));
 }
 
 ///
 extension type EqualityExpression.fromJson(Map<String, Object?> node)
     implements Object {
+  static final TypedMapSchema _schema = TypedMapSchema({
+    'left': Type.typedMapPointer,
+    'right': Type.typedMapPointer,
+    'isNotEquals': Type.boolean,
+  });
   EqualityExpression({
     Expression? left,
     Expression? right,
     bool? isNotEquals,
-  }) : this.fromJson({
-          if (left != null) 'left': left,
-          if (right != null) 'right': right,
-          if (isNotEquals != null) 'isNotEquals': isNotEquals,
-        });
+  }) : this.fromJson(Scope.createMap(
+          _schema,
+          left,
+          right,
+          isNotEquals,
+        ));
 
   ///
   Expression get left => node['left'] as Expression;
@@ -1312,13 +1465,18 @@ extension type EqualityExpression.fromJson(Map<String, Object?> node)
 ///
 extension type ExpressionElement.fromJson(Map<String, Object?> node)
     implements Object {
+  static final TypedMapSchema _schema = TypedMapSchema({
+    'expression': Type.typedMapPointer,
+    'isNullAware': Type.boolean,
+  });
   ExpressionElement({
     Expression? expression,
     bool? isNullAware,
-  }) : this.fromJson({
-          if (expression != null) 'expression': expression,
-          if (isNullAware != null) 'isNullAware': isNullAware,
-        });
+  }) : this.fromJson(Scope.createMap(
+          _schema,
+          expression,
+          isNullAware,
+        ));
 
   ///
   Expression get expression => node['expression'] as Expression;
@@ -1330,47 +1488,75 @@ extension type ExpressionElement.fromJson(Map<String, Object?> node)
 ///
 extension type ExtensionReference.fromJson(Map<String, Object?> node)
     implements Object {
-  ExtensionReference() : this.fromJson({});
+  static final TypedMapSchema _schema = TypedMapSchema({});
+  ExtensionReference()
+      : this.fromJson(Scope.createMap(
+          _schema,
+        ));
 }
 
 ///
 extension type ExtensionTypeReference.fromJson(Map<String, Object?> node)
     implements Object {
-  ExtensionTypeReference() : this.fromJson({});
+  static final TypedMapSchema _schema = TypedMapSchema({});
+  ExtensionTypeReference()
+      : this.fromJson(Scope.createMap(
+          _schema,
+        ));
 }
 
 ///
 extension type FieldReference.fromJson(Map<String, Object?> node)
     implements Object {
-  FieldReference() : this.fromJson({});
+  static final TypedMapSchema _schema = TypedMapSchema({});
+  FieldReference()
+      : this.fromJson(Scope.createMap(
+          _schema,
+        ));
 }
 
 ///
 extension type FormalParameter.fromJson(Map<String, Object?> node)
     implements Object {
-  FormalParameter() : this.fromJson({});
+  static final TypedMapSchema _schema = TypedMapSchema({});
+  FormalParameter()
+      : this.fromJson(Scope.createMap(
+          _schema,
+        ));
 }
 
 ///
 extension type FormalParameterGroup.fromJson(Map<String, Object?> node)
     implements Object {
-  FormalParameterGroup() : this.fromJson({});
+  static final TypedMapSchema _schema = TypedMapSchema({});
+  FormalParameterGroup()
+      : this.fromJson(Scope.createMap(
+          _schema,
+        ));
 }
 
 ///
 extension type FunctionReference.fromJson(Map<String, Object?> node)
     implements Object {
-  FunctionReference() : this.fromJson({});
+  static final TypedMapSchema _schema = TypedMapSchema({});
+  FunctionReference()
+      : this.fromJson(Scope.createMap(
+          _schema,
+        ));
 }
 
 ///
 extension type FunctionTearOff.fromJson(Map<String, Object?> node)
     implements Object {
+  static final TypedMapSchema _schema = TypedMapSchema({
+    'reference': Type.typedMapPointer,
+  });
   FunctionTearOff({
     FunctionReference? reference,
-  }) : this.fromJson({
-          if (reference != null) 'reference': reference,
-        });
+  }) : this.fromJson(Scope.createMap(
+          _schema,
+          reference,
+        ));
 
   ///
   FunctionReference get reference => node['reference'] as FunctionReference;
@@ -1379,15 +1565,21 @@ extension type FunctionTearOff.fromJson(Map<String, Object?> node)
 ///
 extension type FunctionTypeAnnotation.fromJson(Map<String, Object?> node)
     implements Object {
+  static final TypedMapSchema _schema = TypedMapSchema({
+    'returnType': Type.typedMapPointer,
+    'typeParameters': Type.closedListPointer,
+    'formalParameters': Type.closedListPointer,
+  });
   FunctionTypeAnnotation({
     TypeAnnotation? returnType,
     List<FunctionTypeParameter>? typeParameters,
     List<FormalParameter>? formalParameters,
-  }) : this.fromJson({
-          if (returnType != null) 'returnType': returnType,
-          if (typeParameters != null) 'typeParameters': typeParameters,
-          if (formalParameters != null) 'formalParameters': formalParameters,
-        });
+  }) : this.fromJson(Scope.createMap(
+          _schema,
+          returnType,
+          typeParameters,
+          formalParameters,
+        ));
 
   ///
   TypeAnnotation? get returnType => node['returnType'] as TypeAnnotation?;
@@ -1404,24 +1596,35 @@ extension type FunctionTypeAnnotation.fromJson(Map<String, Object?> node)
 ///
 extension type FunctionTypeParameter.fromJson(Map<String, Object?> node)
     implements Object {
-  FunctionTypeParameter() : this.fromJson({});
+  static final TypedMapSchema _schema = TypedMapSchema({});
+  FunctionTypeParameter()
+      : this.fromJson(Scope.createMap(
+          _schema,
+        ));
 }
 
 ///
 extension type FunctionTypeParameterReference.fromJson(
     Map<String, Object?> node) implements Object {
-  FunctionTypeParameterReference() : this.fromJson({});
+  static final TypedMapSchema _schema = TypedMapSchema({});
+  FunctionTypeParameterReference()
+      : this.fromJson(Scope.createMap(
+          _schema,
+        ));
 }
 
 ///
 extension type FunctionTypeParameterType.fromJson(Map<String, Object?> node)
     implements Object {
+  static final TypedMapSchema _schema = TypedMapSchema({
+    'functionTypeParameter': Type.typedMapPointer,
+  });
   FunctionTypeParameterType({
     FunctionTypeParameter? functionTypeParameter,
-  }) : this.fromJson({
-          if (functionTypeParameter != null)
-            'functionTypeParameter': functionTypeParameter,
-        });
+  }) : this.fromJson(Scope.createMap(
+          _schema,
+          functionTypeParameter,
+        ));
 
   ///
   FunctionTypeParameter get functionTypeParameter =>
@@ -1430,15 +1633,21 @@ extension type FunctionTypeParameterType.fromJson(Map<String, Object?> node)
 
 ///
 extension type IfElement.fromJson(Map<String, Object?> node) implements Object {
+  static final TypedMapSchema _schema = TypedMapSchema({
+    'condition': Type.typedMapPointer,
+    'then': Type.typedMapPointer,
+    'otherwise': Type.typedMapPointer,
+  });
   IfElement({
     Expression? condition,
     Element? then,
     Element? otherwise,
-  }) : this.fromJson({
-          if (condition != null) 'condition': condition,
-          if (then != null) 'then': then,
-          if (otherwise != null) 'otherwise': otherwise,
-        });
+  }) : this.fromJson(Scope.createMap(
+          _schema,
+          condition,
+          then,
+          otherwise,
+        ));
 
   ///
   Expression get condition => node['condition'] as Expression;
@@ -1452,13 +1661,18 @@ extension type IfElement.fromJson(Map<String, Object?> node) implements Object {
 
 ///
 extension type IfNull.fromJson(Map<String, Object?> node) implements Object {
+  static final TypedMapSchema _schema = TypedMapSchema({
+    'left': Type.typedMapPointer,
+    'right': Type.typedMapPointer,
+  });
   IfNull({
     Expression? left,
     Expression? right,
-  }) : this.fromJson({
-          if (left != null) 'left': left,
-          if (right != null) 'right': right,
-        });
+  }) : this.fromJson(Scope.createMap(
+          _schema,
+          left,
+          right,
+        ));
 
   ///
   Expression get left => node['left'] as Expression;
@@ -1470,15 +1684,21 @@ extension type IfNull.fromJson(Map<String, Object?> node) implements Object {
 ///
 extension type ImplicitInvocation.fromJson(Map<String, Object?> node)
     implements Object {
+  static final TypedMapSchema _schema = TypedMapSchema({
+    'receiver': Type.typedMapPointer,
+    'typeArguments': Type.closedListPointer,
+    'arguments': Type.closedListPointer,
+  });
   ImplicitInvocation({
     Expression? receiver,
     List<TypeAnnotation>? typeArguments,
     List<Argument>? arguments,
-  }) : this.fromJson({
-          if (receiver != null) 'receiver': receiver,
-          if (typeArguments != null) 'typeArguments': typeArguments,
-          if (arguments != null) 'arguments': arguments,
-        });
+  }) : this.fromJson(Scope.createMap(
+          _schema,
+          receiver,
+          typeArguments,
+          arguments,
+        ));
 
   ///
   Expression get receiver => node['receiver'] as Expression;
@@ -1494,13 +1714,18 @@ extension type ImplicitInvocation.fromJson(Map<String, Object?> node)
 ///
 extension type Instantiation.fromJson(Map<String, Object?> node)
     implements Object {
+  static final TypedMapSchema _schema = TypedMapSchema({
+    'receiver': Type.typedMapPointer,
+    'typeArguments': Type.closedListPointer,
+  });
   Instantiation({
     Expression? receiver,
     List<TypeAnnotation>? typeArguments,
-  }) : this.fromJson({
-          if (receiver != null) 'receiver': receiver,
-          if (typeArguments != null) 'typeArguments': typeArguments,
-        });
+  }) : this.fromJson(Scope.createMap(
+          _schema,
+          receiver,
+          typeArguments,
+        ));
 
   ///
   Expression get receiver => node['receiver'] as Expression;
@@ -1513,11 +1738,15 @@ extension type Instantiation.fromJson(Map<String, Object?> node)
 ///
 extension type IntegerLiteral.fromJson(Map<String, Object?> node)
     implements Object {
+  static final TypedMapSchema _schema = TypedMapSchema({
+    'text': Type.stringPointer,
+  });
   IntegerLiteral({
     String? text,
-  }) : this.fromJson({
-          if (text != null) 'text': text,
-        });
+  }) : this.fromJson(Scope.createMap(
+          _schema,
+          text,
+        ));
 
   ///
   String get text => node['text'] as String;
@@ -1526,11 +1755,15 @@ extension type IntegerLiteral.fromJson(Map<String, Object?> node)
 ///
 extension type InterpolationPart.fromJson(Map<String, Object?> node)
     implements Object {
+  static final TypedMapSchema _schema = TypedMapSchema({
+    'expression': Type.typedMapPointer,
+  });
   InterpolationPart({
     Expression? expression,
-  }) : this.fromJson({
-          if (expression != null) 'expression': expression,
-        });
+  }) : this.fromJson(Scope.createMap(
+          _schema,
+          expression,
+        ));
 
   ///
   Expression get expression => node['expression'] as Expression;
@@ -1539,26 +1772,40 @@ extension type InterpolationPart.fromJson(Map<String, Object?> node)
 ///
 extension type InvalidExpression.fromJson(Map<String, Object?> node)
     implements Object {
-  InvalidExpression() : this.fromJson({});
+  static final TypedMapSchema _schema = TypedMapSchema({});
+  InvalidExpression()
+      : this.fromJson(Scope.createMap(
+          _schema,
+        ));
 }
 
 ///
 extension type InvalidTypeAnnotation.fromJson(Map<String, Object?> node)
     implements Object {
-  InvalidTypeAnnotation() : this.fromJson({});
+  static final TypedMapSchema _schema = TypedMapSchema({});
+  InvalidTypeAnnotation()
+      : this.fromJson(Scope.createMap(
+          _schema,
+        ));
 }
 
 ///
 extension type IsTest.fromJson(Map<String, Object?> node) implements Object {
+  static final TypedMapSchema _schema = TypedMapSchema({
+    'expression': Type.typedMapPointer,
+    'type': Type.typedMapPointer,
+    'isNot': Type.boolean,
+  });
   IsTest({
     Expression? expression,
     TypeAnnotation? type,
     bool? isNot,
-  }) : this.fromJson({
-          if (expression != null) 'expression': expression,
-          if (type != null) 'type': type,
-          if (isNot != null) 'isNot': isNot,
-        });
+  }) : this.fromJson(Scope.createMap(
+          _schema,
+          expression,
+          type,
+          isNot,
+        ));
 
   ///
   Expression get expression => node['expression'] as Expression;
@@ -1573,13 +1820,18 @@ extension type IsTest.fromJson(Map<String, Object?> node) implements Object {
 ///
 extension type ListLiteral.fromJson(Map<String, Object?> node)
     implements Object {
+  static final TypedMapSchema _schema = TypedMapSchema({
+    'typeArguments': Type.closedListPointer,
+    'elements': Type.closedListPointer,
+  });
   ListLiteral({
     List<TypeAnnotation>? typeArguments,
     List<Element>? elements,
-  }) : this.fromJson({
-          if (typeArguments != null) 'typeArguments': typeArguments,
-          if (elements != null) 'elements': elements,
-        });
+  }) : this.fromJson(Scope.createMap(
+          _schema,
+          typeArguments,
+          elements,
+        ));
 
   ///
   List<TypeAnnotation> get typeArguments =>
@@ -1592,15 +1844,21 @@ extension type ListLiteral.fromJson(Map<String, Object?> node)
 ///
 extension type LogicalExpression.fromJson(Map<String, Object?> node)
     implements Object {
+  static final TypedMapSchema _schema = TypedMapSchema({
+    'left': Type.typedMapPointer,
+    'operator': Type.stringPointer,
+    'right': Type.typedMapPointer,
+  });
   LogicalExpression({
     Expression? left,
     LogicalOperator? operator,
     Expression? right,
-  }) : this.fromJson({
-          if (left != null) 'left': left,
-          if (operator != null) 'operator': operator,
-          if (right != null) 'right': right,
-        });
+  }) : this.fromJson(Scope.createMap(
+          _schema,
+          left,
+          operator,
+          right,
+        ));
 
   ///
   Expression get left => node['left'] as Expression;
@@ -1615,17 +1873,24 @@ extension type LogicalExpression.fromJson(Map<String, Object?> node)
 ///
 extension type MapEntryElement.fromJson(Map<String, Object?> node)
     implements Object {
+  static final TypedMapSchema _schema = TypedMapSchema({
+    'key': Type.typedMapPointer,
+    'value': Type.typedMapPointer,
+    'isNullAwareKey': Type.boolean,
+    'isNullAwareValue': Type.boolean,
+  });
   MapEntryElement({
     Expression? key,
     Expression? value,
     bool? isNullAwareKey,
     bool? isNullAwareValue,
-  }) : this.fromJson({
-          if (key != null) 'key': key,
-          if (value != null) 'value': value,
-          if (isNullAwareKey != null) 'isNullAwareKey': isNullAwareKey,
-          if (isNullAwareValue != null) 'isNullAwareValue': isNullAwareValue,
-        });
+  }) : this.fromJson(Scope.createMap(
+          _schema,
+          key,
+          value,
+          isNullAwareKey,
+          isNullAwareValue,
+        ));
 
   ///
   Expression get key => node['key'] as Expression;
@@ -1643,17 +1908,24 @@ extension type MapEntryElement.fromJson(Map<String, Object?> node)
 ///
 extension type MethodInvocation.fromJson(Map<String, Object?> node)
     implements Object {
+  static final TypedMapSchema _schema = TypedMapSchema({
+    'receiver': Type.typedMapPointer,
+    'name': Type.stringPointer,
+    'typeArguments': Type.closedListPointer,
+    'arguments': Type.closedListPointer,
+  });
   MethodInvocation({
     Expression? receiver,
     String? name,
     List<TypeAnnotation>? typeArguments,
     List<Argument>? arguments,
-  }) : this.fromJson({
-          if (receiver != null) 'receiver': receiver,
-          if (name != null) 'name': name,
-          if (typeArguments != null) 'typeArguments': typeArguments,
-          if (arguments != null) 'arguments': arguments,
-        });
+  }) : this.fromJson(Scope.createMap(
+          _schema,
+          receiver,
+          name,
+          typeArguments,
+          arguments,
+        ));
 
   ///
   Expression get receiver => node['receiver'] as Expression;
@@ -1672,13 +1944,18 @@ extension type MethodInvocation.fromJson(Map<String, Object?> node)
 ///
 extension type NamedArgument.fromJson(Map<String, Object?> node)
     implements Object {
+  static final TypedMapSchema _schema = TypedMapSchema({
+    'name': Type.stringPointer,
+    'expression': Type.typedMapPointer,
+  });
   NamedArgument({
     String? name,
     Expression? expression,
-  }) : this.fromJson({
-          if (name != null) 'name': name,
-          if (expression != null) 'expression': expression,
-        });
+  }) : this.fromJson(Scope.createMap(
+          _schema,
+          name,
+          expression,
+        ));
 
   ///
   String get name => node['name'] as String;
@@ -1690,13 +1967,18 @@ extension type NamedArgument.fromJson(Map<String, Object?> node)
 ///
 extension type NamedTypeAnnotation.fromJson(Map<String, Object?> node)
     implements Object {
+  static final TypedMapSchema _schema = TypedMapSchema({
+    'reference': Type.typedMapPointer,
+    'typeArguments': Type.closedListPointer,
+  });
   NamedTypeAnnotation({
     Reference? reference,
     List<TypeAnnotation>? typeArguments,
-  }) : this.fromJson({
-          if (reference != null) 'reference': reference,
-          if (typeArguments != null) 'typeArguments': typeArguments,
-        });
+  }) : this.fromJson(Scope.createMap(
+          _schema,
+          reference,
+          typeArguments,
+        ));
 
   ///
   Reference get reference => node['reference'] as Reference;
@@ -1709,11 +1991,15 @@ extension type NamedTypeAnnotation.fromJson(Map<String, Object?> node)
 ///
 extension type NullableTypeAnnotation.fromJson(Map<String, Object?> node)
     implements Object {
+  static final TypedMapSchema _schema = TypedMapSchema({
+    'typeAnnotation': Type.typedMapPointer,
+  });
   NullableTypeAnnotation({
     TypeAnnotation? typeAnnotation,
-  }) : this.fromJson({
-          if (typeAnnotation != null) 'typeAnnotation': typeAnnotation,
-        });
+  }) : this.fromJson(Scope.createMap(
+          _schema,
+          typeAnnotation,
+        ));
 
   ///
   TypeAnnotation get typeAnnotation => node['typeAnnotation'] as TypeAnnotation;
@@ -1722,13 +2008,18 @@ extension type NullableTypeAnnotation.fromJson(Map<String, Object?> node)
 ///
 extension type NullAwarePropertyGet.fromJson(Map<String, Object?> node)
     implements Object {
+  static final TypedMapSchema _schema = TypedMapSchema({
+    'receiver': Type.typedMapPointer,
+    'name': Type.stringPointer,
+  });
   NullAwarePropertyGet({
     Expression? receiver,
     String? name,
-  }) : this.fromJson({
-          if (receiver != null) 'receiver': receiver,
-          if (name != null) 'name': name,
-        });
+  }) : this.fromJson(Scope.createMap(
+          _schema,
+          receiver,
+          name,
+        ));
 
   ///
   Expression get receiver => node['receiver'] as Expression;
@@ -1739,11 +2030,15 @@ extension type NullAwarePropertyGet.fromJson(Map<String, Object?> node)
 
 ///
 extension type NullCheck.fromJson(Map<String, Object?> node) implements Object {
+  static final TypedMapSchema _schema = TypedMapSchema({
+    'expression': Type.typedMapPointer,
+  });
   NullCheck({
     Expression? expression,
-  }) : this.fromJson({
-          if (expression != null) 'expression': expression,
-        });
+  }) : this.fromJson(Scope.createMap(
+          _schema,
+          expression,
+        ));
 
   ///
   Expression get expression => node['expression'] as Expression;
@@ -1752,17 +2047,25 @@ extension type NullCheck.fromJson(Map<String, Object?> node) implements Object {
 ///
 extension type NullLiteral.fromJson(Map<String, Object?> node)
     implements Object {
-  NullLiteral() : this.fromJson({});
+  static final TypedMapSchema _schema = TypedMapSchema({});
+  NullLiteral()
+      : this.fromJson(Scope.createMap(
+          _schema,
+        ));
 }
 
 ///
 extension type ParenthesizedExpression.fromJson(Map<String, Object?> node)
     implements Object {
+  static final TypedMapSchema _schema = TypedMapSchema({
+    'expression': Type.typedMapPointer,
+  });
   ParenthesizedExpression({
     Expression? expression,
-  }) : this.fromJson({
-          if (expression != null) 'expression': expression,
-        });
+  }) : this.fromJson(Scope.createMap(
+          _schema,
+          expression,
+        ));
 
   ///
   Expression get expression => node['expression'] as Expression;
@@ -1771,11 +2074,15 @@ extension type ParenthesizedExpression.fromJson(Map<String, Object?> node)
 ///
 extension type PositionalArgument.fromJson(Map<String, Object?> node)
     implements Object {
+  static final TypedMapSchema _schema = TypedMapSchema({
+    'expression': Type.typedMapPointer,
+  });
   PositionalArgument({
     Expression? expression,
-  }) : this.fromJson({
-          if (expression != null) 'expression': expression,
-        });
+  }) : this.fromJson(Scope.createMap(
+          _schema,
+          expression,
+        ));
 
   ///
   Expression get expression => node['expression'] as Expression;
@@ -1784,13 +2091,18 @@ extension type PositionalArgument.fromJson(Map<String, Object?> node)
 ///
 extension type PropertyGet.fromJson(Map<String, Object?> node)
     implements Object {
+  static final TypedMapSchema _schema = TypedMapSchema({
+    'receiver': Type.typedMapPointer,
+    'name': Type.stringPointer,
+  });
   PropertyGet({
     Expression? receiver,
     String? name,
-  }) : this.fromJson({
-          if (receiver != null) 'receiver': receiver,
-          if (name != null) 'name': name,
-        });
+  }) : this.fromJson(Scope.createMap(
+          _schema,
+          receiver,
+          name,
+        ));
 
   ///
   Expression get receiver => node['receiver'] as Expression;
@@ -1802,11 +2114,15 @@ extension type PropertyGet.fromJson(Map<String, Object?> node)
 ///
 extension type RecordLiteral.fromJson(Map<String, Object?> node)
     implements Object {
+  static final TypedMapSchema _schema = TypedMapSchema({
+    'fields': Type.closedListPointer,
+  });
   RecordLiteral({
     List<RecordField>? fields,
-  }) : this.fromJson({
-          if (fields != null) 'fields': fields,
-        });
+  }) : this.fromJson(Scope.createMap(
+          _schema,
+          fields,
+        ));
 
   ///
   List<RecordField> get fields => (node['fields'] as List).cast();
@@ -1815,13 +2131,18 @@ extension type RecordLiteral.fromJson(Map<String, Object?> node)
 ///
 extension type RecordNamedField.fromJson(Map<String, Object?> node)
     implements Object {
+  static final TypedMapSchema _schema = TypedMapSchema({
+    'name': Type.stringPointer,
+    'expression': Type.typedMapPointer,
+  });
   RecordNamedField({
     String? name,
     Expression? expression,
-  }) : this.fromJson({
-          if (name != null) 'name': name,
-          if (expression != null) 'expression': expression,
-        });
+  }) : this.fromJson(Scope.createMap(
+          _schema,
+          name,
+          expression,
+        ));
 
   ///
   String get name => node['name'] as String;
@@ -1833,11 +2154,15 @@ extension type RecordNamedField.fromJson(Map<String, Object?> node)
 ///
 extension type RecordPositionalField.fromJson(Map<String, Object?> node)
     implements Object {
+  static final TypedMapSchema _schema = TypedMapSchema({
+    'expression': Type.typedMapPointer,
+  });
   RecordPositionalField({
     Expression? expression,
-  }) : this.fromJson({
-          if (expression != null) 'expression': expression,
-        });
+  }) : this.fromJson(Scope.createMap(
+          _schema,
+          expression,
+        ));
 
   ///
   Expression get expression => node['expression'] as Expression;
@@ -1846,13 +2171,18 @@ extension type RecordPositionalField.fromJson(Map<String, Object?> node)
 ///
 extension type RecordTypeAnnotation.fromJson(Map<String, Object?> node)
     implements Object {
+  static final TypedMapSchema _schema = TypedMapSchema({
+    'positional': Type.closedListPointer,
+    'named': Type.closedListPointer,
+  });
   RecordTypeAnnotation({
     List<RecordTypeEntry>? positional,
     List<RecordTypeEntry>? named,
-  }) : this.fromJson({
-          if (positional != null) 'positional': positional,
-          if (named != null) 'named': named,
-        });
+  }) : this.fromJson(Scope.createMap(
+          _schema,
+          positional,
+          named,
+        ));
 
   ///
   List<RecordTypeEntry> get positional => (node['positional'] as List).cast();
@@ -1864,25 +2194,38 @@ extension type RecordTypeAnnotation.fromJson(Map<String, Object?> node)
 ///
 extension type RecordTypeEntry.fromJson(Map<String, Object?> node)
     implements Object {
-  RecordTypeEntry() : this.fromJson({});
+  static final TypedMapSchema _schema = TypedMapSchema({});
+  RecordTypeEntry()
+      : this.fromJson(Scope.createMap(
+          _schema,
+        ));
 }
 
 ///
 extension type References.fromJson(Map<String, Object?> node)
     implements Object {
-  References() : this.fromJson({});
+  static final TypedMapSchema _schema = TypedMapSchema({});
+  References()
+      : this.fromJson(Scope.createMap(
+          _schema,
+        ));
 }
 
 ///
 extension type SetOrMapLiteral.fromJson(Map<String, Object?> node)
     implements Object {
+  static final TypedMapSchema _schema = TypedMapSchema({
+    'typeArguments': Type.closedListPointer,
+    'elements': Type.closedListPointer,
+  });
   SetOrMapLiteral({
     List<TypeAnnotation>? typeArguments,
     List<Element>? elements,
-  }) : this.fromJson({
-          if (typeArguments != null) 'typeArguments': typeArguments,
-          if (elements != null) 'elements': elements,
-        });
+  }) : this.fromJson(Scope.createMap(
+          _schema,
+          typeArguments,
+          elements,
+        ));
 
   ///
   List<TypeAnnotation> get typeArguments =>
@@ -1895,13 +2238,18 @@ extension type SetOrMapLiteral.fromJson(Map<String, Object?> node)
 ///
 extension type SpreadElement.fromJson(Map<String, Object?> node)
     implements Object {
+  static final TypedMapSchema _schema = TypedMapSchema({
+    'expression': Type.typedMapPointer,
+    'isNullAware': Type.boolean,
+  });
   SpreadElement({
     Expression? expression,
     bool? isNullAware,
-  }) : this.fromJson({
-          if (expression != null) 'expression': expression,
-          if (isNullAware != null) 'isNullAware': isNullAware,
-        });
+  }) : this.fromJson(Scope.createMap(
+          _schema,
+          expression,
+          isNullAware,
+        ));
 
   ///
   Expression get expression => node['expression'] as Expression;
@@ -1912,11 +2260,15 @@ extension type SpreadElement.fromJson(Map<String, Object?> node)
 
 ///
 extension type StaticGet.fromJson(Map<String, Object?> node) implements Object {
+  static final TypedMapSchema _schema = TypedMapSchema({
+    'reference': Type.typedMapPointer,
+  });
   StaticGet({
     FieldReference? reference,
-  }) : this.fromJson({
-          if (reference != null) 'reference': reference,
-        });
+  }) : this.fromJson(Scope.createMap(
+          _schema,
+          reference,
+        ));
 
   ///
   FieldReference get reference => node['reference'] as FieldReference;
@@ -1925,15 +2277,21 @@ extension type StaticGet.fromJson(Map<String, Object?> node) implements Object {
 ///
 extension type StaticInvocation.fromJson(Map<String, Object?> node)
     implements Object {
+  static final TypedMapSchema _schema = TypedMapSchema({
+    'function': Type.typedMapPointer,
+    'typeArguments': Type.closedListPointer,
+    'arguments': Type.closedListPointer,
+  });
   StaticInvocation({
     FunctionReference? function,
     List<TypeAnnotation>? typeArguments,
     List<Argument>? arguments,
-  }) : this.fromJson({
-          if (function != null) 'function': function,
-          if (typeArguments != null) 'typeArguments': typeArguments,
-          if (arguments != null) 'arguments': arguments,
-        });
+  }) : this.fromJson(Scope.createMap(
+          _schema,
+          function,
+          typeArguments,
+          arguments,
+        ));
 
   ///
   FunctionReference get function => node['function'] as FunctionReference;
@@ -1949,11 +2307,15 @@ extension type StaticInvocation.fromJson(Map<String, Object?> node)
 ///
 extension type AdjacentStringLiterals.fromJson(Map<String, Object?> node)
     implements Object {
+  static final TypedMapSchema _schema = TypedMapSchema({
+    'expressions': Type.closedListPointer,
+  });
   AdjacentStringLiterals({
     List<Expression>? expressions,
-  }) : this.fromJson({
-          if (expressions != null) 'expressions': expressions,
-        });
+  }) : this.fromJson(Scope.createMap(
+          _schema,
+          expressions,
+        ));
 
   ///
   List<Expression> get expressions => (node['expressions'] as List).cast();
@@ -1962,11 +2324,15 @@ extension type AdjacentStringLiterals.fromJson(Map<String, Object?> node)
 ///
 extension type StringLiteral.fromJson(Map<String, Object?> node)
     implements Object {
+  static final TypedMapSchema _schema = TypedMapSchema({
+    'parts': Type.closedListPointer,
+  });
   StringLiteral({
     List<StringLiteralPart>? parts,
-  }) : this.fromJson({
-          if (parts != null) 'parts': parts,
-        });
+  }) : this.fromJson(Scope.createMap(
+          _schema,
+          parts,
+        ));
 
   ///
   List<StringLiteralPart> get parts => (node['parts'] as List).cast();
@@ -1975,11 +2341,15 @@ extension type StringLiteral.fromJson(Map<String, Object?> node)
 ///
 extension type StringPart.fromJson(Map<String, Object?> node)
     implements Object {
+  static final TypedMapSchema _schema = TypedMapSchema({
+    'text': Type.stringPointer,
+  });
   StringPart({
     String? text,
-  }) : this.fromJson({
-          if (text != null) 'text': text,
-        });
+  }) : this.fromJson(Scope.createMap(
+          _schema,
+          text,
+        ));
 
   ///
   String get text => node['text'] as String;
@@ -1988,11 +2358,15 @@ extension type StringPart.fromJson(Map<String, Object?> node)
 ///
 extension type SymbolLiteral.fromJson(Map<String, Object?> node)
     implements Object {
+  static final TypedMapSchema _schema = TypedMapSchema({
+    'parts': Type.closedListPointer,
+  });
   SymbolLiteral({
     List<String>? parts,
-  }) : this.fromJson({
-          if (parts != null) 'parts': parts,
-        });
+  }) : this.fromJson(Scope.createMap(
+          _schema,
+          parts,
+        ));
 
   ///
   List<String> get parts => (node['parts'] as List).cast();
@@ -2001,17 +2375,25 @@ extension type SymbolLiteral.fromJson(Map<String, Object?> node)
 ///
 extension type TypedefReference.fromJson(Map<String, Object?> node)
     implements Object {
-  TypedefReference() : this.fromJson({});
+  static final TypedMapSchema _schema = TypedMapSchema({});
+  TypedefReference()
+      : this.fromJson(Scope.createMap(
+          _schema,
+        ));
 }
 
 ///
 extension type TypeLiteral.fromJson(Map<String, Object?> node)
     implements Object {
+  static final TypedMapSchema _schema = TypedMapSchema({
+    'typeAnnotation': Type.typedMapPointer,
+  });
   TypeLiteral({
     TypeAnnotation? typeAnnotation,
-  }) : this.fromJson({
-          if (typeAnnotation != null) 'typeAnnotation': typeAnnotation,
-        });
+  }) : this.fromJson(Scope.createMap(
+          _schema,
+          typeAnnotation,
+        ));
 
   ///
   TypeAnnotation get typeAnnotation => node['typeAnnotation'] as TypeAnnotation;
@@ -2020,19 +2402,28 @@ extension type TypeLiteral.fromJson(Map<String, Object?> node)
 ///
 extension type TypeReference.fromJson(Map<String, Object?> node)
     implements Object {
-  TypeReference() : this.fromJson({});
+  static final TypedMapSchema _schema = TypedMapSchema({});
+  TypeReference()
+      : this.fromJson(Scope.createMap(
+          _schema,
+        ));
 }
 
 ///
 extension type UnaryExpression.fromJson(Map<String, Object?> node)
     implements Object {
+  static final TypedMapSchema _schema = TypedMapSchema({
+    'operator': Type.stringPointer,
+    'expression': Type.typedMapPointer,
+  });
   UnaryExpression({
     UnaryOperator? operator,
     Expression? expression,
-  }) : this.fromJson({
-          if (operator != null) 'operator': operator,
-          if (expression != null) 'expression': expression,
-        });
+  }) : this.fromJson(Scope.createMap(
+          _schema,
+          operator,
+          expression,
+        ));
 
   ///
   UnaryOperator get operator => node['operator'] as UnaryOperator;
@@ -2044,23 +2435,35 @@ extension type UnaryExpression.fromJson(Map<String, Object?> node)
 ///
 extension type UnresolvedExpression.fromJson(Map<String, Object?> node)
     implements Object {
-  UnresolvedExpression() : this.fromJson({});
+  static final TypedMapSchema _schema = TypedMapSchema({});
+  UnresolvedExpression()
+      : this.fromJson(Scope.createMap(
+          _schema,
+        ));
 }
 
 ///
 extension type UnresolvedTypeAnnotation.fromJson(Map<String, Object?> node)
     implements Object {
-  UnresolvedTypeAnnotation() : this.fromJson({});
+  static final TypedMapSchema _schema = TypedMapSchema({});
+  UnresolvedTypeAnnotation()
+      : this.fromJson(Scope.createMap(
+          _schema,
+        ));
 }
 
 ///
 extension type VoidTypeAnnotation.fromJson(Map<String, Object?> node)
     implements Object {
+  static final TypedMapSchema _schema = TypedMapSchema({
+    'reference': Type.typedMapPointer,
+  });
   VoidTypeAnnotation({
     Reference? reference,
-  }) : this.fromJson({
-          if (reference != null) 'reference': reference,
-        });
+  }) : this.fromJson(Scope.createMap(
+          _schema,
+          reference,
+        ));
 
   ///
   Reference get reference => node['reference'] as Reference;

--- a/pkgs/dart_model/test/model_test.dart
+++ b/pkgs/dart_model/test/model_test.dart
@@ -16,13 +16,7 @@ void main() {
         model = Model()
           ..uris['package:dart_model/dart_model.dart'] = (Library()
             ..scopes['JsonData'] = (Interface(
-                properties: Properties(isClass: true),
-                metadataAnnotations: [
-                  MetadataAnnotation(
-                      type: QualifiedName(
-                          uri: 'package:dart_model/dart_model.dart',
-                          name: 'SomeAnnotation'))
-                ])
+                properties: Properties(isClass: true), metadataAnnotations: [])
               ..members['_root'] = Member(
                 properties: Properties(isField: true, isStatic: false),
               )));
@@ -34,14 +28,7 @@ void main() {
         'package:dart_model/dart_model.dart': {
           'scopes': {
             'JsonData': {
-              'metadataAnnotations': [
-                {
-                  'type': {
-                    'uri': 'package:dart_model/dart_model.dart',
-                    'name': 'SomeAnnotation'
-                  }
-                }
-              ],
+              'metadataAnnotations': <Map<String, Object?>>[],
               'members': {
                 '_root': {
                   'properties': {'isField': true, 'isStatic': false}

--- a/schemas/dart_model.schema.json
+++ b/schemas/dart_model.schema.json
@@ -85,9 +85,9 @@
       "type": "object",
       "description": "A metadata annotation.",
       "properties": {
-        "type": {
-          "$comment": "The type of the annotation.",
-          "$ref": "#/$defs/QualifiedName"
+        "expression": {
+          "$comment": "The expression of the annotation.",
+          "$ref": "file:macro_metadata.schema.json#/$defs/Expression"
         }
       }
     },

--- a/tool/dart_model_generator/lib/definitions.dart
+++ b/tool/dart_model_generator/lib/definitions.dart
@@ -113,9 +113,9 @@ static Protocol handshakeProtocol = Protocol(
             description: 'A metadata annotation.',
             createInBuffer: true,
             properties: [
-              Property('type',
-                  type: 'QualifiedName',
-                  description: 'The type of the annotation.'),
+              Property('expression',
+                  type: 'Expression',
+                  description: 'The expression of the annotation.'),
             ]),
         Definition.clazz('Declaration',
             description: 'Interface type for all declarations',

--- a/tool/dart_model_generator/lib/macro_metadata_definitions.dart
+++ b/tool/dart_model_generator/lib/macro_metadata_definitions.dart
@@ -11,6 +11,7 @@ import 'generate_dart_model.dart';
 final definitions = [
   Definition.union(
     'Argument',
+    createInBuffer: true,
     description: '',
     types: [
       'PositionalArgument',
@@ -20,6 +21,7 @@ final definitions = [
   ),
   Definition.union(
     'Element',
+    createInBuffer: true,
     description: '',
     types: [
       'ExpressionElement',
@@ -31,6 +33,7 @@ final definitions = [
   ),
   Definition.union(
     'Expression',
+    createInBuffer: true,
     description: '',
     types: [
       'InvalidExpression',
@@ -71,6 +74,7 @@ final definitions = [
   ),
   Definition.union(
     'RecordField',
+    createInBuffer: true,
     description: '',
     types: [
       'RecordNamedField',
@@ -80,6 +84,7 @@ final definitions = [
   ),
   Definition.union(
     'Reference',
+    createInBuffer: true,
     description: '',
     types: [
       'FieldReference',
@@ -97,6 +102,7 @@ final definitions = [
   ),
   Definition.union(
     'StringLiteralPart',
+    createInBuffer: true,
     description: '',
     types: [
       'StringPart',
@@ -106,6 +112,7 @@ final definitions = [
   ),
   Definition.union(
     'TypeAnnotation',
+    createInBuffer: true,
     description: '',
     types: [
       'NamedTypeAnnotation',
@@ -161,6 +168,7 @@ final definitions = [
   ),
   Definition.clazz(
     'AsExpression',
+    createInBuffer: true,
     description: '',
     properties: [
       Property('expression', type: 'Expression', description: ''),
@@ -169,6 +177,7 @@ final definitions = [
   ),
   Definition.clazz(
     'BinaryExpression',
+    createInBuffer: true,
     description: '',
     properties: [
       Property('left', type: 'Expression', description: ''),
@@ -178,6 +187,7 @@ final definitions = [
   ),
   Definition.clazz(
     'BooleanLiteral',
+    createInBuffer: true,
     description: '',
     properties: [
       Property('text', type: 'String', description: ''),
@@ -185,11 +195,13 @@ final definitions = [
   ),
   Definition.clazz(
     'ClassReference',
+    createInBuffer: true,
     description: '',
     properties: [],
   ),
   Definition.clazz(
     'ConditionalExpression',
+    createInBuffer: true,
     description: '',
     properties: [
       Property('condition', type: 'Expression', description: ''),
@@ -199,6 +211,7 @@ final definitions = [
   ),
   Definition.clazz(
     'ConstructorInvocation',
+    createInBuffer: true,
     description: '',
     properties: [
       Property('type', type: 'TypeAnnotation', description: ''),
@@ -208,11 +221,13 @@ final definitions = [
   ),
   Definition.clazz(
     'ConstructorReference',
+    createInBuffer: true,
     description: '',
     properties: [],
   ),
   Definition.clazz(
     'ConstructorTearOff',
+    createInBuffer: true,
     description: '',
     properties: [
       Property('type', type: 'TypeAnnotation', description: ''),
@@ -221,6 +236,7 @@ final definitions = [
   ),
   Definition.clazz(
     'DoubleLiteral',
+    createInBuffer: true,
     description: '',
     properties: [
       Property('text', type: 'String', description: ''),
@@ -228,6 +244,7 @@ final definitions = [
   ),
   Definition.clazz(
     'DynamicTypeAnnotation',
+    createInBuffer: true,
     description: '',
     properties: [
       Property('reference', type: 'Reference', description: ''),
@@ -235,11 +252,13 @@ final definitions = [
   ),
   Definition.clazz(
     'EnumReference',
+    createInBuffer: true,
     description: '',
     properties: [],
   ),
   Definition.clazz(
     'EqualityExpression',
+    createInBuffer: true,
     description: '',
     properties: [
       Property('left', type: 'Expression', description: ''),
@@ -249,6 +268,7 @@ final definitions = [
   ),
   Definition.clazz(
     'ExpressionElement',
+    createInBuffer: true,
     description: '',
     properties: [
       Property('expression', type: 'Expression', description: ''),
@@ -257,36 +277,43 @@ final definitions = [
   ),
   Definition.clazz(
     'ExtensionReference',
+    createInBuffer: true,
     description: '',
     properties: [],
   ),
   Definition.clazz(
     'ExtensionTypeReference',
+    createInBuffer: true,
     description: '',
     properties: [],
   ),
   Definition.clazz(
     'FieldReference',
+    createInBuffer: true,
     description: '',
     properties: [],
   ),
   Definition.clazz(
     'FormalParameter',
+    createInBuffer: true,
     description: '',
     properties: [],
   ),
   Definition.clazz(
     'FormalParameterGroup',
+    createInBuffer: true,
     description: '',
     properties: [],
   ),
   Definition.clazz(
     'FunctionReference',
+    createInBuffer: true,
     description: '',
     properties: [],
   ),
   Definition.clazz(
     'FunctionTearOff',
+    createInBuffer: true,
     description: '',
     properties: [
       Property('reference', type: 'FunctionReference', description: ''),
@@ -294,6 +321,7 @@ final definitions = [
   ),
   Definition.clazz(
     'FunctionTypeAnnotation',
+    createInBuffer: true,
     description: '',
     properties: [
       Property('returnType',
@@ -306,16 +334,19 @@ final definitions = [
   ),
   Definition.clazz(
     'FunctionTypeParameter',
+    createInBuffer: true,
     description: '',
     properties: [],
   ),
   Definition.clazz(
     'FunctionTypeParameterReference',
+    createInBuffer: true,
     description: '',
     properties: [],
   ),
   Definition.clazz(
     'FunctionTypeParameterType',
+    createInBuffer: true,
     description: '',
     properties: [
       Property('functionTypeParameter',
@@ -324,6 +355,7 @@ final definitions = [
   ),
   Definition.clazz(
     'IfElement',
+    createInBuffer: true,
     description: '',
     properties: [
       Property('condition', type: 'Expression', description: ''),
@@ -333,6 +365,7 @@ final definitions = [
   ),
   Definition.clazz(
     'IfNull',
+    createInBuffer: true,
     description: '',
     properties: [
       Property('left', type: 'Expression', description: ''),
@@ -341,6 +374,7 @@ final definitions = [
   ),
   Definition.clazz(
     'ImplicitInvocation',
+    createInBuffer: true,
     description: '',
     properties: [
       Property('receiver', type: 'Expression', description: ''),
@@ -350,6 +384,7 @@ final definitions = [
   ),
   Definition.clazz(
     'Instantiation',
+    createInBuffer: true,
     description: '',
     properties: [
       Property('receiver', type: 'Expression', description: ''),
@@ -358,6 +393,7 @@ final definitions = [
   ),
   Definition.clazz(
     'IntegerLiteral',
+    createInBuffer: true,
     description: '',
     properties: [
       Property('text', type: 'String', description: ''),
@@ -365,6 +401,7 @@ final definitions = [
   ),
   Definition.clazz(
     'InterpolationPart',
+    createInBuffer: true,
     description: '',
     properties: [
       Property('expression', type: 'Expression', description: ''),
@@ -372,16 +409,19 @@ final definitions = [
   ),
   Definition.clazz(
     'InvalidExpression',
+    createInBuffer: true,
     description: '',
     properties: [],
   ),
   Definition.clazz(
     'InvalidTypeAnnotation',
+    createInBuffer: true,
     description: '',
     properties: [],
   ),
   Definition.clazz(
     'IsTest',
+    createInBuffer: true,
     description: '',
     properties: [
       Property('expression', type: 'Expression', description: ''),
@@ -391,6 +431,7 @@ final definitions = [
   ),
   Definition.clazz(
     'ListLiteral',
+    createInBuffer: true,
     description: '',
     properties: [
       Property('typeArguments', type: 'List<TypeAnnotation>', description: ''),
@@ -399,6 +440,7 @@ final definitions = [
   ),
   Definition.clazz(
     'LogicalExpression',
+    createInBuffer: true,
     description: '',
     properties: [
       Property('left', type: 'Expression', description: ''),
@@ -408,6 +450,7 @@ final definitions = [
   ),
   Definition.clazz(
     'MapEntryElement',
+    createInBuffer: true,
     description: '',
     properties: [
       Property('key', type: 'Expression', description: ''),
@@ -418,6 +461,7 @@ final definitions = [
   ),
   Definition.clazz(
     'MethodInvocation',
+    createInBuffer: true,
     description: '',
     properties: [
       Property('receiver', type: 'Expression', description: ''),
@@ -428,6 +472,7 @@ final definitions = [
   ),
   Definition.clazz(
     'NamedArgument',
+    createInBuffer: true,
     description: '',
     properties: [
       Property('name', type: 'String', description: ''),
@@ -436,6 +481,7 @@ final definitions = [
   ),
   Definition.clazz(
     'NamedTypeAnnotation',
+    createInBuffer: true,
     description: '',
     properties: [
       Property('reference', type: 'Reference', description: ''),
@@ -444,6 +490,7 @@ final definitions = [
   ),
   Definition.clazz(
     'NullableTypeAnnotation',
+    createInBuffer: true,
     description: '',
     properties: [
       Property('typeAnnotation', type: 'TypeAnnotation', description: ''),
@@ -451,6 +498,7 @@ final definitions = [
   ),
   Definition.clazz(
     'NullAwarePropertyGet',
+    createInBuffer: true,
     description: '',
     properties: [
       Property('receiver', type: 'Expression', description: ''),
@@ -459,6 +507,7 @@ final definitions = [
   ),
   Definition.clazz(
     'NullCheck',
+    createInBuffer: true,
     description: '',
     properties: [
       Property('expression', type: 'Expression', description: ''),
@@ -466,11 +515,13 @@ final definitions = [
   ),
   Definition.clazz(
     'NullLiteral',
+    createInBuffer: true,
     description: '',
     properties: [],
   ),
   Definition.clazz(
     'ParenthesizedExpression',
+    createInBuffer: true,
     description: '',
     properties: [
       Property('expression', type: 'Expression', description: ''),
@@ -478,6 +529,7 @@ final definitions = [
   ),
   Definition.clazz(
     'PositionalArgument',
+    createInBuffer: true,
     description: '',
     properties: [
       Property('expression', type: 'Expression', description: ''),
@@ -485,6 +537,7 @@ final definitions = [
   ),
   Definition.clazz(
     'PropertyGet',
+    createInBuffer: true,
     description: '',
     properties: [
       Property('receiver', type: 'Expression', description: ''),
@@ -493,6 +546,7 @@ final definitions = [
   ),
   Definition.clazz(
     'RecordLiteral',
+    createInBuffer: true,
     description: '',
     properties: [
       Property('fields', type: 'List<RecordField>', description: ''),
@@ -500,6 +554,7 @@ final definitions = [
   ),
   Definition.clazz(
     'RecordNamedField',
+    createInBuffer: true,
     description: '',
     properties: [
       Property('name', type: 'String', description: ''),
@@ -508,6 +563,7 @@ final definitions = [
   ),
   Definition.clazz(
     'RecordPositionalField',
+    createInBuffer: true,
     description: '',
     properties: [
       Property('expression', type: 'Expression', description: ''),
@@ -515,6 +571,7 @@ final definitions = [
   ),
   Definition.clazz(
     'RecordTypeAnnotation',
+    createInBuffer: true,
     description: '',
     properties: [
       Property('positional', type: 'List<RecordTypeEntry>', description: ''),
@@ -523,16 +580,19 @@ final definitions = [
   ),
   Definition.clazz(
     'RecordTypeEntry',
+    createInBuffer: true,
     description: '',
     properties: [],
   ),
   Definition.clazz(
     'References',
+    createInBuffer: true,
     description: '',
     properties: [],
   ),
   Definition.clazz(
     'SetOrMapLiteral',
+    createInBuffer: true,
     description: '',
     properties: [
       Property('typeArguments', type: 'List<TypeAnnotation>', description: ''),
@@ -541,6 +601,7 @@ final definitions = [
   ),
   Definition.clazz(
     'SpreadElement',
+    createInBuffer: true,
     description: '',
     properties: [
       Property('expression', type: 'Expression', description: ''),
@@ -549,6 +610,7 @@ final definitions = [
   ),
   Definition.clazz(
     'StaticGet',
+    createInBuffer: true,
     description: '',
     properties: [
       Property('reference', type: 'FieldReference', description: ''),
@@ -556,6 +618,7 @@ final definitions = [
   ),
   Definition.clazz(
     'StaticInvocation',
+    createInBuffer: true,
     description: '',
     properties: [
       Property('function', type: 'FunctionReference', description: ''),
@@ -565,6 +628,7 @@ final definitions = [
   ),
   Definition.clazz(
     'AdjacentStringLiterals',
+    createInBuffer: true,
     description: '',
     properties: [
       Property('expressions', type: 'List<Expression>', description: ''),
@@ -572,6 +636,7 @@ final definitions = [
   ),
   Definition.clazz(
     'StringLiteral',
+    createInBuffer: true,
     description: '',
     properties: [
       Property('parts', type: 'List<StringLiteralPart>', description: ''),
@@ -579,6 +644,7 @@ final definitions = [
   ),
   Definition.clazz(
     'StringPart',
+    createInBuffer: true,
     description: '',
     properties: [
       Property('text', type: 'String', description: ''),
@@ -586,6 +652,7 @@ final definitions = [
   ),
   Definition.clazz(
     'SymbolLiteral',
+    createInBuffer: true,
     description: '',
     properties: [
       Property('parts', type: 'List<String>', description: ''),
@@ -593,11 +660,13 @@ final definitions = [
   ),
   Definition.clazz(
     'TypedefReference',
+    createInBuffer: true,
     description: '',
     properties: [],
   ),
   Definition.clazz(
     'TypeLiteral',
+    createInBuffer: true,
     description: '',
     properties: [
       Property('typeAnnotation', type: 'TypeAnnotation', description: ''),
@@ -605,11 +674,13 @@ final definitions = [
   ),
   Definition.clazz(
     'TypeReference',
+    createInBuffer: true,
     description: '',
     properties: [],
   ),
   Definition.clazz(
     'UnaryExpression',
+    createInBuffer: true,
     description: '',
     properties: [
       Property('operator', type: 'UnaryOperator', description: ''),
@@ -618,16 +689,19 @@ final definitions = [
   ),
   Definition.clazz(
     'UnresolvedExpression',
+    createInBuffer: true,
     description: '',
     properties: [],
   ),
   Definition.clazz(
     'UnresolvedTypeAnnotation',
+    createInBuffer: true,
     description: '',
     properties: [],
   ),
   Definition.clazz(
     'VoidTypeAnnotation',
+    createInBuffer: true,
     description: '',
     properties: [
       Property('reference', type: 'Reference', description: ''),


### PR DESCRIPTION
Wire up macro metadata in queries in the analyzer implementation.

Use `parseAnnotation` in the analyzer codebase and the converter in `_analyzer_cfe_macros`.

`dart_model` type `MetadataAnnotation` holds an `Expression` instead of a `QualifiedName`.

Add goldens/foo/lib/metadata.dart and goldens/foo/lib/metadata.analyzer.json which shows it working for a couple of primitive named fields.

`dart_model` definitions changed to add `createInBuffer: true` so they can be added to query results.