### PR TITLE
[Do not submit] Add model digest

### DIFF
--- a/pkgs/dart_model/lib/src/dart_model.g.dart
+++ b/pkgs/dart_model/lib/src/dart_model.g.dart
@@ -2,6 +2,10 @@
 // then run from the repo root: dart tool/dart_model_generator/bin/main.dart
 
 // ignore: implementation_imports,unused_import,prefer_relative_imports
+import 'dart:typed_data';
+// ignore: implementation_imports,unused_import,prefer_relative_imports
+import 'package:crypto/crypto.dart';
+// ignore: implementation_imports,unused_import,prefer_relative_imports
 import 'package:dart_model/src/deep_cast_map.dart';
 // ignore: implementation_imports,unused_import,prefer_relative_imports
 import 'package:dart_model/src/json_buffer/json_buffer_builder.dart';
@@ -251,6 +255,8 @@ extension type Model.fromJson(Map<String, Object?> node) implements Object {
           Scope.createGrowableMap(),
           types,
         ));
+// A digest of all the bytes in the current buffer.
+  Digest get digest => md5.convert((node as MapInBuffer).buffer.serialize());
 
   /// Libraries by URI.
   Map<String, Library> get uris =>

--- a/pkgs/dart_model/lib/src/dart_model.g.dart
+++ b/pkgs/dart_model/lib/src/dart_model.g.dart
@@ -256,7 +256,10 @@ extension type Model.fromJson(Map<String, Object?> node) implements Object {
           types,
         ));
 // A digest of all the bytes in the current buffer.
-  Digest get digest => md5.convert((node as MapInBuffer).buffer.serialize());
+  Digest get digest => md5.convert(switch (node) {
+        MapInBuffer mapInBuffer => mapInBuffer.buffer.serialize(),
+        _ => (JsonBufferBuilder()..map.addAll(node)).serialize(),
+      });
 
   /// Libraries by URI.
   Map<String, Library> get uris =>

--- a/pkgs/dart_model/lib/src/json_buffer/iterables.dart
+++ b/pkgs/dart_model/lib/src/json_buffer/iterables.dart
@@ -42,7 +42,7 @@ class _IteratorFunctionIterable<T> extends Iterable<T> {
 
 /// A `Map` in a `JsonBufferBuilder`.
 abstract interface class MapInBuffer {
-  /// The buffer backing this `Map`.
+  /// The buffer backing this [Map].
   JsonBufferBuilder get buffer;
 
   /// The `Map` that contains this value, or `null` if this value has not been

--- a/pkgs/dart_model/lib/src/macro_metadata.g.dart
+++ b/pkgs/dart_model/lib/src/macro_metadata.g.dart
@@ -2,6 +2,10 @@
 // then run from the repo root: dart tool/dart_model_generator/bin/main.dart
 
 // ignore: implementation_imports,unused_import,prefer_relative_imports
+import 'dart:typed_data';
+// ignore: implementation_imports,unused_import,prefer_relative_imports
+import 'package:crypto/crypto.dart';
+// ignore: implementation_imports,unused_import,prefer_relative_imports
 import 'package:dart_model/src/deep_cast_map.dart';
 // ignore: implementation_imports,unused_import,prefer_relative_imports
 import 'package:dart_model/src/json_buffer/json_buffer_builder.dart';

--- a/pkgs/dart_model/pubspec.yaml
+++ b/pkgs/dart_model/pubspec.yaml
@@ -12,6 +12,7 @@ environment:
 
 dependencies:
   collection: ^1.19.0
+  crypto: ^3.0.6
 
 dev_dependencies:
   benchmark_harness: ^2.2.2

--- a/pkgs/dart_model/test/model_test.dart
+++ b/pkgs/dart_model/test/model_test.dart
@@ -201,6 +201,11 @@ void main() {
       expect(copiedModel.qualifiedNameOf(member.node), null);
       expect(model.qualifiedNameOf(copiedMember.node), null);
     });
+
+    test('can produce and compare digests for buffer and SDK maps', () {
+      final copiedModel = Model.fromJson(_copyMap(model.node));
+      expect(model.digest, copiedModel.digest);
+    });
   });
 
   group('QualifiedName', () {

--- a/pkgs/macro_service/lib/src/handshake.g.dart
+++ b/pkgs/macro_service/lib/src/handshake.g.dart
@@ -2,6 +2,10 @@
 // then run from the repo root: dart tool/dart_model_generator/bin/main.dart
 
 // ignore: implementation_imports,unused_import,prefer_relative_imports
+import 'dart:typed_data';
+// ignore: implementation_imports,unused_import,prefer_relative_imports
+import 'package:crypto/crypto.dart';
+// ignore: implementation_imports,unused_import,prefer_relative_imports
 import 'package:dart_model/src/deep_cast_map.dart';
 // ignore: implementation_imports,unused_import,prefer_relative_imports
 import 'package:dart_model/src/json_buffer/json_buffer_builder.dart';

--- a/pkgs/macro_service/lib/src/macro_service.g.dart
+++ b/pkgs/macro_service/lib/src/macro_service.g.dart
@@ -2,6 +2,10 @@
 // then run from the repo root: dart tool/dart_model_generator/bin/main.dart
 
 // ignore: implementation_imports,unused_import,prefer_relative_imports
+import 'dart:typed_data';
+// ignore: implementation_imports,unused_import,prefer_relative_imports
+import 'package:crypto/crypto.dart';
+// ignore: implementation_imports,unused_import,prefer_relative_imports
 import 'package:dart_model/src/dart_model.g.dart';
 // ignore: implementation_imports,unused_import,prefer_relative_imports
 import 'package:dart_model/src/deep_cast_map.dart';

--- a/tool/dart_model_generator/lib/definitions.dart
+++ b/tool/dart_model_generator/lib/definitions.dart
@@ -183,16 +183,21 @@ static Protocol handshakeProtocol = Protocol(
                   description: 'The named parameters of this member, '
                       'if it has them.'),
             ]),
