### PR TITLE
Let the analyzer know which phases to run.

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -38,23 +38,23 @@ jobs:
       - name: mono_repo self validate
         run: dart pub global run mono_repo generate --validate
   job_002:
-    name: "analyze_and_format; linux; Dart 3.7.0-123.0.dev; PKGS: pkgs/_analyzer_cfe_macros, pkgs/_analyzer_macros, pkgs/_cfe_macros, pkgs/_macro_builder, pkgs/_macro_client, pkgs/_macro_host, pkgs/_macro_runner, pkgs/_macro_server, pkgs/_macro_tool, pkgs/_test_macros, pkgs/dart_model, pkgs/macro, pkgs/macro_service, tool/benchmark_generator, tool/dart_model_generator; `dart analyze --fatal-infos .`"
+    name: "analyze_and_format; linux; Dart 3.7.0-157.0.dev; PKGS: pkgs/_analyzer_cfe_macros, pkgs/_analyzer_macros, pkgs/_cfe_macros, pkgs/_macro_builder, pkgs/_macro_client, pkgs/_macro_host, pkgs/_macro_runner, pkgs/_macro_server, pkgs/_macro_tool, pkgs/_test_macros, pkgs/dart_model, pkgs/macro, pkgs/macro_service, tool/benchmark_generator, tool/dart_model_generator; `dart analyze --fatal-infos .`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-123.0.dev;packages:pkgs/_analyzer_cfe_macros-pkgs/_analyzer_macros-pkgs/_cfe_macros-pkgs/_macro_builder-pkgs/_macro_client-pkgs/_macro_host-pkgs/_macro_runner-pkgs/_macro_server-pkgs/_macro_tool-pkgs/_test_macros-pkgs/dart_model-pkgs/macro-pkgs/macro_service-tool/benchmark_generator-tool/dart_model_generator;commands:analyze"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-157.0.dev;packages:pkgs/_analyzer_cfe_macros-pkgs/_analyzer_macros-pkgs/_cfe_macros-pkgs/_macro_builder-pkgs/_macro_client-pkgs/_macro_host-pkgs/_macro_runner-pkgs/_macro_server-pkgs/_macro_tool-pkgs/_test_macros-pkgs/dart_model-pkgs/macro-pkgs/macro_service-tool/benchmark_generator-tool/dart_model_generator;commands:analyze"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-123.0.dev;packages:pkgs/_analyzer_cfe_macros-pkgs/_analyzer_macros-pkgs/_cfe_macros-pkgs/_macro_builder-pkgs/_macro_client-pkgs/_macro_host-pkgs/_macro_runner-pkgs/_macro_server-pkgs/_macro_tool-pkgs/_test_macros-pkgs/dart_model-pkgs/macro-pkgs/macro_service-tool/benchmark_generator-tool/dart_model_generator
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-123.0.dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-157.0.dev;packages:pkgs/_analyzer_cfe_macros-pkgs/_analyzer_macros-pkgs/_cfe_macros-pkgs/_macro_builder-pkgs/_macro_client-pkgs/_macro_host-pkgs/_macro_runner-pkgs/_macro_server-pkgs/_macro_tool-pkgs/_test_macros-pkgs/dart_model-pkgs/macro-pkgs/macro_service-tool/benchmark_generator-tool/dart_model_generator
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-157.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.7.0-123.0.dev"
+          sdk: "3.7.0-157.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -488,23 +488,23 @@ jobs:
         if: "always() && steps.tool_dart_model_generator_pub_upgrade.conclusion == 'success'"
         working-directory: tool/dart_model_generator
   job_005:
-    name: "unit_test; linux; Dart 3.7.0-123.0.dev; PKG: goldens/foo; `../../tool/run_e2e_tests.sh`"
+    name: "unit_test; linux; Dart 3.7.0-157.0.dev; PKG: goldens/foo; `../../tool/run_e2e_tests.sh`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-123.0.dev;packages:goldens/foo;commands:command_0"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-157.0.dev;packages:goldens/foo;commands:command_0"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-123.0.dev;packages:goldens/foo
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-123.0.dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-157.0.dev;packages:goldens/foo
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-157.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.7.0-123.0.dev"
+          sdk: "3.7.0-157.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -523,23 +523,23 @@ jobs:
       - job_003
       - job_004
   job_006:
