### PR TITLE
Add built_value test macro.

### DIFF
--- a/goldens/foo/lib/built_value/built_value_test.analyzer.augmentations
+++ b/goldens/foo/lib/built_value/built_value_test.analyzer.augmentations
@@ -1,0 +1,25 @@
+part of 'package:foo/built_value/built_value_test.dart';
+
+import 'package:_test_macros/built_value.dart' as prefix0;
+import 'package:foo/built_value/built_value_test.dart' as prefix1;
+
+@prefix0.BuiltValueBuilder()
+class EmptyBuilder {}
+
+augment class Empty {
+Empty([void Function(prefix1.EmptyBuilder)? updates]) {}
+Empty._() {}
+
+prefix1.EmptyBuilder toBuilder() => prefix1.EmptyBuilder()..replace(this);
+prefix1.Empty rebuild(void Function(prefix1.EmptyBuilder) updates) =>
+    (toBuilder()..update(updates)).build();
+
+  bool operator==(Object other) => other is prefix1.Empty;
+
+}
+augment class EmptyBuilder {
+void replace(prefix1.Empty other) {}
+void update(void Function(prefix1.EmptyBuilder) updates) => updates(this);
+prefix1.Empty build() => prefix1.Empty._();
+
+}

--- a/goldens/foo/lib/built_value/built_value_test.dart
+++ b/goldens/foo/lib/built_value/built_value_test.dart
@@ -1,0 +1,24 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:_test_macros/built_value.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Empty class', () {
+    test('instantiation, builder, rebuild, comparison', () {
+      final empty = Empty();
+      final empty2 = empty.rebuild((b) {});
+      expect(empty2, empty);
+
+      // analyzer: The function 'EmptyBuilder' isn't defined.
+      // final emptyBuilder = EmptyBuilder();
+      // final empty3 = emptyBuilder.build();
+      // expect(empty3, empty);
+    });
+  });
+}
+
+@BuiltValue()
+class Empty {}

