### PR TITLE
update gitignore, benchmark readme, and macro tool output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 **/.dart_tool
 **/pubspec.lock
 goldens/foo/lib/generated/**
+*.macro_tool_output

--- a/pkgs/_macro_tool/lib/macro_tool.dart
+++ b/pkgs/_macro_tool/lib/macro_tool.dart
@@ -201,7 +201,8 @@ class MacroTool {
       }
 
       stdout.write(
-        'Macros ran in in ${_applyResult!.firstResultAfter.inMilliseconds}ms,'
+        'Macros ran in ${_applyResult!.firstResultAfter.inMilliseconds}ms '
+        '(${_applyResult!.lastResultAfter.inMilliseconds}ms total),'
         ' watching...',
       );
       await events.first;

--- a/tool/benchmark_generator/README.md
+++ b/tool/benchmark_generator/README.md
@@ -2,15 +2,15 @@
 
 Generates code that uses macros, for benchmarking.
 
-Example use, from the root of this package:
+Example use, from the root of this repo:
 
 ```
-dart bin/main.dart large macro 64
-dart ../../pkgs/_macro_tool/bin/main.dart \
-    --workspace=../../goldens/foo \
-    --packageConfig=../../.dart_tool/package_config.json \
-    --script=../../goldens/foo/lib/generated/large/a0.dart \
-    --host=analyzer --watch
+dart run benchmark_generator large macro 64
+dart run _macro_tool \
+    --workspace=goldens/foo \
+    --packageConfig=.dart_tool/package_config.json \
+    --script=goldens/foo/lib/generated/large/a0.dart \
+    --host=analyzer watch
 ```
 
 then change `goldens/foo/lib/generated/large/a0.dart` to see the refresh time.


### PR DESCRIPTION
Some small cleanup stuff:

- Add macro tool output files to gitignore.
- Update benchmark readme to use `dart run`.
- log the total time to re-analyze from the macro_tool (I might be misunderstanding what this is trying to report though).