-    name: "unit_test; linux; Dart 3.7.0-123.0.dev; PKG: pkgs/_analyzer_cfe_macros; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; linux; Dart 3.7.0-157.0.dev; PKG: pkgs/_analyzer_cfe_macros; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-123.0.dev;packages:pkgs/_analyzer_cfe_macros;commands:test_0"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-157.0.dev;packages:pkgs/_analyzer_cfe_macros;commands:test_0"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-123.0.dev;packages:pkgs/_analyzer_cfe_macros
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-123.0.dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-157.0.dev;packages:pkgs/_analyzer_cfe_macros
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-157.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.7.0-123.0.dev"
+          sdk: "3.7.0-157.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -558,23 +558,23 @@ jobs:
       - job_003
       - job_004
   job_007:
-    name: "unit_test; linux; Dart 3.7.0-123.0.dev; PKG: pkgs/_analyzer_macros; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; linux; Dart 3.7.0-157.0.dev; PKG: pkgs/_analyzer_macros; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-123.0.dev;packages:pkgs/_analyzer_macros;commands:test_0"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-157.0.dev;packages:pkgs/_analyzer_macros;commands:test_0"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-123.0.dev;packages:pkgs/_analyzer_macros
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-123.0.dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-157.0.dev;packages:pkgs/_analyzer_macros
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-157.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.7.0-123.0.dev"
+          sdk: "3.7.0-157.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -593,23 +593,23 @@ jobs:
       - job_003
       - job_004
   job_008:
-    name: "unit_test; linux; Dart 3.7.0-123.0.dev; PKG: pkgs/_cfe_macros; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; linux; Dart 3.7.0-157.0.dev; PKG: pkgs/_cfe_macros; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-123.0.dev;packages:pkgs/_cfe_macros;commands:test_0"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-157.0.dev;packages:pkgs/_cfe_macros;commands:test_0"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-123.0.dev;packages:pkgs/_cfe_macros
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-123.0.dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-157.0.dev;packages:pkgs/_cfe_macros
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-157.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.7.0-123.0.dev"
+          sdk: "3.7.0-157.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -628,23 +628,23 @@ jobs:
       - job_003
       - job_004
   job_009:
-    name: "unit_test; linux; Dart 3.7.0-123.0.dev; PKG: pkgs/_macro_builder; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; linux; Dart 3.7.0-157.0.dev; PKG: pkgs/_macro_builder; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-123.0.dev;packages:pkgs/_macro_builder;commands:test_0"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-157.0.dev;packages:pkgs/_macro_builder;commands:test_0"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-123.0.dev;packages:pkgs/_macro_builder
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-123.0.dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-157.0.dev;packages:pkgs/_macro_builder
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-157.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.7.0-123.0.dev"
+          sdk: "3.7.0-157.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -663,23 +663,23 @@ jobs:
       - job_003
       - job_004
   job_010:
-    name: "unit_test; linux; Dart 3.7.0-123.0.dev; PKG: pkgs/_macro_client; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; linux; Dart 3.7.0-157.0.dev; PKG: pkgs/_macro_client; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-123.0.dev;packages:pkgs/_macro_client;commands:test_0"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-157.0.dev;packages:pkgs/_macro_client;commands:test_0"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-123.0.dev;packages:pkgs/_macro_client
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-123.0.dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-157.0.dev;packages:pkgs/_macro_client
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-157.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.7.0-123.0.dev"
+          sdk: "3.7.0-157.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -698,23 +698,23 @@ jobs:
       - job_003
       - job_004
   job_011:
-    name: "unit_test; linux; Dart 3.7.0-123.0.dev; PKG: pkgs/_macro_host; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; linux; Dart 3.7.0-157.0.dev; PKG: pkgs/_macro_host; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-123.0.dev;packages:pkgs/_macro_host;commands:test_0"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-157.0.dev;packages:pkgs/_macro_host;commands:test_0"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-123.0.dev;packages:pkgs/_macro_host
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-123.0.dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-157.0.dev;packages:pkgs/_macro_host
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-157.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.7.0-123.0.dev"
+          sdk: "3.7.0-157.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -733,23 +733,23 @@ jobs:
       - job_003
       - job_004
   job_012:
-    name: "unit_test; linux; Dart 3.7.0-123.0.dev; PKG: pkgs/_macro_runner; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; linux; Dart 3.7.0-157.0.dev; PKG: pkgs/_macro_runner; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-123.0.dev;packages:pkgs/_macro_runner;commands:test_0"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-157.0.dev;packages:pkgs/_macro_runner;commands:test_0"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-123.0.dev;packages:pkgs/_macro_runner
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-123.0.dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-157.0.dev;packages:pkgs/_macro_runner
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-157.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.7.0-123.0.dev"
+          sdk: "3.7.0-157.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -768,23 +768,23 @@ jobs:
       - job_003
       - job_004
   job_013:
-    name: "unit_test; linux; Dart 3.7.0-123.0.dev; PKG: pkgs/_macro_server; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; linux; Dart 3.7.0-157.0.dev; PKG: pkgs/_macro_server; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-123.0.dev;packages:pkgs/_macro_server;commands:test_0"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-157.0.dev;packages:pkgs/_macro_server;commands:test_0"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-123.0.dev;packages:pkgs/_macro_server
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-123.0.dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-157.0.dev;packages:pkgs/_macro_server
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-157.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.7.0-123.0.dev"
+          sdk: "3.7.0-157.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -803,23 +803,23 @@ jobs:
       - job_003
       - job_004
   job_014:
-    name: "unit_test; linux; Dart 3.7.0-123.0.dev; PKG: pkgs/macro_service; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; linux; Dart 3.7.0-157.0.dev; PKG: pkgs/macro_service; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-123.0.dev;packages:pkgs/macro_service;commands:test_0"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-157.0.dev;packages:pkgs/macro_service;commands:test_0"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-123.0.dev;packages:pkgs/macro_service
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-123.0.dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-157.0.dev;packages:pkgs/macro_service
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-157.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.7.0-123.0.dev"
+          sdk: "3.7.0-157.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -838,23 +838,23 @@ jobs:
       - job_003
       - job_004
   job_015:
-    name: "unit_test; linux; Dart 3.7.0-123.0.dev; PKG: tool/dart_model_generator; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; linux; Dart 3.7.0-157.0.dev; PKG: tool/dart_model_generator; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-123.0.dev;packages:tool/dart_model_generator;commands:test_0"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-157.0.dev;packages:tool/dart_model_generator;commands:test_0"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-123.0.dev;packages:tool/dart_model_generator
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-123.0.dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-157.0.dev;packages:tool/dart_model_generator
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-157.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.7.0-123.0.dev"
+          sdk: "3.7.0-157.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -873,23 +873,23 @@ jobs:
       - job_003
       - job_004
   job_016:
-    name: "unit_test; linux; Dart 3.7.0-123.0.dev; PKG: pkgs/_macro_tool; `dart test --test-randomize-ordering-seed=random --concurrency=1`"
+    name: "unit_test; linux; Dart 3.7.0-157.0.dev; PKG: pkgs/_macro_tool; `dart test --test-randomize-ordering-seed=random --concurrency=1`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-123.0.dev;packages:pkgs/_macro_tool;commands:test_1"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-157.0.dev;packages:pkgs/_macro_tool;commands:test_1"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-123.0.dev;packages:pkgs/_macro_tool
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-123.0.dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-157.0.dev;packages:pkgs/_macro_tool
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-157.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.7.0-123.0.dev"
+          sdk: "3.7.0-157.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -908,23 +908,23 @@ jobs:
       - job_003
       - job_004
   job_017:
-    name: "unit_test; linux; Dart 3.7.0-123.0.dev; PKG: pkgs/dart_model; `dart -Ddebug_json_buffer=true test --test-randomize-ordering-seed=random -c source`"
+    name: "unit_test; linux; Dart 3.7.0-157.0.dev; PKG: pkgs/dart_model; `dart -Ddebug_json_buffer=true test --test-randomize-ordering-seed=random -c source`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-123.0.dev;packages:pkgs/dart_model;commands:command_1"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-157.0.dev;packages:pkgs/dart_model;commands:command_1"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-123.0.dev;packages:pkgs/dart_model
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-123.0.dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-157.0.dev;packages:pkgs/dart_model
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.7.0-157.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.7.0-123.0.dev"
+          sdk: "3.7.0-157.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -1328,13 +1328,13 @@ jobs:
       - job_003
       - job_004
   job_029:
-    name: "unit_test; windows; Dart 3.7.0-123.0.dev; PKG: pkgs/_analyzer_cfe_macros; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; windows; Dart 3.7.0-157.0.dev; PKG: pkgs/_analyzer_cfe_macros; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.7.0-123.0.dev"
+          sdk: "3.7.0-157.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -1353,13 +1353,13 @@ jobs:
       - job_003
       - job_004
   job_030:
-    name: "unit_test; windows; Dart 3.7.0-123.0.dev; PKG: pkgs/_analyzer_macros; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; windows; Dart 3.7.0-157.0.dev; PKG: pkgs/_analyzer_macros; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.7.0-123.0.dev"
+          sdk: "3.7.0-157.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -1378,13 +1378,13 @@ jobs:
       - job_003
       - job_004
   job_031:
-    name: "unit_test; windows; Dart 3.7.0-123.0.dev; PKG: pkgs/_cfe_macros; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; windows; Dart 3.7.0-157.0.dev; PKG: pkgs/_cfe_macros; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.7.0-123.0.dev"
+          sdk: "3.7.0-157.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -1403,13 +1403,13 @@ jobs:
       - job_003
       - job_004
   job_032:
-    name: "unit_test; windows; Dart 3.7.0-123.0.dev; PKG: pkgs/_macro_builder; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; windows; Dart 3.7.0-157.0.dev; PKG: pkgs/_macro_builder; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.7.0-123.0.dev"
+          sdk: "3.7.0-157.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -1428,13 +1428,13 @@ jobs:
       - job_003
       - job_004
   job_033:
-    name: "unit_test; windows; Dart 3.7.0-123.0.dev; PKG: pkgs/_macro_client; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; windows; Dart 3.7.0-157.0.dev; PKG: pkgs/_macro_client; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.7.0-123.0.dev"
+          sdk: "3.7.0-157.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -1453,13 +1453,13 @@ jobs:
       - job_003
       - job_004
   job_034:
-    name: "unit_test; windows; Dart 3.7.0-123.0.dev; PKG: pkgs/_macro_host; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; windows; Dart 3.7.0-157.0.dev; PKG: pkgs/_macro_host; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.7.0-123.0.dev"
+          sdk: "3.7.0-157.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -1478,13 +1478,13 @@ jobs:
       - job_003
       - job_004
   job_035:
-    name: "unit_test; windows; Dart 3.7.0-123.0.dev; PKG: pkgs/_macro_runner; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; windows; Dart 3.7.0-157.0.dev; PKG: pkgs/_macro_runner; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.7.0-123.0.dev"
+          sdk: "3.7.0-157.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -1503,13 +1503,13 @@ jobs:
       - job_003
       - job_004
   job_036:
-    name: "unit_test; windows; Dart 3.7.0-123.0.dev; PKG: pkgs/_macro_server; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; windows; Dart 3.7.0-157.0.dev; PKG: pkgs/_macro_server; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.7.0-123.0.dev"
+          sdk: "3.7.0-157.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -1528,13 +1528,13 @@ jobs:
       - job_003
       - job_004
   job_037:
-    name: "unit_test; windows; Dart 3.7.0-123.0.dev; PKG: pkgs/macro_service; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; windows; Dart 3.7.0-157.0.dev; PKG: pkgs/macro_service; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.7.0-123.0.dev"
+          sdk: "3.7.0-157.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -1553,13 +1553,13 @@ jobs:
       - job_003
       - job_004
   job_038:
-    name: "unit_test; windows; Dart 3.7.0-123.0.dev; PKG: tool/dart_model_generator; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; windows; Dart 3.7.0-157.0.dev; PKG: tool/dart_model_generator; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.7.0-123.0.dev"
+          sdk: "3.7.0-157.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -1578,13 +1578,13 @@ jobs:
       - job_003
       - job_004
   job_039:
-    name: "unit_test; windows; Dart 3.7.0-123.0.dev; PKG: pkgs/_macro_tool; `dart test --test-randomize-ordering-seed=random --concurrency=1`"
+    name: "unit_test; windows; Dart 3.7.0-157.0.dev; PKG: pkgs/_macro_tool; `dart test --test-randomize-ordering-seed=random --concurrency=1`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.7.0-123.0.dev"
+          sdk: "3.7.0-157.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -1603,13 +1603,13 @@ jobs:
       - job_003
       - job_004
   job_040:
-    name: "unit_test; windows; Dart 3.7.0-123.0.dev; PKG: pkgs/dart_model; `dart -Ddebug_json_buffer=true test --test-randomize-ordering-seed=random -c source`"
+    name: "unit_test; windows; Dart 3.7.0-157.0.dev; PKG: pkgs/dart_model; `dart -Ddebug_json_buffer=true test --test-randomize-ordering-seed=random -c source`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
         with:
-          sdk: "3.7.0-123.0.dev"
+          sdk: "3.7.0-157.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/goldens/foo/pubspec.yaml
+++ b/goldens/foo/pubspec.yaml
@@ -3,7 +3,7 @@ publish-to: none
 resolution: workspace
 
 environment:
-  sdk: ^3.7.0-123.0.dev
+  sdk: ^3.7.0-157.0.dev
 
 dependencies:
   _test_macros: any

--- a/pkgs/_analyzer_cfe_macros/pubspec.yaml
+++ b/pkgs/_analyzer_cfe_macros/pubspec.yaml
@@ -4,7 +4,7 @@ description: Macro support for the analyzer and CFE.
 resolution: workspace
 
 environment:
-  sdk: ^3.7.0-123.0.dev
+  sdk: ^3.7.0-157.0.dev
 
 dependencies:
   _fe_analyzer_shared: any

--- a/pkgs/_analyzer_macros/lib/macro_implementation.dart
+++ b/pkgs/_analyzer_macros/lib/macro_implementation.dart
@@ -82,6 +82,8 @@ class AnalyzerRunningMacro implements injected.RunningMacro {
   /// The name of the macro implementation class itself.
   final QualifiedName implementation;
 
+  Set<macros_api_v1.Phase>? _phasesToExecute;
+
   AnalyzerRunningMacro._(this._impl, this.name, this.implementation);
 
   static AnalyzerRunningMacro run(
@@ -104,6 +106,18 @@ class AnalyzerRunningMacro implements injected.RunningMacro {
           ),
         )).asQueryResponse.model,
   );