--- a/pkgs/_analyzer_macros/lib/macro_implementation.dart
+++ b/pkgs/_analyzer_macros/lib/macro_implementation.dart
@@ -55,7 +55,6 @@ class AnalyzerMacroPackageConfigs implements injected.MacroPackageConfigs {
 
   @override
   bool isMacro(Uri uri, String name) {
-    // TODO(davidmorgan): do this in the analyzer.
     name = _removePrefix(name);
     return _impl._host.isMacro(QualifiedName(uri: '$uri', name: name));
   }
@@ -68,7 +67,6 @@ class AnalyzerMacroRunner implements injected.MacroRunner {
 
   @override
   injected.RunningMacro run(Uri uri, String name) {
-    // TODO(davidmorgan): do this in the analyzer.
     name = _removePrefix(name);
     return AnalyzerRunningMacro.run(
       _impl,
@@ -80,6 +78,9 @@ class AnalyzerMacroRunner implements injected.MacroRunner {
   }
 }
 
+// The analyzer currently sends import prefixes, for example
+// `prefix0.BuiltValueBuilder` when it should send just `BuiltValueBuilder`.
+// TODO(davidmorgan): fix in the analyzer instead.
 String _removePrefix(String name) {
   final index = name.indexOf('.');
   return index == -1 ? name : name.substring(index + 1);

--- a/pkgs/_macro_tool/lib/macro_tool.dart
+++ b/pkgs/_macro_tool/lib/macro_tool.dart
@@ -30,21 +30,21 @@ class MacroTool {
 
   /// Runs macros.
   ///
-  /// Throws `StateError` if there are any errors.
+  /// Writes macro augmentations next to each source file with the extension
+  /// `.macro_tool_output`.
   ///
-  /// Otherwise, writes macro augmentations next to each source file with the
-  /// extension `.macro_tool_output`.
+  /// Then throws `StateError` if there were any errors.
   Future<void> apply() async {
     _applyResult = await macroRunner.run();
-
-    if (_applyResult!.allErrors.isNotEmpty) {
-      throw StateError('Errors: ${_applyResult!.allErrors}');
-    }
 
     for (final result in _applyResult!.fileResults) {
       if (result.output != null) {
         result.sourceFile.writeOutput(macroRunner, result.output!);
       }
+    }
+
+    if (_applyResult!.allErrors.isNotEmpty) {
+      throw StateError('Errors: ${_applyResult!.allErrors}');
     }
   }
 

--- a/pkgs/_test_macros/lib/built_value.dart
+++ b/pkgs/_test_macros/lib/built_value.dart
@@ -1,0 +1,107 @@
+// Copyright (c) 2024, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:dart_model/dart_model.dart';
+import 'package:macro/macro.dart';
+import 'package:macro_service/macro_service.dart';
+
+import 'templating.dart';
+
+/// A macro equivalent to `package:built_value` value types.
+class BuiltValue {
+  const BuiltValue();
+}
+
+/// A macro equivalent to `package:built_value` builders.
+class BuiltValueBuilder {
+  const BuiltValueBuilder();
+}
+
+class BuiltValueImplementation
+    implements ClassTypesMacro, ClassDeclarationsMacro {
+  @override
+  MacroDescription get description => MacroDescription(
+    annotation: QualifiedName(
+      uri: 'package:_test_macros/built_value.dart',
+      name: 'BuiltValue',
+    ),
+    runsInPhases: [1, 2],
+  );
+
+  @override
+  Future<void> buildTypesForClass(ClassTypesBuilder<Interface> builder) async {
+    final valueName = builder.model.qualifiedNameOf(builder.target.node)!;
+    final builderSimpleName = '${valueName.name}Builder';
+    builder.declareType(
+      builderSimpleName,
+      augmentation('''
+@{{package:_test_macros/built_value.dart#BuiltValueBuilder}}()
+class $builderSimpleName {}
+'''),
+    );
+  }
+
+  @override
+  Future<void> buildDeclarationsForClass(
+    ClassDeclarationsBuilder builder,
+  ) async {
+    final valueName = builder.model.qualifiedNameOf(builder.target.node)!;
+    final builderName = QualifiedName(
+      uri: valueName.uri,
+      name: '${valueName.name}Builder',
+    );
+    // TODO(davidmorgan): query for fields, set and compare fields.
+    builder.declareInType(
+      augmentation('''
+${valueName.name}([void Function(${builderName.code})? updates]) {}
+${valueName.name}._() {}
+
+${builderName.code} toBuilder() => ${builderName.code}()..replace(this);
+${valueName.code} rebuild(void Function(${builderName.code}) updates) =>
+    (toBuilder()..update(updates)).build();
+
+  bool operator==(Object other) => other is ${valueName.code};
+'''),
+    );
+  }
+}
+
+class BuiltValueBuilderImplementation implements ClassDeclarationsMacro {
+  @override
+  MacroDescription get description => MacroDescription(
+    annotation: QualifiedName(
+      uri: 'package:_test_macros/built_value.dart',
+      name: 'BuiltValueBuilder',
+    ),
+    runsInPhases: [2],
+  );
+
+  @override
+  Future<void> buildDeclarationsForClass(
+    ClassDeclarationsBuilder builder,
+  ) async {
+    final builderName = builder.model.qualifiedNameOf(builder.target.node)!;
+    var valueShortName = builderName.name;
+    if (valueShortName.endsWith('Builder')) {
+      valueShortName = valueShortName.substring(
+        0,
+        valueShortName.length - 'Builder'.length,
+      );
+    } else {
+      throw StateError('Builder class should have name ending "Builder".');
+    }
+    final valueName = QualifiedName(uri: builderName.uri, name: valueShortName);
+
+    // TODO(davidmorgan): query for fields, actually build fields.
+    builder.declareInType(
+      augmentation('''
+void replace(${valueName.code} other) {}
+void update(void Function(${builderName.code}) updates) => updates(this);
+${valueName.code} build() => ${valueName.code}._();
+'''),
+    );
+  }
+}

--- a/pkgs/_test_macros/lib/templating.dart
+++ b/pkgs/_test_macros/lib/templating.dart
@@ -9,6 +9,9 @@ extension TemplatingExtension on QualifiedName {
   String get code => '{{$uri#$name}}';
 }
 
+Augmentation augmentation(String template) =>
+    Augmentation(code: expandTemplate(template));
+
 /// Converts [template] to a mix of `Identifier` and `String`.
 ///
 /// References of the form `{{uri#name}}` become [QualifiedName] wrapped in

--- a/pkgs/_test_macros/pubspec.yaml
+++ b/pkgs/_test_macros/pubspec.yaml
@@ -18,6 +18,8 @@ dev_dependencies:
   test: ^1.25.0
 
 # TODO(language/3728): use the real feature when there is one.
+# macro lib/built_value.dart#BuiltValue package:_test_macros/built_value.dart#BuiltValueImplementation
+# macro lib/built_value.dart#BuiltValueBuilder package:_test_macros/built_value.dart#BuiltValueBuilderImplementation
 # macro lib/declare_x_macro.dart#DeclareX package:_test_macros/declare_x_macro.dart#DeclareXImplementation
 # macro lib/json_codable.dart#JsonCodable package:_test_macros/json_codable.dart#JsonCodableImplementation
 # macro lib/query_class.dart#QueryClass package:_test_macros/query_class.dart#QueryClassImplementation

--- a/tool/run_e2e_tests.sh
+++ b/tool/run_e2e_tests.sh
@@ -7,7 +7,7 @@ cd $(dirname ${BASH_SOURCE[0]})
 
 echo "Testing goldens/foo/*_test.dart..."
 
-for test_file in $(ls ../goldens/foo/lib/ | egrep '_test.dart$'); do
+for test_file in $(cd ../goldens/foo/lib/; find . -name \*_test.dart); do
   echo "Testing $test_file..."
   if dart run _macro_tool \
       --workspace=../goldens/foo \


### PR DESCRIPTION
I figured we can use a macro that fully uses phase 1+2 for benchmarking, some approximation to `built_value` seems a good fit.

I found a few fixes needed before I got to adding fields, so I figured I'd send already.