-        Definition.clazz('Model',
-            description: 'Partial model of a corpus of Dart source code.',
-            createInBuffer: true,
-            properties: [
-              Property('uris',
-                  type: 'Map<Library>', description: 'Libraries by URI.'),
-              Property('types',
-                  type: 'TypeHierarchy',
-                  description: 'The resolved static type hierarchy.'),
-            ]),
+        Definition.clazz(
+          'Model',
+          description: 'Partial model of a corpus of Dart source code.',
+          createInBuffer: true,
+          properties: [
+            Property('uris',
+                type: 'Map<Library>', description: 'Libraries by URI.'),
+            Property('types',
+                type: 'TypeHierarchy',
+                description: 'The resolved static type hierarchy.'),
+          ],
+          extraCode: '// A digest of all the bytes in the current buffer.\n'
+              'Digest get digest => '
+              'md5.convert((node as MapInBuffer).buffer.serialize());',
+        ),
         Definition.clazz('NamedFunctionTypeParameter',
             description:
                 'A resolved named parameter as part of a [FunctionTypeDesc].',

--- a/tool/dart_model_generator/lib/generate_dart_model.dart
+++ b/tool/dart_model_generator/lib/generate_dart_model.dart
@@ -65,6 +65,8 @@ class GenerationContext {
         lookupDeclaringSchema(typeName),
     }.nonNulls;
     return ([
+      "import 'dart:typed_data';",
+      "import 'package:crypto/crypto.dart';",
       "import 'package:dart_model/src/json_buffer/json_buffer_builder.dart';",
       "import 'package:dart_model/src/deep_cast_map.dart';",
       "import 'package:dart_model/src/scopes.dart';",


### PR DESCRIPTION
I created this simplified version of a model digest mostly out of curiosity to see if it could actually work, and it turns out it doesn't :). The test fails because the digests are different.

I think that just hashing the raw bytes can never really be relied upon because of all the pointers in the bytes - unless it is built in exactly the same order the bytes will inevitably be different.

There is another issue that if the Model is a not the root of the buffer, it will capture more information than we want, in particular info that is not hermetic (for instance, request IDs).

So, I think we will need a different approach here.