### PR TITLE
Use Object.hash to hash raw bytes

### DIFF
--- a/pkgs/_macro_host/lib/src/macro_cache.dart
+++ b/pkgs/_macro_host/lib/src/macro_cache.dart
@@ -36,7 +36,7 @@ class MacroResultsCache {
           .skip(1)
           .fold(queryResults.first.response,
               (model, next) => model.mergeWith(next.response))
-          .identityHash,
+          .fingerprint,
       response: response
     );
   }
@@ -61,7 +61,7 @@ class MacroResultsCache {
         .skip(1)
         .fold(queryResults.first.model,
             (model, next) => model.mergeWith(next.model))
-        .identityHash;
+        .fingerprint;
     if (newResultsHash != cached.resultsHash) {
       _cache.remove(cacheKey);
       return null;

--- a/pkgs/dart_model/lib/src/dart_model.dart
+++ b/pkgs/dart_model/lib/src/dart_model.dart
@@ -34,7 +34,7 @@ extension ModelExtension on Model {
   int get identityHash {
     // TODO: Implementation for non-buffer maps?
     var node = this.node as MapInBuffer;
-    return node.buffer.identityHash(node.pointer,
+    return node.buffer.fingerprint(node.pointer,
         type: Type.typedMapPointer, alreadyDereferenced: true);
   }
 

--- a/pkgs/dart_model/lib/src/dart_model.dart
+++ b/pkgs/dart_model/lib/src/dart_model.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:collection/collection.dart';
-
 import 'dart_model.g.dart';
 import 'json_buffer/json_buffer_builder.dart';
 import 'lazy_merged_map.dart';
@@ -33,7 +31,12 @@ extension ModelExtension on Model {
   /// An identity hash for `this`, used for comparing query results.
   ///
   /// TODO: A faster/better implementation?
-  int get identityHash => const DeepCollectionEquality().hash(node);
+  int get identityHash {
+    // TODO: Implementation for non-buffer maps?
+    var node = this.node as MapInBuffer;
+    return node.buffer.identityHash(node.pointer,
+        type: Type.typedMapPointer, alreadyDereferenced: true);
+  }
 
   /// Looks up [name] in `this`.
   ///

--- a/pkgs/dart_model/lib/src/dart_model.dart
+++ b/pkgs/dart_model/lib/src/dart_model.dart
@@ -31,7 +31,7 @@ extension ModelExtension on Model {
   /// An identity hash for `this`, used for comparing query results.
   ///
   /// TODO: A faster/better implementation?
-  int get identityHash {
+  int get fingerprint {
     // TODO: Implementation for non-buffer maps?
     var node = this.node as MapInBuffer;
     return node.buffer.fingerprint(node.pointer,

--- a/pkgs/dart_model/lib/src/json_buffer/closed_list.dart
+++ b/pkgs/dart_model/lib/src/json_buffer/closed_list.dart
@@ -78,7 +78,7 @@ class _ClosedList with ListMixin<Object?> {
     throw UnsupportedError('This JsonBufferBuilder list is read-only.');
   }
 
-  int fingerprint() {
+  int get fingerprint {
     var iterator = _ClosedListHashIterator(_buffer, _pointer, length);
     var hash = 0;
     while (iterator.moveNext()) {

--- a/pkgs/dart_model/lib/src/json_buffer/closed_list.dart
+++ b/pkgs/dart_model/lib/src/json_buffer/closed_list.dart
@@ -77,10 +77,19 @@ class _ClosedList with ListMixin<Object?> {
   set length(int length) {
     throw UnsupportedError('This JsonBufferBuilder list is read-only.');
   }
+
+  int fingerprint() {
+    var iterator = _ClosedListHashIterator(_buffer, _pointer, length);
+    var hash = 0;
+    while (iterator.moveNext()) {
+      hash = Object.hash(hash, iterator.current);
+    }
+    return hash;
+  }
 }
 
 /// `Iterator` that reads a "closed list" in a [JsonBufferBuilder].
-class _ClosedListIterator implements Iterator<Object?> {
+class _ClosedListIterator<T extends Object?> implements Iterator<T> {
   final JsonBufferBuilder _buffer;
   final _Pointer _last;
   _Pointer _pointer;
@@ -91,7 +100,7 @@ class _ClosedListIterator implements Iterator<Object?> {
         _pointer = pointer + _lengthSize - ClosedLists._valueSize;
 
   @override
-  Object? get current => _buffer._readAny(_pointer);
+  T get current => _buffer._readAny(_pointer) as T;
 
   @override
   bool moveNext() {
@@ -100,4 +109,11 @@ class _ClosedListIterator implements Iterator<Object?> {
     _pointer += ClosedLists._valueSize;
     return _pointer != _last;
   }
+}
+
+class _ClosedListHashIterator extends _ClosedListIterator<int> {
+  _ClosedListHashIterator(super.buffer, super.pointer, super.length);
+
+  @override
+  int get current => _buffer.fingerprint(_pointer);
 }

--- a/pkgs/dart_model/lib/src/json_buffer/closed_map.dart
+++ b/pkgs/dart_model/lib/src/json_buffer/closed_map.dart
@@ -114,12 +114,21 @@ class _ClosedMap
 
   @override
   int get hashCode => Object.hash(buffer, pointer);
+
+  int fingerprint() {
+    var iterator = _ClosedMapHashIterator(buffer, null, pointer, length);
+    var hash = 0;
+    while (iterator.moveNext()) {
+      hash = Object.hash(hash, iterator.current);
+    }
+    return hash;
+  }
 }
 
 /// `Iterator` that reads a "closed map" in a [JsonBufferBuilder].
 abstract class _ClosedMapIterator<T> implements Iterator<T> {
   final JsonBufferBuilder _buffer;
-  final _ClosedMap _parent;
+  final _ClosedMap? _parent;
   final _Pointer _last;
 
   _Pointer _pointer;
@@ -147,7 +156,7 @@ abstract class _ClosedMapIterator<T> implements Iterator<T> {
 
 class _ClosedMapKeyIterator extends _ClosedMapIterator<String> {
   _ClosedMapKeyIterator(
-      super._buffer, super._porent, super.pointer, super.length);
+      super._buffer, super._parent, super.pointer, super.length);
 
   @override
   String get current => _currentKey;
@@ -155,7 +164,7 @@ class _ClosedMapKeyIterator extends _ClosedMapIterator<String> {
 
 class _ClosedMapValueIterator extends _ClosedMapIterator<Object?> {
   _ClosedMapValueIterator(
-      super._buffer, super._porent, super.pointer, super.length);
+      super._buffer, super._parent, super.pointer, super.length);
 
   @override
   Object? get current => _currentValue;
@@ -164,8 +173,19 @@ class _ClosedMapValueIterator extends _ClosedMapIterator<Object?> {
 class _ClosedMapEntryIterator
     extends _ClosedMapIterator<MapEntry<String, Object?>> {
   _ClosedMapEntryIterator(
-      super._buffer, super._porent, super.pointer, super.length);
+      super._buffer, super._parent, super.pointer, super.length);
 
   @override
   MapEntry<String, Object?> get current => MapEntry(_currentKey, _currentValue);
+}
+
+class _ClosedMapHashIterator extends _ClosedMapIterator<int> {
+  _ClosedMapHashIterator(
+      super._buffer, super._parent, super.pointer, super.length);
+
+  @override
+  int get current => Object.hash(
+        _buffer._fingerprint(_pointer, Type.stringPointer),
+        _buffer.fingerprint(_pointer + ClosedMaps._keySize),
+      );
 }

--- a/pkgs/dart_model/lib/src/json_buffer/closed_map.dart
+++ b/pkgs/dart_model/lib/src/json_buffer/closed_map.dart
@@ -55,14 +55,15 @@ class _ClosedMap
     implements MapInBuffer {
   @override
   final JsonBufferBuilder buffer;
-  final _Pointer _pointer;
+  @override
+  final _Pointer pointer;
   @override
   final Map<String, Object?>? parent;
   @override
   final int length;
 
-  _ClosedMap(this.buffer, this._pointer, this.parent)
-      : length = buffer._readLength(_pointer);
+  _ClosedMap(this.buffer, this.pointer, this.parent)
+      : length = buffer._readLength(pointer);
 
   @override
   Object? operator [](Object? key) {
@@ -75,18 +76,18 @@ class _ClosedMap
 
   @override
   late final Iterable<String> keys = _IteratorFunctionIterable(
-      () => _ClosedMapKeyIterator(buffer, this, _pointer, length),
+      () => _ClosedMapKeyIterator(buffer, this, pointer, length),
       length: length);
 
   @override
   late final Iterable<Object?> values = _IteratorFunctionIterable(
-      () => _ClosedMapValueIterator(buffer, this, _pointer, length),
+      () => _ClosedMapValueIterator(buffer, this, pointer, length),
       length: length);
 
   @override
   late final Iterable<MapEntry<String, Object?>> entries =
       _IteratorFunctionIterable(
-          () => _ClosedMapEntryIterator(buffer, this, _pointer, length),
+          () => _ClosedMapEntryIterator(buffer, this, pointer, length),
           length: length);
 
   @override
@@ -109,12 +110,10 @@ class _ClosedMap
 
   @override
   bool operator ==(Object other) =>
-      other is _ClosedMap &&
-      other.buffer == buffer &&
-      other._pointer == _pointer;
+      other is _ClosedMap && other.buffer == buffer && other.pointer == pointer;
 
   @override
-  int get hashCode => Object.hash(buffer, _pointer);
+  int get hashCode => Object.hash(buffer, pointer);
 }
 
 /// `Iterator` that reads a "closed map" in a [JsonBufferBuilder].

--- a/pkgs/dart_model/lib/src/json_buffer/closed_map.dart
+++ b/pkgs/dart_model/lib/src/json_buffer/closed_map.dart
@@ -115,7 +115,7 @@ class _ClosedMap
   @override
   int get hashCode => Object.hash(buffer, pointer);
 
-  int fingerprint() {
+  int get fingerprint {
     var iterator = _ClosedMapHashIterator(buffer, null, pointer, length);
     var hash = 0;
     while (iterator.moveNext()) {

--- a/pkgs/dart_model/lib/src/json_buffer/growable_map.dart
+++ b/pkgs/dart_model/lib/src/json_buffer/growable_map.dart
@@ -168,6 +168,15 @@ class _GrowableMap<V>
 
   @override
   int get hashCode => Object.hash(buffer, pointer);
+
+  int fingerprint() {
+    var iterator = _GrowableMapHashIterator(buffer, null, pointer);
+    var hash = 0;
+    while (iterator.moveNext()) {
+      hash = Object.hash(hash, iterator.current);
+    }
+    return hash;
+  }
 }
 
 /// `Iterator` that reads a "growable map" in a [JsonBufferBuilder].

--- a/pkgs/dart_model/lib/src/json_buffer/growable_map.dart
+++ b/pkgs/dart_model/lib/src/json_buffer/growable_map.dart
@@ -52,7 +52,7 @@ extension GrowableMaps on JsonBufferBuilder {
   /// [createGrowableMap]. Otherwise, [UnsupportedError] is thrown.
   _Pointer _pointerToGrowableMap(_GrowableMap<Object?> map) {
     _checkGrowableMapOwnership(map);
-    return map._pointer;
+    return map.pointer;
   }
 
   /// Throws if [map is backed by a different buffer to `this`.
@@ -75,14 +75,15 @@ class _GrowableMap<V>
     implements MapInBuffer {
   @override
   final JsonBufferBuilder buffer;
-  final _Pointer _pointer;
+  @override
+  final _Pointer pointer;
   @override
   final Map<String, Object?>? parent;
   int _length;
   _Pointer? _lastPointer;
 
-  _GrowableMap(this.buffer, this._pointer, this.parent)
-      : _length = buffer._readLength(_pointer + _pointerSize);
+  _GrowableMap(this.buffer, this.pointer, this.parent)
+      : _length = buffer._readLength(pointer + _pointerSize);
 
   @override
   int get length => _length;
@@ -100,17 +101,17 @@ class _GrowableMap<V>
 
   @override
   late final Iterable<String> keys = _IteratorFunctionIterable(
-      () => _GrowableMapKeyIterator(buffer, this, _pointer),
+      () => _GrowableMapKeyIterator(buffer, this, pointer),
       length: length);
 
   @override
   late final Iterable<V> values = _IteratorFunctionIterable(
-      () => _GrowableMapValueIterator<V>(buffer, this, _pointer),
+      () => _GrowableMapValueIterator<V>(buffer, this, pointer),
       length: length);
 
   @override
   late final Iterable<MapEntry<String, V>> entries = _IteratorFunctionIterable(
-      () => _GrowableMapEntryIterator(buffer, this, _pointer),
+      () => _GrowableMapEntryIterator(buffer, this, pointer),
       length: length);
 
   /// Add [value] to the map with key [key].
@@ -125,27 +126,27 @@ class _GrowableMap<V>
 
     // If `_lastPointer` is not set yet, walk the map to find the end of it.
     if (_lastPointer == null) {
-      final iterator = _GrowableMapEntryIterator<V>(buffer, this, _pointer);
-      _lastPointer = _pointer;
+      final iterator = _GrowableMapEntryIterator<V>(buffer, this, pointer);
+      _lastPointer = pointer;
       while (iterator.moveNext()) {
         _lastPointer = iterator._pointer;
       }
     }
 
     // Reserve and write the new node.
-    final pointer = buffer._reserve(GrowableMaps._entrySize);
-    final entryPointer = pointer + _pointerSize;
+    final newPointer = buffer._reserve(GrowableMaps._entrySize);
+    final entryPointer = newPointer + _pointerSize;
     buffer._writePointer(entryPointer, buffer._pointerToString(key));
     buffer._writeAny(entryPointer + _pointerSize, value);
 
     // Point to the new node in the previous node.
-    buffer._writePointer(_lastPointer!, pointer);
+    buffer._writePointer(_lastPointer!, newPointer);
     // Update `_lastPointer` to the new node.
-    _lastPointer = pointer;
+    _lastPointer = newPointer;
 
     // Update length.
     ++_length;
-    buffer._writeLength(_pointer + _pointerSize, length, allowOverwrite: true);
+    buffer._writeLength(pointer + _pointerSize, length, allowOverwrite: true);
     buffer._explanations?.pop();
   }
 
@@ -163,16 +164,16 @@ class _GrowableMap<V>
   bool operator ==(Object other) =>
       other is _GrowableMap &&
       other.buffer == buffer &&
-      other._pointer == _pointer;
+      other.pointer == pointer;
 
   @override
-  int get hashCode => Object.hash(buffer, _pointer);
+  int get hashCode => Object.hash(buffer, pointer);
 }
 
 /// `Iterator` that reads a "growable map" in a [JsonBufferBuilder].
 abstract class _GrowableMapIterator<T> implements Iterator<T> {
   final JsonBufferBuilder _buffer;
-  final _GrowableMap _parent;
+  final _GrowableMap? _parent;
   _Pointer _pointer;
 
   _GrowableMapIterator(this._buffer, this._parent, this._pointer);
@@ -213,4 +214,14 @@ class _GrowableMapEntryIterator<V>
 
   @override
   MapEntry<String, V> get current => MapEntry(_currentKey, _currentValue as V);
+}
+
+class _GrowableMapHashIterator extends _GrowableMapIterator<int> {
+  _GrowableMapHashIterator(super._buffer, super._parent, super._pointer);
+
+  @override
+  int get current => Object.hash(
+        _buffer._identityHash(_pointer + _pointerSize, Type.stringPointer),
+        _buffer.identityHash(_pointer + _pointerSize + GrowableMaps._keySize),
+      );
 }

--- a/pkgs/dart_model/lib/src/json_buffer/growable_map.dart
+++ b/pkgs/dart_model/lib/src/json_buffer/growable_map.dart
@@ -221,7 +221,7 @@ class _GrowableMapHashIterator extends _GrowableMapIterator<int> {
 
   @override
   int get current => Object.hash(
-        _buffer._identityHash(_pointer + _pointerSize, Type.stringPointer),
-        _buffer.identityHash(_pointer + _pointerSize + GrowableMaps._keySize),
+        _buffer._fingerprint(_pointer + _pointerSize, Type.stringPointer),
+        _buffer.fingerprint(_pointer + _pointerSize + GrowableMaps._keySize),
       );
 }

--- a/pkgs/dart_model/lib/src/json_buffer/growable_map.dart
+++ b/pkgs/dart_model/lib/src/json_buffer/growable_map.dart
@@ -169,7 +169,7 @@ class _GrowableMap<V>
   @override
   int get hashCode => Object.hash(buffer, pointer);
 
-  int fingerprint() {
+  int get fingerprint {
     var iterator = _GrowableMapHashIterator(buffer, null, pointer);
     var hash = 0;
     while (iterator.moveNext()) {

--- a/pkgs/dart_model/lib/src/json_buffer/iterables.dart
+++ b/pkgs/dart_model/lib/src/json_buffer/iterables.dart
@@ -48,4 +48,7 @@ abstract interface class MapInBuffer {
   /// The `Map` that contains this value, or `null` if this value has not been
   /// added to a `Map` or is itself the root `Map`.
   Map<String, Object?>? get parent;
+
+  /// A pointer to the start of this object in [buffer].
+  int get pointer;
 }

--- a/pkgs/dart_model/lib/src/json_buffer/json_buffer_builder.dart
+++ b/pkgs/dart_model/lib/src/json_buffer/json_buffer_builder.dart
@@ -62,13 +62,12 @@ class JsonBufferBuilder {
   /// If [alreadyDereferenced] is `true`, then for types which are pointers,
   /// [pointer] already points at the top of the object, and should not be
   /// followed before reading the object.
-  int identityHash(int pointer,
-      {Type? type, bool alreadyDereferenced = false}) {
+  int fingerprint(int pointer, {Type? type, bool alreadyDereferenced = false}) {
     if (type == null) {
       type = _readType(pointer);
       pointer += _typeSize;
     }
-    return _identityHash(pointer, type,
+    return _fingerprint(pointer, type,
         alreadyDereferenced: alreadyDereferenced);
   }
 
@@ -78,7 +77,7 @@ class JsonBufferBuilder {
   /// If [alreadyDereferenced] is `true`, then for types which are pointers,
   /// [pointer] already points at the top of the object, and should not be
   /// followed before reading the object.
-  int _identityHash(_Pointer pointer, Type type,
+  int _fingerprint(_Pointer pointer, Type type,
       {bool alreadyDereferenced = false}) {
     // Dereference [pointer] if it is a pointer type, and hasn't already been
     // dereferenced.
@@ -92,13 +91,13 @@ class JsonBufferBuilder {
       case Type.type:
         return _buffer[pointer];
       case Type.pointer:
-        return identityHash(pointer);
+        return fingerprint(pointer);
       case Type.uint32:
         return _readUint32(pointer);
       case Type.boolean:
         return _buffer[pointer];
       case Type.anyPointer:
-        return identityHash(pointer);
+        return fingerprint(pointer);
       case Type.stringPointer:
         final length = _readLength(pointer);
         pointer += _lengthSize;
@@ -107,12 +106,12 @@ class JsonBufferBuilder {
         final length = _readLength(pointer);
         pointer += _lengthSize;
         return Object.hashAll(Iterable.generate(
-            length, (i) => identityHash(pointer + i * ClosedLists._valueSize)));
+            length, (i) => fingerprint(pointer + i * ClosedLists._valueSize)));
       case Type.closedMapPointer:
         final length = _readLength(pointer);
         pointer += _lengthSize;
         return Object.hashAll(Iterable.generate(
-            length, (i) => identityHash(pointer + i * ClosedMaps._valueSize)));
+            length, (i) => fingerprint(pointer + i * ClosedMaps._valueSize)));
       case Type.growableMapPointer:
         var iterator = _GrowableMapHashIterator(this, null, pointer);
         var hash = 0;

--- a/pkgs/dart_model/lib/src/json_buffer/json_buffer_builder.dart
+++ b/pkgs/dart_model/lib/src/json_buffer/json_buffer_builder.dart
@@ -103,32 +103,13 @@ class JsonBufferBuilder {
         pointer += _lengthSize;
         return Object.hashAll(_buffer.sublist(pointer, pointer + length));
       case Type.closedListPointer:
-        final length = _readLength(pointer);
-        pointer += _lengthSize;
-        return Object.hashAll(Iterable.generate(
-            length, (i) => fingerprint(pointer + i * ClosedLists._valueSize)));
+        return _ClosedList(this, pointer).fingerprint();
       case Type.closedMapPointer:
-        final length = _readLength(pointer);
-        pointer += _lengthSize;
-        return Object.hashAll(Iterable.generate(
-            length, (i) => fingerprint(pointer + i * ClosedMaps._valueSize)));
+        return _ClosedMap(this, pointer, null).fingerprint();
       case Type.growableMapPointer:
-        var iterator = _GrowableMapHashIterator(this, null, pointer);
-        var hash = 0;
-        while (iterator.moveNext()) {
-          hash = Object.hash(hash, iterator.current);
-        }
-        return hash;
+        return _GrowableMap<Object?>(this, pointer, null).fingerprint();
       case Type.typedMapPointer:
-        final typedMap = _TypedMap(this, pointer, null);
-        var hash = 0;
-        final iterator = typedMap._schema._isAllBooleans
-            ? _AllBoolsTypedMapHashIterator(typedMap)
-            : _PartialTypedMapHashIterator(typedMap);
-        while (iterator.moveNext()) {
-          hash = Object.hash(hash, iterator.current);
-        }
-        return hash;
+        return _TypedMap(this, pointer, null).fingerprint();
     }
   }
 

--- a/pkgs/dart_model/lib/src/json_buffer/json_buffer_builder.dart
+++ b/pkgs/dart_model/lib/src/json_buffer/json_buffer_builder.dart
@@ -52,6 +52,87 @@ class JsonBufferBuilder {
     map = createGrowableMap<Object?>();
   }
 
+  /// Computes the identity hash of the object at [pointer] from its raw bytes.
+  ///
+  /// Any nested pointers use the hash of the values they point to.
+  ///
+  /// If [type] is provided, [pointer] should point directly at the object.
+  /// Otherwise a [Type] will be read first, followed by the value.
+  ///
+  /// If [alreadyDereferenced] is `true`, then for types which are pointers,
+  /// [pointer] already points at the top of the object, and should not be
+  /// followed before reading the object.
+  int identityHash(int pointer,
+      {Type? type, bool alreadyDereferenced = false}) {
+    if (type == null) {
+      type = _readType(pointer);
+      pointer += _typeSize;
+    }
+    return _identityHash(pointer, type,
+        alreadyDereferenced: alreadyDereferenced);
+  }
+
+  /// Computes the identity hash of the object at [pointer] with a known [type]
+  /// from its raw bytes.
+  ///
+  /// If [alreadyDereferenced] is `true`, then for types which are pointers,
+  /// [pointer] already points at the top of the object, and should not be
+  /// followed before reading the object.
+  int _identityHash(_Pointer pointer, Type type,
+      {bool alreadyDereferenced = false}) {
+    // Dereference [pointer] if it is a pointer type, and hasn't already been
+    // dereferenced.
+    if (type.isPointer && !alreadyDereferenced) {
+      pointer = _readPointer(pointer);
+    }
+
+    switch (type) {
+      case Type.nil:
+        return null.hashCode;
+      case Type.type:
+        return _buffer[pointer];
+      case Type.pointer:
+        return identityHash(pointer);
+      case Type.uint32:
+        return _readUint32(pointer);
+      case Type.boolean:
+        return _buffer[pointer];
+      case Type.anyPointer:
+        return identityHash(pointer);
+      case Type.stringPointer:
+        final length = _readLength(pointer);
+        pointer += _lengthSize;
+        return Object.hashAll(_buffer.sublist(pointer, pointer + length));
+      case Type.closedListPointer:
+        final length = _readLength(pointer);
+        pointer += _lengthSize;
+        return Object.hashAll(Iterable.generate(
+            length, (i) => identityHash(pointer + i * ClosedLists._valueSize)));
+      case Type.closedMapPointer:
+        final length = _readLength(pointer);
+        pointer += _lengthSize;
+        return Object.hashAll(Iterable.generate(
+            length, (i) => identityHash(pointer + i * ClosedMaps._valueSize)));
+      case Type.growableMapPointer:
+        var iterator = _GrowableMapHashIterator(this, null, pointer);
+        var hash = 0;
+        while (iterator.moveNext()) {
+          hash = Object.hash(hash, iterator.current);
+        }
+        return hash;
+      case Type.typedMapPointer:
+        final typedMap = _TypedMap(this, pointer, null);
+        var hash = 0;
+        final iterator = typedMap._schema._isAllBooleans
+            ? _AllBoolsTypedMapHashIterator(typedMap)
+            : _PartialTypedMapHashIterator(typedMap);
+        while (iterator.moveNext()) {
+          hash = Object.hash(hash, iterator.current);
+        }
+        return hash;
+    }
+  }
+
   /// The JSON data.
   ///
   /// The buffer is _not_ copied, unpredictable behavior will result if it is

--- a/pkgs/dart_model/lib/src/json_buffer/json_buffer_builder.dart
+++ b/pkgs/dart_model/lib/src/json_buffer/json_buffer_builder.dart
@@ -103,13 +103,13 @@ class JsonBufferBuilder {
         pointer += _lengthSize;
         return Object.hashAll(_buffer.sublist(pointer, pointer + length));
       case Type.closedListPointer:
-        return _ClosedList(this, pointer).fingerprint();
+        return _ClosedList(this, pointer).fingerprint;
       case Type.closedMapPointer:
-        return _ClosedMap(this, pointer, null).fingerprint();
+        return _ClosedMap(this, pointer, null).fingerprint;
       case Type.growableMapPointer:
-        return _GrowableMap<Object?>(this, pointer, null).fingerprint();
+        return _GrowableMap<Object?>(this, pointer, null).fingerprint;
       case Type.typedMapPointer:
-        return _TypedMap(this, pointer, null).fingerprint();
+        return _TypedMap(this, pointer, null).fingerprint;
     }
   }
 

--- a/pkgs/dart_model/lib/src/json_buffer/type.dart
+++ b/pkgs/dart_model/lib/src/json_buffer/type.dart
@@ -23,17 +23,22 @@ typedef _Pointer = int;
 
 /// The type of a value in the buffer.
 enum Type {
-  nil,
-  type,
-  pointer,
-  uint32,
-  boolean,
-  anyPointer,
-  stringPointer,
-  closedListPointer,
-  closedMapPointer,
-  growableMapPointer,
-  typedMapPointer;
+  nil(false),
+  type(false),
+  pointer(true),
+  uint32(false),
+  boolean(false),
+  anyPointer(false), // This is actually a type followed by a pointer.
+  stringPointer(true),
+  closedListPointer(true),
+  closedMapPointer(true),
+  growableMapPointer(true),
+  typedMapPointer(true);
+
+  /// Whether this object is always stored as a raw pointer.
+  final bool isPointer;
+
+  const Type(this.isPointer);
 
   /// Returns the [Type] of [value], or throws if it is not a supported type.
   ///

--- a/pkgs/dart_model/lib/src/json_buffer/typed_map.dart
+++ b/pkgs/dart_model/lib/src/json_buffer/typed_map.dart
@@ -511,7 +511,7 @@ class _PartialTypedMapHashIterator extends _PartialTypedMapIterator<int> {
   @override
   int get current => Object.hash(
       _currentKey,
-      _buffer._identityHash(
+      _buffer._fingerprint(
           _valuesPointer + _offset, _schema._valueTypes[_index]));
 }
 

--- a/pkgs/dart_model/lib/src/json_buffer/typed_map.dart
+++ b/pkgs/dart_model/lib/src/json_buffer/typed_map.dart
@@ -434,7 +434,7 @@ class _TypedMap
   @override
   int get hashCode => Object.hash(buffer, pointer);
 
-  int fingerprint() {
+  int get fingerprint {
     // Note: we could include the schema but don't need to. If something can
     // be one of multiple types, that type will be included in a `type` field
     // in the map.

--- a/pkgs/dart_model/lib/src/json_buffer/typed_map.dart
+++ b/pkgs/dart_model/lib/src/json_buffer/typed_map.dart
@@ -433,6 +433,20 @@ class _TypedMap
 
   @override
   int get hashCode => Object.hash(buffer, pointer);
+
+  int fingerprint() {
+    // Note: we could include the schema but don't need to. If something can
+    // be one of multiple types, that type will be included in a `type` field
+    // in the map.
+    var hash = 0;
+    final iterator = _schema._isAllBooleans
+        ? _AllBoolsTypedMapHashIterator(this)
+        : _PartialTypedMapHashIterator(this);
+    while (iterator.moveNext()) {
+      hash = Object.hash(hash, iterator.current);
+    }
+    return hash;
+  }
 }
 
 /// `Iterator` that reads a "typed map" in a [JsonBufferBuilder].

--- a/pkgs/dart_model/test/json_buffer/json_buffer_builder_test.dart
+++ b/pkgs/dart_model/test/json_buffer/json_buffer_builder_test.dart
@@ -6,7 +6,7 @@ import 'package:dart_model/src/json_buffer/json_buffer_builder.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group(JsonBufferBuilder, () {
+  group('JsonBufferBuilder', () {
     late JsonBufferBuilder builder;
 
     setUp(() {
@@ -87,5 +87,7 @@ void main() {
           JsonBufferBuilder.deserialize(JsonBufferBuilder().serialize());
       expect(() => deserializedBuilder.map['a'] = 'b', throwsStateError);
     });
+
+    test('can create unique fingerprints', () {});
   });
 }

--- a/pkgs/dart_model/test/json_buffer/json_buffer_builder_test.dart
+++ b/pkgs/dart_model/test/json_buffer/json_buffer_builder_test.dart
@@ -88,6 +88,86 @@ void main() {
       expect(() => deserializedBuilder.map['a'] = 'b', throwsStateError);
     });
 
-    test('can create unique fingerprints', () {});
+    group('fingerprint', () {
+      /// Re-usable fingerprint tests, [a] and [b] should be different values,
+      /// possibly of different types.
+      void testFingerprint(Object? a, Object? b) {
+        assert(a != b);
+        expect(fingerprint({'a': a}), equals(fingerprint({'a': a})));
+        expect(
+            fingerprint({
+              'a': {'b': b}
+            }),
+            equals(fingerprint({
+              'a': {'b': b}
+            })));
+        expect(fingerprint({'a': a}), isNot(equals(fingerprint({'a': b}))));
+        expect(fingerprint({'a': a}), isNot(equals(fingerprint({'b': a}))));
+        expect(fingerprint({'a': a, 'b': b}),
+            isNot(equals(fingerprint({'a': b, 'b': a}))));
+      }
+
+      test('boolean fields', () {
+        testFingerprint(true, false);
+      });
+
+      test('String fields', () {
+        testFingerprint('a', 'b');
+      });
+
+      test('int fields', () {
+        testFingerprint(1, 2);
+      });
+
+      test('null fields', () {
+        testFingerprint(null, 0);
+        testFingerprint(null, true);
+        testFingerprint(null, false);
+        testFingerprint(null, <String, Object?>{});
+      });
+
+      test('closed list fields', () {
+        testFingerprint([], [1]);
+        testFingerprint([1, 2], [2, 1]);
+      });
+
+      test('closed map fields', () {
+        testFingerprint(<String, Object?>{}, {'a': 1});
+        testFingerprint({'a': 'b'}, {'b': 'a'});
+      });
+
+      test('growable map fields', () {
+        final builderA = JsonBufferBuilder();
+        final builderB = JsonBufferBuilder();
+        testFingerprint(builderA.createGrowableMap<Object?>()..['a'] = 1,
+            builderB.createGrowableMap<Object?>()..['a'] = 2);
+      });
+
+      test('typed maps with same schema', () {
+        final builderA = JsonBufferBuilder();
+        final builderB = JsonBufferBuilder();
+        final schema = TypedMapSchema({
+          'a': Type.stringPointer,
+        });
+        testFingerprint(builderA.createTypedMap(schema, 'a'),
+            builderB.createTypedMap(schema, 'b'));
+      });
+    });
   });
+}
+
+int fingerprint(Map<String, Object?> map) {
+  final builder =
+      map is MapInBuffer ? (map as MapInBuffer).buffer : JsonBufferBuilder()
+        ..map.deepCopy(map);
+  return builder.fingerprint((builder.map as MapInBuffer).pointer,
+      type: Type.growableMapPointer, alreadyDereferenced: true);
+}
+
+extension on Map<String, Object?> {
+  void deepCopy(Map from) {
+    for (var entry in from.entries) {
+      this[entry.key as String] = entry.value;
+    }
+  }
 }


### PR DESCRIPTION
Avoids decoding values during hashing just to re-encode them as bytes to hash, when stored as raw bytes. Ultimately this mostly just applies to Strings, but that is still impactful. We also avoid a lot of type checks, instead doing switches based on the known or encoded types.

For now I am just using Object.hash and Object.hashAll but we could explore alternatives later on as well, although it would mean passing a byte sink around.

This drops the total time for the large benchmark another 10% ish on my machine.