+
+  @override
+  Future<Set<macros_api_v1.Phase>> get phasesToExecute async =>
+      _phasesToExecute ??= {
+        for (final phase in await _impl._host.queryMacroPhases(name))
+          switch (phase) {
+            1 => macros_api_v1.Phase.types,
+            2 => macros_api_v1.Phase.declarations,
+            3 => macros_api_v1.Phase.definitions,
+            _ => throw ArgumentError(phase),
+          },
+      };
 
   @override
   Future<AnalyzerMacroExecutionResult> executeDeclarationsPhase(

--- a/pkgs/_analyzer_macros/pubspec.yaml
+++ b/pkgs/_analyzer_macros/pubspec.yaml
@@ -4,7 +4,7 @@ description: Macro support for the analyzer.
 resolution: workspace
 
 environment:
-  sdk: ^3.7.0-123.0.dev
+  sdk: ^3.7.0-157.0.dev
 
 dependencies:
   _analyzer_cfe_macros: any

--- a/pkgs/_analyzer_macros/test/package_under_test/pubspec.yaml
+++ b/pkgs/_analyzer_macros/test/package_under_test/pubspec.yaml
@@ -3,7 +3,7 @@ publish-to: none
 resolution: workspace
 
 environment:
-  sdk: ^3.7.0-123.0.dev
+  sdk: ^3.7.0-157.0.dev
 
 dependencies:
   _test_macros: any

--- a/pkgs/_cfe_macros/pubspec.yaml
+++ b/pkgs/_cfe_macros/pubspec.yaml
@@ -4,7 +4,7 @@ description: Macro support for the CFE.
 resolution: workspace
 
 environment:
-  sdk: ^3.7.0-123.0.dev
+  sdk: ^3.7.0-157.0.dev
 
 dependencies:
   _macro_host: any

--- a/pkgs/_cfe_macros/test/package_under_test/pubspec.yaml
+++ b/pkgs/_cfe_macros/test/package_under_test/pubspec.yaml
@@ -3,7 +3,7 @@ publish-to: none
 resolution: workspace
 
 environment:
-  sdk: ^3.7.0-123.0.dev
+  sdk: ^3.7.0-157.0.dev
 
 dependencies:
   _test_macros: any

--- a/pkgs/_macro_builder/pubspec.yaml
+++ b/pkgs/_macro_builder/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/dart-lang/macros/tree/master/pkgs/_macro_builder
 resolution: workspace
 
 environment:
-  sdk: ^3.7.0-123.0.dev
+  sdk: ^3.7.0-157.0.dev
 
 dependencies:
   dart_model: any

--- a/pkgs/_macro_client/pubspec.yaml
+++ b/pkgs/_macro_client/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/dart-lang/macros/tree/master/pkgs/_macro_client
 resolution: workspace
 
 environment:
-  sdk: ^3.7.0-123.0.dev
+  sdk: ^3.7.0-157.0.dev
 
 dependencies:
   dart_model: any

--- a/pkgs/_macro_host/lib/src/macro_host.dart
+++ b/pkgs/_macro_host/lib/src/macro_host.dart
@@ -62,10 +62,7 @@ class MacroHost {
       macroPackageConfig.lookupMacroImplementation(annotation);
 
   /// Determines which phases the macro triggered by [annotation] runs in.
-  Future<Set<int>> queryMacroPhases(
-    Uri packageConfig,
-    QualifiedName annotation,
-  ) async {
+  Future<Set<int>> queryMacroPhases(QualifiedName annotation) async {
     await _ensureRunning(annotation);
     return _hostService._macroState[annotation.asString]!.phases;
   }

--- a/pkgs/_macro_host/pubspec.yaml
+++ b/pkgs/_macro_host/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/dart-lang/macros/tree/master/pkgs/_macro_host
 resolution: workspace
 
 environment:
-  sdk: ^3.7.0-123.0.dev
+  sdk: ^3.7.0-157.0.dev
 
 dependencies:
   _macro_builder: any

--- a/pkgs/_macro_host/test/macro_host_test.dart
+++ b/pkgs/_macro_host/test/macro_host_test.dart
@@ -20,7 +20,6 @@ void main() {
                   properties: Properties(isClass: true),
                 )),
   );
-  final packageConfig = Isolate.packageConfigSync!;
 
   for (final protocol in [
     Protocol(encoding: ProtocolEncoding.json, version: ProtocolVersion.macros1),
@@ -44,9 +43,7 @@ void main() {
         );
 
         expect(host.isMacro(macroAnnotation), true);
-        expect(await host.queryMacroPhases(packageConfig, macroAnnotation), {
-          2,
-        });
+        expect(await host.queryMacroPhases(macroAnnotation), {2});
 
         expect(
           await host.augment(
@@ -76,12 +73,8 @@ void main() {
           queryService: queryService,
         );
 
-        final packageConfig = Isolate.packageConfigSync!;
-
         expect(host.isMacro(macroAnnotation), true);
-        expect(await host.queryMacroPhases(packageConfig, macroAnnotation), {
-          3,
-        });
+        expect(await host.queryMacroPhases(macroAnnotation), {3});
 
         expect(
           await host.augment(

--- a/pkgs/_macro_runner/pubspec.yaml
+++ b/pkgs/_macro_runner/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/dart-lang/macros/tree/master/pkgs/_macro_runner
 resolution: workspace
 
 environment:
-  sdk: ^3.7.0-123.0.dev
+  sdk: ^3.7.0-157.0.dev
 
 dependencies:
   _macro_builder: any

--- a/pkgs/_macro_server/pubspec.yaml
+++ b/pkgs/_macro_server/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/dart-lang/macros/tree/master/pkgs/_macro_server
 resolution: workspace
 
 environment:
-  sdk: ^3.7.0-123.0.dev
+  sdk: ^3.7.0-157.0.dev
 
 dependencies:
   dart_model: any

--- a/pkgs/_macro_tool/pubspec.yaml
+++ b/pkgs/_macro_tool/pubspec.yaml
@@ -4,7 +4,7 @@ description: >-
   CLI for running code with macros applied.
 resolution: workspace
 environment:
-  sdk: ^3.7.0-123.0.dev
+  sdk: ^3.7.0-157.0.dev
 
 dependencies:
   _analyzer_macros: any

--- a/pkgs/_macro_tool/test/package_under_test/pubspec.yaml
+++ b/pkgs/_macro_tool/test/package_under_test/pubspec.yaml
@@ -3,7 +3,7 @@ publish-to: none
 resolution: workspace
 
 environment:
-  sdk: ^3.7.0-123.0.dev
+  sdk: ^3.7.0-157.0.dev
 
 dependencies:
   _test_macros: any

--- a/pkgs/_test_macros/pubspec.yaml
+++ b/pkgs/_test_macros/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/dart-lang/macros/tree/master/pkgs/_test_macros
 resolution: workspace
 
 environment:
-  sdk: ^3.7.0-123.0.dev
+  sdk: ^3.7.0-157.0.dev
 
 dependencies:
   dart_model: any

--- a/pkgs/dart_model/pubspec.yaml
+++ b/pkgs/dart_model/pubspec.yaml
@@ -8,7 +8,7 @@ repository: https://github.com/dart-lang/macros/tree/master/pkgs/dart_model
 resolution: workspace
 
 environment:
-  sdk: ^3.7.0-123.0.dev
+  sdk: ^3.7.0-157.0.dev
 
 dependencies:
   collection: ^1.19.0

--- a/pkgs/macro/pubspec.yaml
+++ b/pkgs/macro/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/dart-lang/macros/tree/master/pkgs/macro
 resolution: workspace
 
 environment:
-  sdk: ^3.7.0-123.0.dev
+  sdk: ^3.7.0-157.0.dev
 
 dependencies:
   collection: ^1.19.0

--- a/pkgs/macro_service/pubspec.yaml
+++ b/pkgs/macro_service/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/dart-lang/macros/tree/master/pkgs/macro_service
 resolution: workspace
 
 environment:
-  sdk: ^3.7.0-123.0.dev
+  sdk: ^3.7.0-157.0.dev
 
 dependencies:
   async: ^2.11.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: macros_workspace
 environment:
-  sdk: ^3.7.0-123.0.dev
+  sdk: ^3.7.0-157.0.dev
 dev_dependencies:
   dart_flutter_team_lints: ^3.1.0
 publish_to: none
@@ -31,47 +31,47 @@ dependency_overrides:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/_fe_analyzer_shared
-      ref: 3.7.0-123.0.dev
+      ref: 3.7.0-157.0.dev
   _js_interop_checks:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/_js_interop_checks
-      ref: 3.7.0-123.0.dev
+      ref: 3.7.0-157.0.dev
   _macros:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/_macros
-      ref: 3.7.0-123.0.dev
+      ref: 3.7.0-157.0.dev
   analysis_server:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/analysis_server
-      ref: 3.7.0-123.0.dev
+      ref: 3.7.0-157.0.dev
   analyzer:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/analyzer
-      ref: 3.7.0-123.0.dev
+      ref: 3.7.0-157.0.dev
   analyzer_plugin:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/analyzer_plugin
-      ref: 3.7.0-123.0.dev
+      ref: 3.7.0-157.0.dev
   analyzer_utilities:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/analyzer_utilities
-      ref: 3.7.0-123.0.dev
+      ref: 3.7.0-157.0.dev
   build_integration:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/build_integration
-      ref: 3.7.0-123.0.dev
+      ref: 3.7.0-157.0.dev
   compiler:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/compiler
-      ref: 3.7.0-123.0.dev
+      ref: 3.7.0-157.0.dev
   dart_style:
     git:
       url: https://github.com/dart-lang/dart_style.git
@@ -80,89 +80,89 @@ dependency_overrides:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/dart2js_info
-      ref: 3.7.0-123.0.dev
+      ref: 3.7.0-157.0.dev
   dart2wasm:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/dart2wasm
-      ref: 3.7.0-123.0.dev
+      ref: 3.7.0-157.0.dev
   dev_compiler:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/dev_compiler
-      ref: 3.7.0-123.0.dev
+      ref: 3.7.0-157.0.dev
   front_end:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/front_end
-      ref: 3.7.0-123.0.dev
+      ref: 3.7.0-157.0.dev
   frontend_server:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/frontend_server
-      ref: 3.7.0-123.0.dev
+      ref: 3.7.0-157.0.dev
   heap_snapshot:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/heap_snapshot
-      ref: 3.7.0-123.0.dev
+      ref: 3.7.0-157.0.dev
   js_ast:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/js_ast
-      ref: 3.7.0-123.0.dev
+      ref: 3.7.0-157.0.dev
   js_runtime:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/js_runtime
-      ref: 3.7.0-123.0.dev
+      ref: 3.7.0-157.0.dev
   js_shared:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/js_shared
-      ref: 3.7.0-123.0.dev
+      ref: 3.7.0-157.0.dev
   kernel:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/kernel
-      ref: 3.7.0-123.0.dev
+      ref: 3.7.0-157.0.dev
   analysis_server_plugin:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/analysis_server_plugin
-      ref: 3.7.0-123.0.dev
+      ref: 3.7.0-157.0.dev
   language_server_protocol:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: third_party/pkg/language_server_protocol
-      ref: 3.7.0-123.0.dev
+      ref: 3.7.0-157.0.dev
   linter:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/linter
-      ref: 3.7.0-123.0.dev
+      ref: 3.7.0-157.0.dev
   mmap:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/mmap
-      ref: 3.7.0-123.0.dev
+      ref: 3.7.0-157.0.dev
   telemetry:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/telemetry
-      ref: 3.7.0-123.0.dev
+      ref: 3.7.0-157.0.dev
   vm:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/vm
-      ref: 3.7.0-123.0.dev
+      ref: 3.7.0-157.0.dev
   vm_service:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/vm_service
-      ref: 3.7.0-123.0.dev
+      ref: 3.7.0-157.0.dev
   wasm_builder:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/wasm_builder
-      ref: 3.7.0-123.0.dev
+      ref: 3.7.0-157.0.dev

--- a/tool/benchmark_generator/pubspec.yaml
+++ b/tool/benchmark_generator/pubspec.yaml
@@ -2,7 +2,7 @@ name: benchmark_generator
 publish-to: none
 resolution: workspace
 environment:
-  sdk: ^3.7.0-123.0.dev
+  sdk: ^3.7.0-157.0.dev
 
 dev_dependencies:
   dart_flutter_team_lints: ^3.0.0

--- a/tool/dart_model_generator/pubspec.yaml
+++ b/tool/dart_model_generator/pubspec.yaml
@@ -2,7 +2,7 @@ name: generate_dart_model
 publish-to: none
 resolution: workspace
 environment:
-  sdk: ^3.7.0-123.0.dev
+  sdk: ^3.7.0-157.0.dev
 
 dependencies:
   dart_model: any


### PR DESCRIPTION
Update to SDK version where the analyzer supports this.

The `JsonCodable` macro runs in phases 2 and 3; but doesn't actually output anything useful in phase 2. I verified that it speeds it up to skip phase 2, as expected.