### PR TITLE
Use an MD5 hash instead of Object.hash for model hashes

### DIFF
--- a/pkgs/_macro_host/lib/src/macro_cache.dart
+++ b/pkgs/_macro_host/lib/src/macro_cache.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:crypto/crypto.dart';
 import 'package:dart_model/dart_model.dart';
 import 'package:macro_service/macro_service.dart';
 
@@ -32,14 +33,14 @@ class MacroResultsCache {
       phase: request.phase,
     )] = (
       queries: queryResults.map((q) => q.query),
-      resultsHash:
+      resultsDigest:
           queryResults
               .skip(1)
               .fold(
                 queryResults.first.response,
                 (model, next) => model.mergeWith(next.response),
               )
-              .fingerprint,
+              .digest,
       response: response,
     );
   }
@@ -67,15 +68,15 @@ class MacroResultsCache {
         ),
       ),
     );
-    final newResultsHash =
+    final newResultsDigest =
         queryResults
             .skip(1)
             .fold(
               queryResults.first.model,
               (model, next) => model.mergeWith(next.model),
             )
-            .fingerprint;
-    if (newResultsHash != cached.resultsHash) {
+            .digest;
+    if (newResultsDigest != cached.resultsDigest) {
       _cache.remove(cacheKey);
       return null;
     }
@@ -91,8 +92,8 @@ typedef _MacroResultsCacheValue =
       /// All queries done by a macro in a given phase.
       Iterable<Query> queries,
 
-      /// The `identityHash` of the merged model from all query responses.
-      int resultsHash,
+      /// The [Digest] of the merged model from all query responses.
+      Digest resultsDigest,
 
       /// The macro augmentation response that was cached.
       AugmentResponse response,

--- a/pkgs/dart_model/lib/src/dart_model.dart
+++ b/pkgs/dart_model/lib/src/dart_model.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:crypto/crypto.dart';
+
 import 'dart_model.g.dart';
 import 'json_buffer/json_buffer_builder.dart';
 import 'lazy_merged_map.dart';
@@ -31,10 +33,10 @@ extension ModelExtension on Model {
   /// An identity hash for `this`, used for comparing query results.
   ///
   /// TODO: A faster/better implementation?
-  int get fingerprint {
+  Digest get digest {
     // TODO: Implementation for non-buffer maps?
     var node = this.node as MapInBuffer;
-    return node.buffer.fingerprint(
+    return node.buffer.digest(
       node.pointer,
       type: Type.typedMapPointer,
       alreadyDereferenced: true,

--- a/pkgs/dart_model/lib/src/json_buffer/closed_list.dart
+++ b/pkgs/dart_model/lib/src/json_buffer/closed_list.dart
@@ -75,13 +75,11 @@ class _ClosedList with ListMixin<Object?> {
     throw UnsupportedError('This JsonBufferBuilder list is read-only.');
   }
 
-  int get fingerprint {
-    var iterator = _ClosedListHashIterator(_buffer, _pointer, length);
-    var hash = 0;
+  void buildDigest(ByteConversionSink byteSink) {
+    var iterator = _ClosedListPointerIterator(_buffer, _pointer, length);
     while (iterator.moveNext()) {
-      hash = Object.hash(hash, iterator.current);
+      _buffer._buildDigest(iterator.current, byteSink);
     }
-    return hash;
   }
 }
 
@@ -108,9 +106,9 @@ class _ClosedListIterator<T extends Object?> implements Iterator<T> {
   }
 }
 
-class _ClosedListHashIterator extends _ClosedListIterator<int> {
-  _ClosedListHashIterator(super.buffer, super.pointer, super.length);
+class _ClosedListPointerIterator extends _ClosedListIterator<_Pointer> {
+  _ClosedListPointerIterator(super.buffer, super.pointer, super.length);
 
   @override
-  int get current => _buffer.fingerprint(_pointer);
+  _Pointer get current => _pointer;
 }

--- a/pkgs/dart_model/lib/src/json_buffer/closed_map.dart
+++ b/pkgs/dart_model/lib/src/json_buffer/closed_map.dart
@@ -123,13 +123,16 @@ class _ClosedMap
   @override
   int get hashCode => Object.hash(buffer, pointer);
 
-  int get fingerprint {
-    var iterator = _ClosedMapHashIterator(buffer, null, pointer, length);
-    var hash = 0;
+  void buildDigest(ByteConversionSink byteSink) {
+    var iterator = _ClosedMapPointerIterator(buffer, null, pointer, length);
     while (iterator.moveNext()) {
-      hash = Object.hash(hash, iterator.current);
+      buffer._buildDigest(
+        iterator.current.$1,
+        byteSink,
+        type: Type.stringPointer,
+      );
+      buffer._buildDigest(iterator.current.$2, byteSink);
     }
-    return hash;
   }
 }
 
@@ -199,8 +202,9 @@ class _ClosedMapEntryIterator
   MapEntry<String, Object?> get current => MapEntry(_currentKey, _currentValue);
 }
 
-class _ClosedMapHashIterator extends _ClosedMapIterator<int> {
-  _ClosedMapHashIterator(
+class _ClosedMapPointerIterator
+    extends _ClosedMapIterator<(int keyPointer, int valuePointer)> {
+  _ClosedMapPointerIterator(
     super._buffer,
     super._parent,
     super.pointer,
@@ -208,8 +212,8 @@ class _ClosedMapHashIterator extends _ClosedMapIterator<int> {
   );
 
   @override
-  int get current => Object.hash(
-    _buffer._fingerprint(_pointer, Type.stringPointer),
-    _buffer.fingerprint(_pointer + ClosedMaps._keySize),
+  (int keyPointer, int valuePointer) get current => (
+    _pointer,
+    _pointer + ClosedMaps._keySize,
   );
 }

--- a/pkgs/dart_model/lib/src/json_buffer/growable_map.dart
+++ b/pkgs/dart_model/lib/src/json_buffer/growable_map.dart
@@ -176,13 +176,16 @@ class _GrowableMap<V>
   @override
   int get hashCode => Object.hash(buffer, pointer);
 
-  int get fingerprint {
-    var iterator = _GrowableMapHashIterator(buffer, null, pointer);
-    var hash = 0;
+  void buildDigest(ByteConversionSink byteSink) {
+    var iterator = _GrowableMapPointerIterator(buffer, null, pointer);
     while (iterator.moveNext()) {
-      hash = Object.hash(hash, iterator.current);
+      buffer._buildDigest(
+        iterator.current.$1,
+        byteSink,
+        type: Type.stringPointer,
+      );
+      buffer._buildDigest(iterator.current.$2, byteSink);
     }
-    return hash;
   }
 }
 
@@ -233,12 +236,13 @@ class _GrowableMapEntryIterator<V>
   MapEntry<String, V> get current => MapEntry(_currentKey, _currentValue as V);
 }
 
-class _GrowableMapHashIterator extends _GrowableMapIterator<int> {
-  _GrowableMapHashIterator(super._buffer, super._parent, super._pointer);
+class _GrowableMapPointerIterator
+    extends _GrowableMapIterator<(int keyPointer, int valuePointer)> {
+  _GrowableMapPointerIterator(super._buffer, super._parent, super._pointer);
 
   @override
-  int get current => Object.hash(
-    _buffer._fingerprint(_pointer + _pointerSize, Type.stringPointer),
-    _buffer.fingerprint(_pointer + _pointerSize + GrowableMaps._keySize),
+  (int keyPointer, int valuePointer) get current => (
+    _pointer + _pointerSize,
+    _pointer + _pointerSize + GrowableMaps._keySize,
   );
 }

--- a/pkgs/dart_model/lib/src/json_buffer/json_buffer_builder.dart
+++ b/pkgs/dart_model/lib/src/json_buffer/json_buffer_builder.dart
@@ -105,7 +105,8 @@ class JsonBufferBuilder {
       case Type.uint32:
         byteSink.addSlice(_buffer, pointer, pointer + 4, false);
       case Type.boolean:
-        byteSink.addSlice(_buffer, pointer, pointer + 1, false);
+        // We use [1] and [2] because [0] is `null`.
+        byteSink.add(_readBoolean(pointer) ? const [2] : const [1]);
       case Type.anyPointer:
         _buildDigest(pointer, byteSink);
       case Type.stringPointer:

--- a/pkgs/dart_model/lib/src/json_buffer/typed_map.dart
+++ b/pkgs/dart_model/lib/src/json_buffer/typed_map.dart
@@ -486,7 +486,8 @@ class _TypedMap
         _indexBytes[0] = iterator.current.$1;
         _indexBytes[1] = iterator.current.$1 >> 8;
         byteSink.add(_indexBytes);
-        byteSink.add(iterator.current.$2 ? const [1] : const [0]);
+        // We use [1] and [2] because [0] is `null`.
+        byteSink.add(iterator.current.$2 ? const [2] : const [1]);
       }
     } else {
       var iterator = _PartialTypedMapPointerIterator(this);

--- a/pkgs/dart_model/pubspec.yaml
+++ b/pkgs/dart_model/pubspec.yaml
@@ -12,6 +12,8 @@ environment:
 
 dependencies:
   collection: ^1.19.0
+  convert: ^3.1.2
+  crypto: ^3.0.6
 
 dev_dependencies:
   benchmark_harness: ^2.2.2

--- a/pkgs/dart_model/test/json_buffer/json_buffer_builder_test.dart
+++ b/pkgs/dart_model/test/json_buffer/json_buffer_builder_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:crypto/crypto.dart';
 import 'package:dart_model/src/json_buffer/json_buffer_builder.dart';
 import 'package:test/test.dart';
 
@@ -89,63 +90,63 @@ void main() {
       expect(() => deserializedBuilder.map['a'] = 'b', throwsStateError);
     });
 
-    group('fingerprint', () {
-      /// Re-usable fingerprint tests, [a] and [b] should be different values,
+    group('digest', () {
+      /// Re-usable digest tests, [a] and [b] should be different values,
       /// possibly of different types.
-      void testFingerprint(Object? a, Object? b) {
+      void testDigest(Object? a, Object? b) {
         assert(a != b);
-        expect(fingerprint({'a': a}), equals(fingerprint({'a': a})));
+        expect(digest({'a': a}), equals(digest({'a': a})));
         expect(
-          fingerprint({
+          digest({
             'a': {'b': b},
           }),
           equals(
-            fingerprint({
+            digest({
               'a': {'b': b},
             }),
           ),
         );
-        expect(fingerprint({'a': a}), isNot(equals(fingerprint({'a': b}))));
-        expect(fingerprint({'a': a}), isNot(equals(fingerprint({'b': a}))));
+        expect(digest({'a': a}), isNot(equals(digest({'a': b}))));
+        expect(digest({'a': a}), isNot(equals(digest({'b': a}))));
         expect(
-          fingerprint({'a': a, 'b': b}),
-          isNot(equals(fingerprint({'a': b, 'b': a}))),
+          digest({'a': a, 'b': b}),
+          isNot(equals(digest({'a': b, 'b': a}))),
         );
       }
 
       test('boolean fields', () {
-        testFingerprint(true, false);
+        testDigest(true, false);
       });
 
       test('String fields', () {
-        testFingerprint('a', 'b');
+        testDigest('a', 'b');
       });
 
       test('int fields', () {
-        testFingerprint(1, 2);
+        testDigest(1, 2);
       });
 
       test('null fields', () {
-        testFingerprint(null, 0);
-        testFingerprint(null, true);
-        testFingerprint(null, false);
-        testFingerprint(null, <String, Object?>{});
+        testDigest(null, 0);
+        testDigest(null, true);
+        testDigest(null, false);
+        testDigest(null, <String, Object?>{});
       });
 
       test('closed list fields', () {
-        testFingerprint([], [1]);
-        testFingerprint([1, 2], [2, 1]);
+        testDigest([], [1]);
+        testDigest([1, 2], [2, 1]);
       });
 
       test('closed map fields', () {
-        testFingerprint(<String, Object?>{}, {'a': 1});
-        testFingerprint({'a': 'b'}, {'b': 'a'});
+        testDigest(<String, Object?>{}, {'a': 1});
+        testDigest({'a': 'b'}, {'b': 'a'});
       });
 
       test('growable map fields', () {
         final builderA = JsonBufferBuilder();
         final builderB = JsonBufferBuilder();
-        testFingerprint(
+        testDigest(
           builderA.createGrowableMap<Object?>()..['a'] = 1,
           builderB.createGrowableMap<Object?>()..['a'] = 2,
         );
@@ -155,7 +156,7 @@ void main() {
         final builderA = JsonBufferBuilder();
         final builderB = JsonBufferBuilder();
         final schema = TypedMapSchema({'a': Type.stringPointer});
-        testFingerprint(
+        testDigest(
           builderA.createTypedMap(schema, 'a'),
           builderB.createTypedMap(schema, 'b'),
         );
@@ -164,11 +165,11 @@ void main() {
   });
 }
 
-int fingerprint(Map<String, Object?> map) {
+Digest digest(Map<String, Object?> map) {
   final builder =
       map is MapInBuffer ? (map as MapInBuffer).buffer : JsonBufferBuilder()
         ..map.deepCopy(map);
-  return builder.fingerprint(
+  return builder.digest(
     (builder.map as MapInBuffer).pointer,
     type: Type.growableMapPointer,
     alreadyDereferenced: true,


### PR DESCRIPTION
We can easily swap out the actual hash algorithm here now, in one place.

This is a bit slower (unsurprisingly) than using `Object.hash` etc, a few hundred milliseconds in total per iteration, but is a fairer representation of what we actually want.