### PR TITLE
add benchmark for real wrapper classes around a JsonBuffer

### DIFF
--- a/pkgs/dart_model/benchmark/lazy_wrappers_buffer_wire_benchmark.dart
+++ b/pkgs/dart_model/benchmark/lazy_wrappers_buffer_wire_benchmark.dart
@@ -10,7 +10,9 @@ import 'serialization_benchmark.dart';
 
 JsonBufferBuilder? runningBuffer;
 
-/// Benchmark accumulating data directly into a [JsonBufferBuilder].
+/// Benchmark accumulating data directly into a [JsonBufferBuilder] with an
+/// indirection through a thin wrapper type (which is a real type, not an
+/// extension type).
 class LazyWrappersBufferWireBenchmark extends SerializationBenchmark {
   @override
   void run() {

--- a/pkgs/dart_model/benchmark/lazy_wrappers_buffer_wire_benchmark.dart
+++ b/pkgs/dart_model/benchmark/lazy_wrappers_buffer_wire_benchmark.dart
@@ -1,0 +1,274 @@
+// Copyright (c) 2024, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:collection';
+
+import 'package:dart_model/src/json_buffer/json_buffer_builder.dart';
+
+import 'serialization_benchmark.dart';
+
+JsonBufferBuilder? runningBuffer;
+
+/// Benchmark accumulating data directly into a [JsonBufferBuilder].
+class LazyWrappersBufferWireBenchmark extends SerializationBenchmark {
+  @override
+  void run() {
+    createData();
+
+    serialized = runningBuffer!.serialize();
+  }
+
+  Map<String, Object?> createData() {
+    final buffer = runningBuffer = JsonBufferBuilder();
+    final map = buffer.map;
+
+    for (final key in mapKeys) {
+      final intKey = int.parse(key);
+      var interface = Interface(
+        properties: Properties(
+          isAbstract: (intKey & 1) == 1,
+          isClass: (intKey & 2) == 2,
+          isGetter: (intKey & 4) == 4,
+          isField: (intKey & 8) == 8,
+          isMethod: (intKey & 16) == 16,
+          isStatic: (intKey & 32) == 32,
+        ),
+      );
+      map[key] = interface.toJson();
+      var members = interface.members;
+      for (final memberName in makeMemberNames(intKey)) {
+        members[memberName] = _makeMember(memberName);
+      }
+    }
+
+    return buffer.map;
+  }
+
+  Member _makeMember(String key) {
+    final intKey = key.length;
+    return Member(
+      properties: Properties(
+        isAbstract: (intKey & 1) == 1,
+        isClass: (intKey & 2) == 2,
+        isGetter: (intKey & 4) == 4,
+        isField: const [true, false, null][intKey % 3],
+        isMethod: (intKey & 16) == 16,
+        isStatic: (intKey & 32) == 32,
+      ),
+    );
+  }
+
+  @override
+  void deserialize() {
+    deserialized = _LazyMap<Object?, Interface>(
+      JsonBufferBuilder.deserialize(serialized!).map,
+      (json) => Interface.fromJson(json as Map<String, Object?>),
+      (i) => i.toJson(),
+    );
+  }
+}
+
+class _LazyMap<From, To> extends MapBase<String, To> {
+  final Map<String, From> _map;
+  final To Function(From) _convertFrom;
+  final From Function(To) _convertTo;
+
+  _LazyMap(this._map, this._convertFrom, this._convertTo);
+
+  @override
+  To? operator [](Object? key) {
+    if (_map[key] case var value?) {
+      return _convertFrom(value as From);
+    } else {
+      return null;
+    }
+  }
+
+  @override
+  void operator []=(String key, To value) {
+    _map[key] = _convertTo(value);
+  }
+
+  @override
+  void clear() {
+    _map.clear();
+  }
+
+  @override
+  Iterable<String> get keys => _map.keys;
+
+  @override
+  To? remove(Object? key) {
+    if (_map.remove(key) case var value?) {
+      return _convertFrom(value);
+    } else {
+      return null;
+    }
+  }
+
+  @override
+  Iterable<MapEntry<String, To>> get entries =>
+      _map.entries.map((e) => MapEntry(e.key, _convertFrom(e.value)));
+}
+
+abstract interface class Serializable {
+  Map<String, Object?> toJson();
+}
+
+/// An interface.
+abstract interface class Interface implements Serializable {
+  Map<String, Member> get members;
+  Properties get properties;
+
+  static TypedMapSchema schema = TypedMapSchema({
+    'members': Type.growableMapPointer,
+    'properties': Type.typedMapPointer,
+  });
+
+  factory Interface({Properties? properties}) => _JsonInterface(
+    runningBuffer!.createTypedMap(
+      schema,
+      runningBuffer!.createGrowableMap<Map<String, Object?>>(),
+      properties?.toJson(),
+    ),
+  );
+
+  factory Interface.fromJson(Map<String, Object?> json) => _JsonInterface(json);
+}
+
+/// An [Interface] that lazily reads from a map.
+class _JsonInterface implements Interface {
+  final Map<String, Object?> json;
+
+  _JsonInterface(this.json);
+
+  /// Map of members by name.
+  @override
+  Map<String, Member> get members => _LazyMap<Map<String, Object?>, Member>(
+    (json['members'] as Map<String, Object?>).cast(),
+    Member.fromJson,
+    (m) => m.toJson(),
+  );
+
+  /// The properties of this interface.
+  @override
+  Properties get properties =>
+      Properties.fromJson(json['properties'] as Map<String, Object?>);
+
+  @override
+  Map<String, Object?> toJson() => json;
+}
+
+/// A member.
+abstract interface class Member implements Serializable {
+  Properties get properties;
+
+  static TypedMapSchema schema = TypedMapSchema({
+    'properties': Type.typedMapPointer,
+  });
+
+  factory Member({Properties? properties}) =>
+      _JsonMember(runningBuffer!.createTypedMap(schema, properties?.toJson()));
+
+  factory Member.fromJson(Map<String, Object?> json) => _JsonMember(json);
+}
+
+class _JsonMember implements Member {
+  final Map<String, Object?> json;
+
+  _JsonMember(this.json);
+
+  /// The properties of this member.
+  @override
+  Properties get properties =>
+      Properties.fromJson(json['properties'] as Map<String, Object?>);
+
+  @override
+  Map<String, Object?> toJson() => json;
+}
+
+/// Set of boolean properties.
+abstract interface class Properties implements Serializable {
+  /// Whether the entity is abstract, meaning it has no definition.
+  bool get isAbstract;
+
+  /// Whether the entity is a class.
+  bool get isClass;
+
+  /// Whether the entity is a getter.
+  bool get isGetter;
+
+  /// Whether the entity is a field.
+  bool get isField;
+
+  /// Whether the entity is a method.
+  bool get isMethod;
+
+  /// Whether the entity is static.
+  bool get isStatic;
+
+  static TypedMapSchema schema = TypedMapSchema({
+    'isAbstract': Type.boolean,
+    'isClass': Type.boolean,
+    'isGetter': Type.boolean,
+    'isField': Type.boolean,
+    'isMethod': Type.boolean,
+    'isStatic': Type.boolean,
+  });
+
+  factory Properties({
+    bool? isAbstract,
+    bool? isClass,
+    bool? isGetter,
+    bool? isField,
+    bool? isMethod,
+    bool? isStatic,
+  }) => _JsonProperties(
+    runningBuffer!.createTypedMap(
+      schema,
+      isAbstract,
+      isClass,
+      isGetter,
+      isField,
+      isMethod,
+      isStatic,
+    ),
+  );
+
+  factory Properties.fromJson(Map<String, Object?> json) =>
+      _JsonProperties(json);
+}
+
+class _JsonProperties implements Properties {
+  final Map<String, Object?> json;
+
+  _JsonProperties(this.json);
+
+  /// Whether the entity is abstract, meaning it has no definition.
+  @override
+  bool get isAbstract => json['isAbstract'] as bool;
+
+  /// Whether the entity is a class.
+  @override
+  bool get isClass => json['isClass'] as bool;
+
+  /// Whether the entity is a getter.
+  @override
+  bool get isGetter => json['isGetter'] as bool;
+
+  /// Whether the entity is a field.
+  @override
+  bool get isField => json['isField'] as bool;
+
+  /// Whether the entity is a method.
+  @override
+  bool get isMethod => json['isMethod'] as bool;
+
+  /// Whether the entity is static.
+  @override
+  bool get isStatic => json['isStatic'] as bool;
+
+  @override
+  Map<String, Object?> toJson() => json;
+}

--- a/pkgs/dart_model/benchmark/main.dart
+++ b/pkgs/dart_model/benchmark/main.dart
@@ -8,6 +8,8 @@ import 'builder_maps_builder_wire_benchmark.dart';
 import 'builder_maps_json_wire_benchmark.dart';
 import 'lazy_maps_buffer_wire_benchmark.dart';
 import 'lazy_maps_json_wire_benchmark.dart';
+import 'lazy_wrappers_buffer_wire_benchmark.dart';
+import 'lazy_wrappers_buffer_wire_benchmark.dart' as wrapped;
 import 'sdk_maps_buffer_wire_benchmark.dart';
 import 'sdk_maps_builder_wire_benchmark.dart';
 import 'sdk_maps_json_wire_benchmark.dart';
@@ -15,6 +17,7 @@ import 'sdk_maps_json_wire_benchmark.dart';
 void main() {
   final sdkMapsJsonWireBenchmark = SdkMapsJsonWireBenchmark();
   final lazyMapsBufferWireBenchmark = LazyMapsBufferWireBenchmark();
+  final lazyWrappersBufferWireBenchmark = LazyWrappersBufferWireBenchmark();
   final builderMapsBuilderWireBenchmark = BuilderMapsBuilderWireBenchmark();
   final serializationBenchmarks = [
     sdkMapsJsonWireBenchmark,
@@ -22,6 +25,7 @@ void main() {
     SdkMapsBuilderWireBenchmark(),
     LazyMapsJsonWireBenchmark(),
     lazyMapsBufferWireBenchmark,
+    lazyWrappersBufferWireBenchmark,
     BuilderMapsJsonWireBenchmark(),
     builderMapsBuilderWireBenchmark,
   ];
@@ -41,6 +45,7 @@ void main() {
     for (final benchmark in [
       sdkMapsJsonWireBenchmark.processBenchmark(),
       lazyMapsBufferWireBenchmark.processBenchmark(),
+      lazyWrappersBufferWireBenchmark.processBenchmark(),
       builderMapsBuilderWireBenchmark.processBenchmark(),
     ]) {
       final measure = benchmark.measure().toMilliseconds;
@@ -51,8 +56,15 @@ void main() {
     }
 
     for (final benchmark in serializationBenchmarks.skip(1)) {
+      var deserialized = benchmark.deserialized;
+      // Need to unwrap these to compare them as raw maps.
+      if (deserialized is Map<String, wrapped.Interface>) {
+        deserialized = deserialized.map<String, Object?>(
+          (k, v) => MapEntry(k, v.toJson()),
+        );
+      }
       if (!const DeepCollectionEquality().equals(
-        benchmark.deserialized,
+        deserialized,
         serializationBenchmarks.first.deserialized,
       )) {
         throw StateError(

--- a/pkgs/dart_model/benchmark/serialization_benchmark.dart
+++ b/pkgs/dart_model/benchmark/serialization_benchmark.dart
@@ -6,6 +6,8 @@ import 'dart:typed_data';
 
 import 'package:benchmark_harness/benchmark_harness.dart';
 
+import 'lazy_wrappers_buffer_wire_benchmark.dart';
+
 const mapSize = 10000;
 final mapKeys = List.generate(mapSize, (i) => i.toString());
 
@@ -62,6 +64,8 @@ class ProcessBenchmark extends BenchmarkBase {
       final value = entry.value;
       if (value is Map) {
         result ^= deepHash(value);
+      } else if (value is Serializable) {
+        result ^= deepHash(value.toJson());
       } else {
         result ^= value.hashCode;
       }


### PR DESCRIPTION
This helps us to evaluate how much extension types are actually buying us, by benchmarking against thin wrappers around maps.

There are many advantages of real wrappers, such as type checks can actually work, and we can have many different implementations.

I have a specific idea in mind here, which is that the analyzer/CFE could provide their own thin wrapper implementations of these types, which wrap the analyzer/CFE representations and implement lazy getters. This would potentially allow us to handle all the query filtering, by just lazily reading the properties we care about into a new (buffer based) representation of the object, based on the fields present in the query.

Results are as follows:

```
SdkMapsJsonWireBenchmark: 1896ms, 7177227 bytes
     SdkMapsBufferWireBenchmark: 1984ms, 5122684 bytes
    SdkMapsBuilderWireBenchmark: 1631ms, 4859868 bytes
      LazyMapsJsonWireBenchmark: 1099ms, 7177227 bytes
    LazyMapsBufferWireBenchmark:  590ms, 5122684 bytes
LazyWrappersBufferWireBenchmark:  424ms, 2111761 bytes
   BuilderMapsJsonWireBenchmark: 1394ms, 7177227 bytes
BuilderMapsBuilderWireBenchmark:  396ms, 2111761 bytes

     ProcessSdkMapsJsonWireBenchmark:  161ms, hash 23186292
  ProcessLazyMapsBufferWireBenchmark:  257ms, hash 23186292
ProcessLazyWrappersBufferWireBenchmark:  362ms, hash 23186292
ProcessBuilderMapsBuilderWireBenchmark:  356ms, hash 23186292
```