### PR TITLE
Fix "without macros" benchmark: notify analyzer of new files.

### DIFF
--- a/pkgs/_macro_tool/lib/analyzer_macro_runner.dart
+++ b/pkgs/_macro_tool/lib/analyzer_macro_runner.dart
@@ -32,8 +32,8 @@ class AnalyzerMacroRunner implements MacroRunner {
     analysisContext = contextCollection.contexts.single;
   }
 
-  void notifyChange(SourceFile sourceFile) {
-    analysisContext.changeFile(sourceFile.path);
+  void notifyChange(String sourcePath) {
+    analysisContext.changeFile(sourcePath);
   }
 
   @override

--- a/pkgs/_macro_tool/lib/cfe_macro_runner.dart
+++ b/pkgs/_macro_tool/lib/cfe_macro_runner.dart
@@ -25,9 +25,8 @@ class CfeMacroRunner implements MacroRunner {
   CfeMacroRunner({required this.workspacePath, required this.packageConfigPath})
       : sourceFiles = SourceFile.findDartInWorkspace(workspacePath);
 
-  void notifyChange(SourceFile sourceFile) {
-    throw UnimplementedError(
-        'CfeMacroRunner does not support incremental compilation.');
+  void notifyChange(String sourcePath) {
+    // No incremental compile.
   }
 
   File get _productPlatformDill {
@@ -66,6 +65,7 @@ class CfeMacroRunner implements MacroRunner {
     final packagesUri = Uri.file(packageConfigPath);
 
     final computeKernelResult = await computeKernel([
+      '--enable-experiment=macros',
       '--no-summary',
       '--no-summary-only',
       '--target=vm',

--- a/pkgs/_macro_tool/lib/macro_runner.dart
+++ b/pkgs/_macro_tool/lib/macro_runner.dart
@@ -20,7 +20,7 @@ abstract interface class MacroRunner {
   /// Notifies the host that a file changed.
   ///
   /// Call this on changed files then call [run] again for an incremental run.
-  void notifyChange(SourceFile sourceFile);
+  void notifyChange(String sourcePath);
 }
 
 /// [MacroRunner] result for the whole workspace.

--- a/pkgs/_macro_tool/lib/macro_tool.dart
+++ b/pkgs/_macro_tool/lib/macro_tool.dart
@@ -43,7 +43,7 @@ class MacroTool {
 
     for (final result in _applyResult!.fileResults) {
       if (result.output != null) {
-        result.sourceFile.writeOutput(result.output!);
+        result.sourceFile.writeOutput(macroRunner, result.output!);
       }
     }
   }
@@ -60,7 +60,7 @@ class MacroTool {
 
     for (final result in _applyResult!.fileResults) {
       if (result.output != null) {
-        result.sourceFile.patchForAnalyzer();
+        result.sourceFile.patchForAnalyzer(macroRunner);
       }
     }
   }
@@ -77,7 +77,7 @@ class MacroTool {
 
     for (final result in _applyResult!.fileResults) {
       if (result.output != null) {
-        result.sourceFile.patchForCfe();
+        result.sourceFile.patchForCfe(macroRunner);
       }
     }
   }
@@ -110,7 +110,7 @@ class MacroTool {
   /// and/or [bustCaches].
   void revert() {
     for (final sourceFile in macroRunner.sourceFiles) {
-      sourceFile.revert();
+      sourceFile.revert(macroRunner);
     }
   }
 
@@ -167,11 +167,8 @@ class MacroTool {
   void bustCaches() {
     var cacheBusterFound = false;
     for (final sourceFile in macroRunner.sourceFiles) {
-      if (sourceFile.bustCaches()) {
+      if (sourceFile.bustCaches(macroRunner)) {
         cacheBusterFound = true;
-        // Notify the macro runner of the change so that it will be picked up
-        // by the next incremental run.
-        macroRunner.notifyChange(sourceFile);
       }
     }
     if (!cacheBusterFound) {
@@ -195,7 +192,7 @@ class MacroTool {
       _applyResult = await macroRunner.run();
       for (final result in _applyResult!.fileResults) {
         if (result.output != null) {
-          result.sourceFile.writeOutput(result.output!);
+          result.sourceFile.writeOutput(macroRunner, result.output!);
         }
       }
       if (_applyResult!.allErrors.isNotEmpty) {


### PR DESCRIPTION
If the analyzer instance is created before the augmentation files are written, it needs notifying of the new files.

Make `SourceFile` notify always.

Unrelated changes: sort the workspace files list, add `--enable-experiment-macros` to CFE runner. (It's not clear how I managed to submit without that last one, the test fails for me).