### PR TITLE
fix converting type annotations

### DIFF
--- a/pkgs/_analyzer_cfe_macros/lib/metadata_converter.dart
+++ b/pkgs/_analyzer_cfe_macros/lib/metadata_converter.dart
@@ -502,7 +502,10 @@ T? convert<T>(Object? object) => switch (object) {
   front_end.TypedefReference o =>
     dart_model.TypedefReference(name: convert(o.name)) as T,
   front_end.TypeLiteral o =>
-    dart_model.TypeLiteral(typeAnnotation: convert(o.typeAnnotation)) as T,
+    dart_model.TypeLiteral(
+          typeAnnotation: convertToTypeAnnotation(o.typeAnnotation),
+        )
+        as T,
   front_end.TypeReference o => dart_model.TypeReference() as T,
   front_end.UnaryExpression o =>
     dart_model.UnaryExpression(

--- a/pkgs/_analyzer_cfe_macros/test/metadata_converter_test.dart
+++ b/pkgs/_analyzer_cfe_macros/test/metadata_converter_test.dart
@@ -81,4 +81,28 @@ void main() {
       });
     });
   });
+
+  test('converts a type literal', () {
+    final invocation = TypeLiteral(NamedTypeAnnotation(TestClassReference()));
+
+    Scope.query.run(() {
+      expect(convert<Object>(invocation), <String, Object?>{
+        'typeAnnotation': {
+          'type': 'NamedTypeAnnotation',
+          'value': {
+            'reference': {
+              'type': 'ClassReference',
+              'value': {'name': 'Test'},
+            },
+            'typeArguments': <Object>[],
+          },
+        },
+      });
+    });
+  });
+}
+
+class TestClassReference implements ClassReference {
+  @override
+  String get name => 'Test';
 }


### PR DESCRIPTION
without `convertToTypeAnnotation` the `typeAnnotation.type` did not exist and you were not able to convert to any type annotation (e.g. `.asNamedTypeAnnotation` threw error)